### PR TITLE
GEODE-88: code fixes for c++ client

### DIFF
--- a/geode-client-native/src/cppcache/DataOutput.cpp
+++ b/geode-client-native/src/cppcache/DataOutput.cpp
@@ -84,7 +84,7 @@ class TSSDataOutput
     } else {
       uint8_t* buf;
       *size = 8192;
-      GF_ALLOC( buf, uint8_t, 8192 );
+      buf = new uint8_t [8192]; //Copyright: Amdocs Software Systems Limited, 2016
       return buf;
     }
   }
@@ -110,7 +110,7 @@ TSSDataOutput::~TSSDataOutput( )
   while(! m_buffers.empty() ) {
     BufferDesc desc = m_buffers.back();
     m_buffers.pop_back();
-    GF_FREE(desc.m_buf);
+    delete [] desc.m_buf; //Copyright: Amdocs Software Systems Limited, 2016
   }
 }
 

--- a/geode-client-native/src/cppcache/DataOutput.hpp
+++ b/geode-client-native/src/cppcache/DataOutput.hpp
@@ -8,6 +8,10 @@
  * more patents listed at http://www.pivotal.io/patents.
  *=========================================================================
  */
+ /*=========================================================================
+ * Copyright: Amdocs Software Systems Limited, 2016
+ *=========================================================================
+ */
 
 #include "gfcpp_globals.hpp"
 #include "ExceptionTypes.hpp"
@@ -30,29 +34,6 @@ namespace gemfire {
  * C style memory allocation that throws OutOfMemoryException
  * if it fails
  */
-#define GF_ALLOC(v,t,s) \
-{ \
-  v = (t*)malloc((s) * sizeof(t)); \
-  if ((v) == NULL) { \
-    throw OutOfMemoryException( \
-        "Out of Memory while allocating buffer for "#t" of size "#s); \
-  } \
-}
-
-/**
- * C style memory re-allocation that throws OutOfMemoryException
- * if it fails
- */
-#define GF_RESIZE(v,t,s) \
-{ \
-  v = (t*)realloc(v, (s) * sizeof(t)); \
-  if ((v) == NULL) { \
-    throw OutOfMemoryException( \
-        "Out of Memory while resizing buffer for "#t); \
-  } \
-}
-
-#define GF_FREE(v) free(v)
 
 /**
  * Provide operations for writing primitive data values, byte arrays,
@@ -703,7 +684,7 @@ public:
   {
     uint32_t size = (uint32_t)( m_buf - m_bytes );
     uint8_t * result;
-    GF_ALLOC(result, uint8_t, size);
+    result = new uint8_t[size];
     memcpy( result, m_bytes, size );
     return result;
   }
@@ -723,9 +704,9 @@ public:
   {
     if (m_haveBigBuffer) {
       // free existing buffer
-      GF_FREE(m_bytes);
+      delete [] m_bytes;
       // create smaller buffer
-      GF_ALLOC(m_bytes, uint8_t, m_lowWaterMark);
+      m_bytes = new uint8_t[m_lowWaterMark];
       m_size = m_lowWaterMark;
       // reset the flag
       m_haveBigBuffer = false;
@@ -747,8 +728,13 @@ public:
         // set flag
         m_haveBigBuffer = true;
       }
+      
+      uint8_t* newPtr = new uint8_t[newSize];
+      memcpy(newPtr, m_bytes, m_size);
+      delete [] m_bytes;
+      m_bytes = newPtr;
       m_size = newSize;
-      GF_RESIZE( m_bytes, uint8_t, m_size );
+
       m_buf = m_bytes + offset;
     }
   }
@@ -778,19 +764,6 @@ public:
     return result;
   }
   
-  static void safeDelete(uint8_t* src)
-  {
-    GF_SAFE_DELETE(src);
-  }
-
-  static DataOutput* getDataOutput()
-  {
-    return new DataOutput();
-  }
-  static void releaseDataOutput(DataOutput* dataOutput)
-  {
-    GF_SAFE_DELETE(dataOutput);
-  }
 private:
 
   void writeObjectInternal( const Serializable* ptr, bool isDelta = false );

--- a/geode-client-native/src/cppcache/RegionAttributes.cpp
+++ b/geode-client-native/src/cppcache/RegionAttributes.cpp
@@ -432,7 +432,8 @@ uint8_t RegionAttributes::getConcurrencyLevel() const
    return m_concurrencyLevel;
 }
 
-const ExpirationAction::Action RegionAttributes::getLruEvictionAction( ) const
+//Copyright: Amdocs Software Systems Limited, 2016
+ExpirationAction::Action RegionAttributes::getLruEvictionAction( ) const
 {
   return m_lruEvictionAction;
 }

--- a/geode-client-native/src/cppcache/RegionAttributes.hpp
+++ b/geode-client-native/src/cppcache/RegionAttributes.hpp
@@ -167,7 +167,8 @@ class CPPCACHE_EXPORT RegionAttributes: public Serializable  {
   /**
    * Returns the ExpirationAction used for LRU Eviction, default is LOCAL_DESTROY.
    */
-  const ExpirationAction::Action getLruEvictionAction( ) const;
+  //Copyright: Amdocs Software Systems Limited, 2016
+  ExpirationAction::Action getLruEvictionAction( ) const;
 
   /**
    * Returns the name of the pool attached to the region.

--- a/geode-client-native/src/cppcache/SystemProperties.hpp
+++ b/geode-client-native/src/cppcache/SystemProperties.hpp
@@ -9,6 +9,10 @@
  * more patents listed at http://www.pivotal.io/patents.
  *=========================================================================
  */
+ /*=========================================================================
+ * Copyright: Amdocs Software Systems Limited, 2016
+ *=========================================================================
+ */
 
 
 #include "Properties.hpp"
@@ -61,7 +65,7 @@ public:
   /** print all settings to the process log. */
   void logSettings( );
 
-  const uint32_t threadPoolSize() const
+  uint32_t threadPoolSize() const
   { return m_threadPoolSize; }
 
 
@@ -69,7 +73,7 @@ public:
   * Returns the sampling interval of the sampling thread.
   * This would be how often the statistics thread writes to disk in seconds.
   */
-  const uint32_t statisticsSampleInterval() const
+  uint32_t statisticsSampleInterval() const
     { return m_statisticsSampleInterval; }
 
 
@@ -140,7 +144,7 @@ public:
   * memory
   *
   */
-  const bool heapLRULimitEnabled() const
+  bool heapLRULimitEnabled() const
   { return (m_heapLRULimit > 0); }
 
   /**
@@ -150,7 +154,7 @@ public:
     * cache memory usage
     *
     */
-    const size_t heapLRULimit() const
+    size_t heapLRULimit() const
     { return m_heapLRULimit; }
 
 
@@ -159,31 +163,31 @@ public:
     * percentage of entries the system will evict each time it detects that
     * it has exceeded the HeapLRULimit. Defaults to 10%
     */
-      const int32_t heapLRUDelta() const
+      int32_t heapLRUDelta() const
       { return m_heapLRUDelta; }
  /**
   * Returns  the maximum socket buffer size to use
   */
-  const int32_t maxSocketBufferSize() const { return m_maxSocketBufferSize; }
+  int32_t maxSocketBufferSize() const { return m_maxSocketBufferSize; }
 
  /**
   * Returns  the time between two consecutive ping to servers
   */
-  const int32_t pingInterval() const { return m_pingInterval; }
+  int32_t pingInterval() const { return m_pingInterval; }
  /**
   * Returns  the time between two consecutive checks for redundancy for HA
   */
-  const int32_t redundancyMonitorInterval() const { return m_redundancyMonitorInterval; }
+  int32_t redundancyMonitorInterval() const { return m_redundancyMonitorInterval; }
 
   /**
    * Returns the periodic notify ack interval
    */
-  const int32_t notifyAckInterval() const { return m_notifyAckInterval; }
+  int32_t notifyAckInterval() const { return m_notifyAckInterval; }
 
   /**
   * Returns the expiry time of an idle event id map entry for duplicate notification checking
   */
-  const int32_t notifyDupCheckLife() const { return m_notifyDupCheckLife; }
+  int32_t notifyDupCheckLife() const { return m_notifyDupCheckLife; }
 
  /**
   * Returns the durable client ID
@@ -193,24 +197,24 @@ public:
  /**
   * Returns the durable timeout
   */
-  const uint32_t durableTimeout() const { return m_durableTimeout; }
+  uint32_t durableTimeout() const { return m_durableTimeout; }
 
  /**
   * Returns the connect timeout used for server and locator handshakes
   */
-  const uint32_t connectTimeout() const { return m_connectTimeout; }
+  uint32_t connectTimeout() const { return m_connectTimeout; }
 
   /**
   * Returns the connect wait timeout(in millis) used for to connect to server
   * This is only applicable for linux
   */
-  const uint32_t connectWaitTimeout() const { return m_connectWaitTimeout; }
+  uint32_t connectWaitTimeout() const { return m_connectWaitTimeout; }
 
   /**
   * Returns the connect wait timeout(in millis) used for to connect to server
   * This is only applicable for linux
   */
-  const uint32_t bucketWaitTimeout() const { return m_bucketWaitTimeout; }
+  uint32_t bucketWaitTimeout() const { return m_bucketWaitTimeout; }
 
 
  /**
@@ -221,7 +225,7 @@ public:
   /**
   * Returns  true if the stack trace is enabled ,false otherwise
   */
-  const bool debugStackTraceEnabled() const
+  bool debugStackTraceEnabled() const
     { return m_debugStackTraceEnabled; }
 
   /**
@@ -233,7 +237,7 @@ public:
    * The default prefix is "gemfire_cpp".
    * The actual dump file will have timestamp and process ID in the full name.
    */
-  inline const bool crashDumpEnabled() const
+  inline bool crashDumpEnabled() const
   {
     return m_crashDumpEnabled;
   }
@@ -247,31 +251,31 @@ public:
   /**
   * Returns the log-file-size-limit.
   */
-  const uint32_t logFileSizeLimit() const
+  uint32_t logFileSizeLimit() const
      {return m_logFileSizeLimit;}
 
   /**
   * Returns the log-disk-space-limit.
   */
-  const uint32_t logDiskSpaceLimit() const
+  uint32_t logDiskSpaceLimit() const
      {return m_logDiskSpaceLimit;}
 
   /**
   * Returns the stat-file-space-limit.
   */
-  const uint32_t statsFileSizeLimit() const
+  uint32_t statsFileSizeLimit() const
      {return m_statsFileSizeLimit;}
 
   /**
   * Returns the stat-disk-size-limit.
   */
-  const uint32_t statsDiskSpaceLimit() const
+  uint32_t statsDiskSpaceLimit() const
      {return m_statsDiskSpaceLimit;}
 
-  const uint32_t maxQueueSize()
+  uint32_t maxQueueSize()
      {return m_maxQueueSize;}
 
-  const uint32_t javaConnectionPoolSize() const
+  uint32_t javaConnectionPoolSize() const
      { return m_javaConnectionPoolSize;}
   void setjavaConnectionPoolSize(uint32_t size) {
     m_javaConnectionPoolSize = size ;
@@ -423,12 +427,12 @@ public:
   /**
   * Returns the timeout after which suspended transactions are rolled back.
   */
-  const uint32_t suspendedTxTimeout() const { return m_suspendedTxTimeout; }
+  uint32_t suspendedTxTimeout() const { return m_suspendedTxTimeout; }
 
   /**
    * Returns the tombstone timeout .
    */
-  const uint32_t tombstoneTimeoutInMSec() const { return m_tombstoneTimeoutInMSec; }
+  uint32_t tombstoneTimeoutInMSec() const { return m_tombstoneTimeoutInMSec; }
 
 private:
 

--- a/geode-client-native/src/cppcache/impl/BucketServerLocation.hpp
+++ b/geode-client-native/src/cppcache/impl/BucketServerLocation.hpp
@@ -8,8 +8,10 @@
 #ifndef __BUCKET_SERVER_LOCATION__
 #define __BUCKET_SERVER_LOCATION__
 
+#include "gf_base.hpp" //Copyright: Amdocs Software Systems Limited, 2016
 #include "ServerLocation.hpp"
 #include <string>
+#include <stdint.h> //Copyright: Amdocs Software Systems Limited, 2016
 
 namespace gemfire
 {

--- a/geode-client-native/src/cppcache/impl/ClientProxyMembershipID.hpp
+++ b/geode-client-native/src/cppcache/impl/ClientProxyMembershipID.hpp
@@ -16,6 +16,7 @@
 #include "DSMemberForVersionStamp.hpp"
 #include <ace/OS.h>
 #include <string>
+#include <stdint.h> //Copyright: Amdocs Software Systems Limited, 2016
 
 namespace gemfire
 {

--- a/geode-client-native/src/cppcache/impl/CppCacheLibrary.cpp
+++ b/geode-client-native/src/cppcache/impl/CppCacheLibrary.cpp
@@ -5,6 +5,10 @@
  * one or more patents listed at http://www.pivotal.io/patents.
  *=========================================================================
  */
+ /*=========================================================================
+ * Copyright: Amdocs Software Systems Limited, 2016
+ *=========================================================================
+ */
 
 #include "CppCacheLibrary.hpp"
 
@@ -30,6 +34,7 @@
 
 #include <string>
 
+#include <unistd.h>  
 
 using namespace gemfire;
 
@@ -79,7 +84,6 @@ typedef ACE_Singleton<CppCacheLibrary,ACE_Recursive_Thread_Mutex> TheLibrary;
 // internals are prepared. fw_helper framework will handle this.
 CppCacheLibrary* CppCacheLibrary::initLib( void )
 {
-  ACE::init();
   return TheLibrary::instance();
 }
 

--- a/geode-client-native/src/cppcache/impl/TcpConn.hpp
+++ b/geode-client-native/src/cppcache/impl/TcpConn.hpp
@@ -41,6 +41,8 @@ namespace gemfire {
     protected:
 
       ACE_INET_Addr m_addr;
+	  //Copyright: Amdocs Software Systems Limited, 2016
+      uint8 m_suffixFiller[32]; // Protection from the ACE bug
       uint32_t m_waitSeconds;
 
       int32_t m_maxBuffSizePool;

--- a/geode-client-native/src/cppcache/impl/TcrEndpoint.hpp
+++ b/geode-client-native/src/cppcache/impl/TcrEndpoint.hpp
@@ -80,7 +80,8 @@ namespace gemfire
     // ARB: setConnectionStatus is now a public method, as it is used by TcrDistributionManager.
     void setConnectionStatus(bool status);
 
-    inline const int getNumRegionListeners() const
+	//Copyright: Amdocs Software Systems Limited, 2016
+    inline int getNumRegionListeners() const
     {
       return m_numRegionListener;
     }

--- a/geode-client-native/src/cppcache/impl/ThinClientRedundancyManager.hpp
+++ b/geode-client-native/src/cppcache/impl/ThinClientRedundancyManager.hpp
@@ -56,7 +56,7 @@ namespace gemfire {
    void netDown( );
    void acquireRedundancyLock( ) { m_redundantEndpointsLock.acquire_read( ); }
    void releaseRedundancyLock( ) { m_redundantEndpointsLock.release( ); }
-   volatile bool allEndPointDiscon() { return m_IsAllEpDisCon;}
+   bool allEndPointDiscon() { return m_IsAllEpDisCon;} //Copyright: Amdocs Software Systems Limited, 2016
    void removeCallbackConnection( TcrEndpoint* );
 
    ACE_Recursive_Thread_Mutex & getRedundancyLock() { return m_redundantEndpointsLock; }


### PR DESCRIPTION
1) removing "const" and "volatile" to avoid compilation warnings
2) fixing inconsistencies in memory allocation
3) adding missing include statements to allow compilation
