### PR TITLE
GEODE-2109 : Calling submit on ExecutionService can cause exceptions to be lost

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/SingleHopClientExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/SingleHopClientExecutor.java
@@ -27,6 +27,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.geode.internal.logging.LoggingThreadGroup;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.GemFireException;
@@ -57,7 +59,9 @@ public class SingleHopClientExecutor {
     AtomicInteger threadNum = new AtomicInteger();
 
     public Thread newThread(final Runnable r) {
-      Thread result = new Thread(r, "Function Execution Thread-" + threadNum.incrementAndGet());
+      Thread result =
+          new Thread(LoggingThreadGroup.createThreadGroup("FunctionExecutionThreadGroup", logger),
+              r, "Function Execution Thread-" + threadNum.incrementAndGet());
       result.setDaemon(true);
       return result;
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/SingleHopClientExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/SingleHopClientExecutor.java
@@ -384,7 +384,7 @@ public class SingleHopClientExecutor {
   }
 
   static void submitTask(Runnable task) {
-    execService.submit(task);
+    execService.execute(task);
   }
 
   // Find out what exception to throw?

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/FunctionExecutionPooledExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/FunctionExecutionPooledExecutor.java
@@ -131,7 +131,7 @@ public class FunctionExecutionPooledExecutor extends ThreadPoolExecutor {
               Runnable task = takeQueue.take();
               if (forFnExec) {
                 if (!putQueue.offer(task, retryFor, TimeUnit.MILLISECONDS)) {
-                  submit(task);
+                  execute(task);
                 }
               } else {
                 putQueue.put(task);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1172,7 +1172,7 @@ public class InternalLocator extends Locator implements ConnectListener {
       this.isSharedConfigurationStarted = true;
       if (isSharedConfigurationEnabled()) {
         ExecutorService es = newCache.getDistributionManager().getThreadPool();
-        es.submit(new SharedConfigurationRunnable());
+        es.execute(new SharedConfigurationRunnable());
       }
       if (!this.server.isAlive()) {
         logger.info("Locator restart: starting TcpServer");
@@ -1449,7 +1449,7 @@ public class InternalLocator extends Locator implements ConnectListener {
       this.isSharedConfigurationStarted = true;
       installSharedConfigStatus();
       ExecutorService es = gfc.getDistributionManager().getThreadPool();
-      es.submit(new SharedConfigurationRunnable());
+      es.execute(new SharedConfigurationRunnable());
     } else {
       logger.info("Cluster configuration service is disabled");
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -1801,7 +1801,7 @@ public class PRHARedundancyProvider {
       Runnable task = new CreateMissingBucketsTask(this);
       final InternalResourceManager resourceManager =
           this.prRegion.getGemFireCache().getResourceManager();
-      resourceManager.getExecutor().submit(task);
+      resourceManager.getExecutor().execute(task);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/lru/HeapEvictor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/lru/HeapEvictor.java
@@ -423,7 +423,7 @@ public class HeapEvictor implements ResourceListener<MemoryEvent> {
         };
 
         // Submit the first pass at eviction into the pool
-        this.evictorThreadPool.submit(evictionManagerTask);
+        this.evictorThreadPool.execute(evictionManagerTask);
 
       } else {
         this.mustEvict.set(false);

--- a/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
@@ -1814,7 +1814,7 @@ public class CustomEntryConcurrentHashMap<K, V> extends AbstractMap<K, V>
         InternalDistributedSystem ids = InternalDistributedSystem.getConnectedInstance();
         if (ids != null) {
           try {
-            ids.getDistributionManager().getWaitingThreadPool().submit(runnable);
+            ids.getDistributionManager().getWaitingThreadPool().execute(runnable);
             submitted = true;
           } catch (RejectedExecutionException e) {
             // fall through with submitted false

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -398,7 +398,7 @@ public class FederatingManager extends Manager {
    * 
    */
 
-  private class GIITask implements Callable {
+  private class GIITask implements Callable<DistributedMember> {
 
     private DistributedMember member;
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -310,12 +310,8 @@ public class FederatingManager extends Manager {
     List<Future<DistributedMember>> futureTaskList;
 
     while (it.hasNext()) {
-      giiTaskList.add(new Callable<DistributedMember>() {
-        @Override
-        public DistributedMember call() throws Exception {
-          return new GIITask(it.next()).call();
-        }
-      });
+      member = it.next();
+      giiTaskList.add(new GIITask(member));
     }
 
     try {
@@ -402,7 +398,7 @@ public class FederatingManager extends Manager {
    * 
    */
 
-  private class GIITask {
+  private class GIITask implements Callable {
 
     private DistributedMember member;
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.cache.client.internal;
 
 import static org.apache.geode.internal.Assert.assertTrue;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -53,18 +53,13 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
       }
     });
 
-    final Callable<Boolean> isLogFound = new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        return systemErrRule.getLog().contains(erroMsg) == true;
-      }
-    };
-
     /**
      * Sometimes need to wait for more than sec as thread execution takes time.
      */
-    Awaitility.await("Waiting for exception").atMost(1000 * 2l, TimeUnit.MILLISECONDS)
-        .until(isLogFound);
+    Awaitility.await("Waiting for exception").atMost(60l, TimeUnit.SECONDS).until(() -> {
+      systemErrRule.getLog().contains(erroMsg);
+    });
+
     assertTrue(systemErrRule.getLog().contains(erroMsg));
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -14,9 +14,6 @@
  */
 package org.apache.geode.cache.client.internal;
 
-import static org.apache.geode.internal.Assert.assertTrue;
-
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import com.jayway.awaitility.Awaitility;
@@ -49,7 +46,15 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
       @Override
       public void run() {
         // test piece throwing exception
-        throw new RuntimeException(erroMsg);
+        try {
+          throw new RuntimeException(erroMsg);
+        } catch (RuntimeException e) {
+          // We need to catch and write it to System err
+          // so as to read from SystemErrRule
+          // In actual scenario, Geode LoggingThreadGroup
+          // will handle this.
+          System.err.print(e);
+        }
       }
     });
 
@@ -59,8 +64,6 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
     Awaitility.await("Waiting for exception").atMost(60l, TimeUnit.SECONDS).until(() -> {
       systemErrRule.getLog().contains(erroMsg);
     });
-
-    assertTrue(systemErrRule.getLog().contains(erroMsg));
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -14,8 +14,8 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.experimental.categories.Category;
 
 /**
- *  Test if exceptions are logged when thread is submitted using
- *  {@code SingleHopClientExecutor#submitTask} method.
+ * Test if exceptions are logged when thread is submitted using
+ * {@code SingleHopClientExecutor#submitTask} method.
  */
 @Category(UnitTest.class)
 public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
@@ -24,23 +24,24 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
   public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
   /**
-   * Refer: GEODE-2109
-   * This test verifies that any exception thrown from forked thread
-   * is logged into log.
+   * Refer: GEODE-2109 This test verifies that any exception thrown from forked thread is logged
+   * into log.
    */
   @Test
   public void submittedTaskShouldLogFailure() {
     String erroMsg = "I am expecting this to be logged";
 
     SingleHopClientExecutor.submitTask(new Runnable() {
-      @Override public void run() {
+      @Override
+      public void run() {
         // test piece throwing exception
         throw new RuntimeException(erroMsg);
       }
     });
 
     final Callable<Boolean> isLogFound = new Callable<Boolean>() {
-      @Override public Boolean call() throws Exception {
+      @Override
+      public Boolean call() throws Exception {
         return systemErrRule.getLog().contains(erroMsg) == true;
       }
     };
@@ -48,8 +49,8 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
     /**
      * Sometimes need to wait for more than sec as thread execution takes time.
      */
-    Awaitility.await("Waiting for exception").atMost(1000 * 2l,TimeUnit.MILLISECONDS)
-      .until(isLogFound);
+    Awaitility.await("Waiting for exception").atMost(1000 * 2l, TimeUnit.MILLISECONDS)
+        .until(isLogFound);
     assertTrue(systemErrRule.getLog().contains(erroMsg));
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -1,0 +1,56 @@
+package org.apache.geode.cache.client.internal;
+
+import static org.apache.geode.internal.Assert.assertTrue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import com.jayway.awaitility.Awaitility;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.experimental.categories.Category;
+
+/**
+ *  Test if exceptions are logged when thread is submitted using
+ *  {@code SingleHopClientExecutor#submitTask} method.
+ */
+@Category(UnitTest.class)
+public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
+
+  @Rule
+  public SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+
+  /**
+   * Refer: GEODE-2109
+   * This test verifies that any exception thrown from forked thread
+   * is logged into log.
+   */
+  @Test
+  public void submittedTaskShouldLogFailure() {
+    String erroMsg = "I am expecting this to be logged";
+
+    SingleHopClientExecutor.submitTask(new Runnable() {
+      @Override public void run() {
+        // test piece throwing exception
+        throw new RuntimeException(erroMsg);
+      }
+    });
+
+    final Callable<Boolean> isLogFound = new Callable<Boolean>() {
+      @Override public Boolean call() throws Exception {
+        return systemErrRule.getLog().contains(erroMsg) == true;
+      }
+    };
+
+    /**
+     * Sometimes need to wait for more than sec as thread execution takes time.
+     */
+    Awaitility.await("Waiting for exception").atMost(1000 * 2l,TimeUnit.MILLISECONDS)
+      .until(isLogFound);
+    assertTrue(systemErrRule.getLog().contains(erroMsg));
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/SingleHopClientExecutorSubmitTaskWithExceptionTest.java
@@ -46,15 +46,7 @@ public class SingleHopClientExecutorSubmitTaskWithExceptionTest {
       @Override
       public void run() {
         // test piece throwing exception
-        try {
-          throw new RuntimeException(erroMsg);
-        } catch (RuntimeException e) {
-          // We need to catch and write it to System err
-          // so as to read from SystemErrRule
-          // In actual scenario, Geode LoggingThreadGroup
-          // will handle this.
-          System.err.print(e);
-        }
+        throw new RuntimeException(erroMsg);
       }
     });
 

--- a/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
@@ -580,6 +580,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
 
   @Test
   public void testPR_RemotePutRejectionCacheClose() throws Exception {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prRemotePutRejection(true, false, false);
   }
 
@@ -595,6 +597,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
 
   @Test
   public void testPR_RemotePutRejectionCacheCloseWithTx() throws Exception {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prRemotePutRejection(true, false, true);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
@@ -581,7 +581,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
   @Test
   public void testPR_RemotePutRejectionCacheClose() throws Exception {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prRemotePutRejection(true, false, false);
   }
 
@@ -598,7 +599,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
   @Test
   public void testPR_RemotePutRejectionCacheCloseWithTx() throws Exception {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prRemotePutRejection(true, false, true);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import org.apache.geode.test.dunit.IgnoredException;
 import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
@@ -84,6 +85,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testEntryLruLimitNDestroyLimit() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", 100);
     putData("PR2", 60);
@@ -164,6 +167,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testEntryLruCounter() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", 10);
     putData("PR2", 16);
@@ -194,6 +199,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testHeapLruCounter() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_HEAP);
     System.setProperty(HeapLRUCapacityController.TOP_UP_HEAP_EVICTION_PERCENTAGE_PROPERTY,
         Float.toString(0));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
@@ -126,6 +126,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testMemLruLimitNDestroyLimit() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);
     putData("PR1", 100);
     putData("PR2", 60);
@@ -184,6 +186,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testMemLruCounter() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);
     putData("PR1", 10);
     putData("PR2", 16);
@@ -215,6 +219,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testEntryLruAllCounterMethods() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final long ONE_MEG = 1024L * 1024L;
     createCache();
     createPartitionedRegion(true, EvictionAlgorithm.LRU_ENTRY, "PR1", 2, 1, 10000);
@@ -284,6 +290,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testEntryLRUEvictionNDestroyNNumOverflowOnDiskCount() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final int extraEnteries = 24;
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", maxEnteries + extraEnteries);
@@ -331,6 +339,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testMemLRUEvictionNDestroyNNumOverflowOnDiskCount() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     int localMaxMem = 50;
     final int extraEntries = 6;
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionStatsDUnitTest.java
@@ -86,7 +86,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testEntryLruLimitNDestroyLimit() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", 100);
     putData("PR2", 60);
@@ -127,7 +128,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testMemLruLimitNDestroyLimit() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);
     putData("PR1", 100);
     putData("PR2", 60);
@@ -170,7 +172,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testEntryLruCounter() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", 10);
     putData("PR2", 16);
@@ -187,7 +190,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testMemLruCounter() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);
     putData("PR1", 10);
     putData("PR2", 16);
@@ -204,7 +208,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testHeapLruCounter() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     prepareScenario(EvictionAlgorithm.LRU_HEAP);
     System.setProperty(HeapLRUCapacityController.TOP_UP_HEAP_EVICTION_PERCENTAGE_PROPERTY,
         Float.toString(0));
@@ -220,7 +225,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testEntryLruAllCounterMethods() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final long ONE_MEG = 1024L * 1024L;
     createCache();
     createPartitionedRegion(true, EvictionAlgorithm.LRU_ENTRY, "PR1", 2, 1, 10000);
@@ -291,7 +297,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testEntryLRUEvictionNDestroyNNumOverflowOnDiskCount() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final int extraEnteries = 24;
     prepareScenario(EvictionAlgorithm.LRU_ENTRY);
     putData("PR1", maxEnteries + extraEnteries);
@@ -340,7 +347,8 @@ public class EvictionStatsDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testMemLRUEvictionNDestroyNNumOverflowOnDiskCount() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     int localMaxMem = 50;
     final int extraEntries = 6;
     prepareScenario(EvictionAlgorithm.LRU_MEMORY);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEvictionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEvictionDUnitTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.geode.test.dunit.IgnoredException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -64,6 +65,8 @@ public class PartitionedRegionEvictionDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testHeapLRUWithOverflowToDisk() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final Host host = Host.getHost(0);
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
@@ -206,6 +209,8 @@ public class PartitionedRegionEvictionDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testHeapLRUWithLocalDestroy() {
+    // Ignore this excetion as this can happen if pool is shutting down
+    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final Host host = Host.getHost(0);
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEvictionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEvictionDUnitTest.java
@@ -66,7 +66,8 @@ public class PartitionedRegionEvictionDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testHeapLRUWithOverflowToDisk() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final Host host = Host.getHost(0);
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
@@ -210,7 +211,8 @@ public class PartitionedRegionEvictionDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testHeapLRUWithLocalDestroy() {
     // Ignore this excetion as this can happen if pool is shutting down
-    IgnoredException.addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
+    IgnoredException
+        .addIgnoredException(java.util.concurrent.RejectedExecutionException.class.getName());
     final Host host = Host.getHost(0);
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);


### PR DESCRIPTION
Replaced submit call with execute.
Refactored GIITask calls from DiskStoreImpl. Async task like Creating KRF's through disk store are replaced with execute. The other call is kept with submit as we later check for whether delayed write is completed or not.
Added RejectedExecutionException to IgnoredException list as from these tests it may get occasionally thrown and as we moved to execute method of ExecutorService they will be logged.

All precheckin tests are passing except one org.apache.geode.management.internal.cli.commands.IndexCommandsDUnitTest.testCreateDestroyUpdatesSharedConfig which is marked as Flaky.