### PR TITLE
 GEODE-734: gfsh export stack-traces should not require an output file with extension .txt

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/MiscellaneousCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/MiscellaneousCommands.java
@@ -1013,8 +1013,7 @@ public class MiscellaneousCommands implements CommandMarker {
    * @return Stack Trace
    */
   @CliCommand(value = CliStrings.EXPORT_STACKTRACE, help = CliStrings.EXPORT_STACKTRACE__HELP)
-  @CliMetaData(shellOnly = false, relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL},
-      interceptor = "org.apache.geode.management.internal.cli.commands.MiscellaneousCommands$ExportStackTraceInterceptor")
+  @CliMetaData(shellOnly = false, relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = Resource.CLUSTER, operation = Operation.READ)
   public Result exportStackTrace(@CliOption(key = CliStrings.EXPORT_STACKTRACE__MEMBER,
       optionContext = ConverterHint.ALL_MEMBER_IDNAME,
@@ -1024,11 +1023,25 @@ public class MiscellaneousCommands implements CommandMarker {
           optionContext = ConverterHint.ALL_MEMBER_IDNAME,
           help = CliStrings.EXPORT_STACKTRACE__GROUP) String group,
 
-      @CliOption(key = CliStrings.EXPORT_STACKTRACE__FILE, mandatory = true,
-          help = CliStrings.EXPORT_STACKTRACE__FILE__HELP) String fileName) {
+      @CliOption(key = CliStrings.EXPORT_STACKTRACE__FILE,
+          help = CliStrings.EXPORT_STACKTRACE__FILE__HELP) String fileName,
+
+      @CliOption(key = CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,
+          unspecifiedDefaultValue = "false",
+          help = CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT__HELP) boolean failIfFilePresent) {
 
     Result result = null;
+    StringBuffer filePrefix = new StringBuffer("stacktrace");
     try {
+      if (fileName == null) {
+        fileName = filePrefix.append("_").append(System.currentTimeMillis()).toString();
+      }
+      final File outFile = new File(fileName);
+      if (outFile.exists() && failIfFilePresent) {
+        return ResultBuilder.createShellClientErrorResult(CliStrings.format(
+            CliStrings.EXPORT_STACKTRACE__ERROR__FILE__PRESENT, outFile.getCanonicalPath()));
+      }
+
       Cache cache = CacheFactory.getAnyInstance();
       GemFireCacheImpl gfeCacheImpl = (GemFireCacheImpl) cache;
       InternalDistributedSystem ads = gfeCacheImpl.getSystem();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1427,9 +1427,14 @@ public class CliStrings {
   public static final String EXPORT_STACKTRACE__FILE = "file";
   public static final String EXPORT_STACKTRACE__FILE__HELP =
       "Name of the file to which the stack traces will be written.";
+  public static final String EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT = "abort-if-file-exists";
+  public static final String EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT__HELP =
+      "Abort the command if already exists at locator directory";
   public static final String EXPORT_STACKTRACE__MEMBER__NOT__FOUND = "Member not found";
   public static final String EXPORT_STACKTRACE__SUCCESS = "stack-trace(s) exported to file: {0}";
   public static final String EXPORT_STACKTRACE__ERROR = "Error occured while showing stack-traces";
+  public static final String EXPORT_STACKTRACE__ERROR__FILE__PRESENT =
+      "Error occured while exporting stack-traces, file {0} already present";
   public static final String EXPORT_STACKTRACE__HOST = "On host : ";
   public static final String EXPORT_STACKTRACE_WARN_USER =
       "If file {0} already present at locator directory it will be overwritten, do you want to continue?";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1431,8 +1431,9 @@ public class CliStrings {
   public static final String EXPORT_STACKTRACE__SUCCESS = "stack-trace(s) exported to file: {0}";
   public static final String EXPORT_STACKTRACE__ERROR = "Error occured while showing stack-traces";
   public static final String EXPORT_STACKTRACE__HOST = "On host : ";
-  public static final String EXPORT_STACKTRACE__INVALID_FILE_TYPE =
-      "Invalid file extension. File must be a text file (.txt)";
+  public static final String EXPORT_STACKTRACE_WARN_USER =
+      "If file {0} already present at locator directory it will be overwritten, do you want to continue?";
+  public static final String EXPORT_STACKTRACE_MSG_ABORTING = "Aborting export stack-traces";
 
   /* 'gc' command */
   public static final String GC = "gc";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/MiscellaneousCommandsController.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/MiscellaneousCommandsController.java
@@ -100,14 +100,18 @@ public class MiscellaneousCommandsController extends AbstractCommandsController 
   @RequestMapping(method = RequestMethod.GET, value = "/stacktraces")
   @ResponseBody
   public String exportStackTraces(
-      @RequestParam(value = CliStrings.EXPORT_STACKTRACE__FILE) final String file,
+      @RequestParam(value = CliStrings.EXPORT_STACKTRACE__FILE, required = false) final String file,
       @RequestParam(value = CliStrings.EXPORT_STACKTRACE__GROUP,
           required = false) final String groupName,
       @RequestParam(value = CliStrings.EXPORT_STACKTRACE__MEMBER,
-          required = false) final String memberNameId) {
+          required = false) final String memberNameId,
+      @RequestParam(value = CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,
+          required = false) final boolean failIfFilePresent) {
     CommandStringBuilder command = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
 
-    command.addOption(CliStrings.EXPORT_STACKTRACE__FILE, decode(file));
+    if (hasValue(file)) {
+      command.addOption(CliStrings.EXPORT_STACKTRACE__FILE, decode(file));
+    }
 
     if (hasValue(groupName)) {
       command.addOption(CliStrings.EXPORT_STACKTRACE__GROUP, groupName);
@@ -115,6 +119,11 @@ public class MiscellaneousCommandsController extends AbstractCommandsController 
 
     if (hasValue(memberNameId)) {
       command.addOption(CliStrings.EXPORT_STACKTRACE__MEMBER, memberNameId);
+    }
+
+    if (hasValue(failIfFilePresent)) {
+      command.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,
+          String.valueOf(failIfFilePresent));
     }
 
     return processCommand(command.toString());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
@@ -222,8 +222,8 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
   }
 
   /***
-   * Tests the behavior of the show stack-trace command when file option is not provided
-   * File should get auto-generated
+   * Tests the behavior of the show stack-trace command when file option is not provided File should
+   * get auto-generated
    *
    * @throws ClassNotFoundException
    * @throws IOException
@@ -237,7 +237,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     stacktracesFile.createNewFile();
     stacktracesFile.deleteOnExit();
     CommandStringBuilder commandStringBuilder =
-      new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+        new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     String exportCommandString = commandStringBuilder.toString();
     getLogWriter().info("CommandString : " + exportCommandString);
     CommandResult exportCommandResult = executeCommand(exportCommandString);
@@ -245,8 +245,8 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     assertTrue(exportCommandResult.getStatus().equals(Status.OK));
     try {
       assertTrue(
-        ((String) exportCommandResult.getResultData().getGfJsonObject().getJSONObject("content")
-          .getJSONArray("message").get(0)).contains("stack-trace(s) exported to file:"));
+          ((String) exportCommandResult.getResultData().getGfJsonObject().getJSONObject("content")
+              .getJSONArray("message").get(0)).contains("stack-trace(s) exported to file:"));
     } catch (GfJsonException e) {
       fail("Exception while parsing command result", e.getCause());
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
@@ -15,6 +15,12 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.distributed.ConfigurationProperties.*;
+import static org.apache.geode.test.dunit.Assert.*;
+import static org.apache.geode.test.dunit.LogWriterUtils.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
 
 import org.apache.geode.management.cli.Result.Status;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -25,16 +31,11 @@ import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Properties;
-
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.test.dunit.Assert.*;
-import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
+import org.junit.rules.TemporaryFolder;
 
 /***
  * DUnit test for 'show stack-trace' command
@@ -43,6 +44,9 @@ import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
 public class ShowStackTraceDUnitTest extends CliCommandTestBase {
 
   private static final long serialVersionUID = 1L;
+
+  @Rule
+  public TemporaryFolder workDirectory = new SerializableTemporaryFolder();
 
   private void createCache(Properties props) {
     getSystem(props);
@@ -90,23 +94,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
   public void testExportStacktrace() throws ClassNotFoundException, IOException {
     setupSystem();
 
-    // Test non txt extension file is allowed
-    File stacktracesFile = new File("allStackTraces.log");
-    stacktracesFile.createNewFile();
-    stacktracesFile.deleteOnExit();
-    CommandStringBuilder commandStringBuilder =
-        new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
-    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
-        stacktracesFile.getCanonicalPath());
-    String exportCommandString = commandStringBuilder.toString();
-    getLogWriter().info("CommandString : " + exportCommandString);
-    CommandResult exportCommandResult = executeCommand(exportCommandString);
-    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
-    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
-
-    File allStacktracesFile = new File("allStackTraces.txt");
-    allStacktracesFile.createNewFile();
-    allStacktracesFile.deleteOnExit();
+    File allStacktracesFile = workDirectory.newFile("allStackTraces.txt");
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     csb.addOption(CliStrings.EXPORT_STACKTRACE__FILE, allStacktracesFile.getCanonicalPath());
     String commandString = csb.toString();
@@ -115,9 +103,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     getLogWriter().info("Output : \n" + commandResultToString(commandResult));
     assertTrue(commandResult.getStatus().equals(Status.OK));
 
-    File mgrStacktraceFile = new File("managerStacktrace.txt");
-    mgrStacktraceFile.createNewFile();
-    mgrStacktraceFile.deleteOnExit();
+    File mgrStacktraceFile = workDirectory.newFile("managerStacktrace.txt");
     csb = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     csb.addOption(CliStrings.EXPORT_STACKTRACE__FILE, mgrStacktraceFile.getCanonicalPath());
     csb.addOption(CliStrings.EXPORT_STACKTRACE__MEMBER, "Manager");
@@ -127,9 +113,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     getLogWriter().info("Output : \n" + commandResultToString(commandResult));
     assertTrue(commandResult.getStatus().equals(Status.OK));
 
-    File serverStacktraceFile = new File("serverStacktrace.txt");
-    serverStacktraceFile.createNewFile();
-    serverStacktraceFile.deleteOnExit();
+    File serverStacktraceFile = workDirectory.newFile("serverStacktrace.txt");
     csb = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     csb.addOption(CliStrings.EXPORT_STACKTRACE__FILE, serverStacktraceFile.getCanonicalPath());
     csb.addOption(CliStrings.EXPORT_STACKTRACE__MEMBER, "Server");
@@ -139,9 +123,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     getLogWriter().info("Output : \n" + commandResultToString(commandResult));
     assertTrue(commandResult.getStatus().equals(Status.OK));
 
-    File groupStacktraceFile = new File("groupstacktrace.txt");
-    groupStacktraceFile.createNewFile();
-    groupStacktraceFile.deleteOnExit();
+    File groupStacktraceFile = workDirectory.newFile("groupstacktrace.txt");
     csb = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     csb.addOption(CliStrings.EXPORT_STACKTRACE__FILE, groupStacktraceFile.getCanonicalPath());
     csb.addOption(CliStrings.EXPORT_STACKTRACE__GROUP, "G2");
@@ -151,9 +133,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     getLogWriter().info("Output : \n" + commandResultToString(commandResult));
     assertTrue(commandResult.getStatus().equals(Status.OK));
 
-    File wrongStackTraceFile = new File("wrongStackTrace.txt");
-    wrongStackTraceFile.createNewFile();
-    wrongStackTraceFile.deleteOnExit();
+    File wrongStackTraceFile = workDirectory.newFile("wrongStackTrace.txt");
     csb = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     csb.addOption(CliStrings.EXPORT_STACKTRACE__FILE, wrongStackTraceFile.getCanonicalPath());
     csb.addOption(CliStrings.EXPORT_STACKTRACE__MEMBER, "WrongMember");
@@ -165,7 +145,44 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
   }
 
   /***
-   * Tests the behavior of the show stack-trace command when file is already present
+   * Tests the behavior of the show stack-trace command to verify that files with any extension are
+   * allowed Refer: GEODE-734
+   *
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  @Test
+  public void testExportStacktraceWithNonTXTFile() throws ClassNotFoundException, IOException {
+    setupSystem();
+
+    // Test non txt extension file is allowed
+    File stacktracesFile = workDirectory.newFile("allStackTraces.log");
+    CommandStringBuilder commandStringBuilder =
+        new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+        stacktracesFile.getCanonicalPath());
+    String exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    CommandResult exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
+
+    // test file with-out any extension
+    File allStacktracesFile = workDirectory.newFile("allStackTraces");
+    commandStringBuilder = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+        allStacktracesFile.getCanonicalPath());
+    exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
+  }
+
+  /***
+   * Tests the behavior of the show stack-trace command when file is already present and
+   * abort-if-file-exists option is set to false(which is default). As a result it should overwrite
+   * the file and return OK status
    *
    * @throws ClassNotFoundException
    * @throws IOException
@@ -174,51 +191,51 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
   public void testExportStacktraceWhenFilePresent() throws ClassNotFoundException, IOException {
     setupSystem();
 
-    // test fail if file present
-    File stacktracesFile = new File("allStackTraces.log");
-    stacktracesFile.createNewFile();
-    stacktracesFile.deleteOnExit();
-    getLogWriter().info("ShowStackTraceDUnitTest.testExportStacktraceWhenFilePresent :: "
-        + "Created file at: " + stacktracesFile.getCanonicalPath());
+    // test pass although file present
+    File stacktracesFile = workDirectory.newFile("allStackTraces.log");
     CommandStringBuilder commandStringBuilder =
         new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
         stacktracesFile.getCanonicalPath());
-    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,
-        Boolean.FALSE.toString());
     String exportCommandString = commandStringBuilder.toString();
     getLogWriter().info("CommandString : " + exportCommandString);
     CommandResult exportCommandResult = executeCommand(exportCommandString);
     getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
     assertTrue(exportCommandResult.getStatus().equals(Status.OK));
 
-    // test pass although file present
-    stacktracesFile = new File("allStackTraces.log");
-    stacktracesFile.createNewFile();
-    stacktracesFile.deleteOnExit();
-    commandStringBuilder = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+  }
+
+  /***
+   * Tests the behavior of the show stack-trace command when file is already present and when
+   * abort-if-file-exists option is set to true. As a result it should fail with ERROR status
+   *
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  @Test
+  public void testExportStacktraceFilePresentWithAbort()
+      throws ClassNotFoundException, IOException {
+    setupSystem();
+
+    File stacktracesFile = workDirectory.newFile("allStackTraces.log");
+    CommandStringBuilder commandStringBuilder =
+        new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
         stacktracesFile.getCanonicalPath());
-    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT, "false");
-    exportCommandString = commandStringBuilder.toString();
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,
+        Boolean.TRUE.toString());
+    String exportCommandString = commandStringBuilder.toString();
     getLogWriter().info("CommandString : " + exportCommandString);
-    exportCommandResult = executeCommand(exportCommandString);
+    CommandResult exportCommandResult = executeCommand(exportCommandString);
     getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
-    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
-
-    // test default pass although file present
-    stacktracesFile = new File("allStackTraces.log");
-    stacktracesFile.createNewFile();
-    stacktracesFile.deleteOnExit();
-    commandStringBuilder = new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
-    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
-        stacktracesFile.getCanonicalPath());
-    exportCommandString = commandStringBuilder.toString();
-    getLogWriter().info("CommandString : " + exportCommandString);
-    exportCommandResult = executeCommand(exportCommandString);
-    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
-    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
-
+    assertTrue(exportCommandResult.getStatus().equals(Status.ERROR));
+    try {
+      assertTrue(((String) exportCommandResult.getResultData().getGfJsonObject()
+          .getJSONObject("content").getJSONArray("message").get(0))
+              .contains("file " + stacktracesFile.getCanonicalPath() + " already present"));
+    } catch (GfJsonException e) {
+      fail("Exception while parsing command result", e.getCause());
+    }
   }
 
   /***
@@ -233,9 +250,6 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     setupSystem();
 
     // test auto generated file when file name is not provided
-    File stacktracesFile = new File("allStackTraces.log");
-    stacktracesFile.createNewFile();
-    stacktracesFile.deleteOnExit();
     CommandStringBuilder commandStringBuilder =
         new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
     String exportCommandString = commandStringBuilder.toString();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
@@ -214,7 +214,7 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
    */
   @Test
   public void testExportStacktraceFilePresentWithAbort()
-      throws ClassNotFoundException, IOException {
+      throws ClassNotFoundException, IOException, GfJsonException {
     setupSystem();
 
     File stacktracesFile = workDirectory.newFile("allStackTraces.log");
@@ -229,13 +229,9 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     CommandResult exportCommandResult = executeCommand(exportCommandString);
     getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
     assertTrue(exportCommandResult.getStatus().equals(Status.ERROR));
-    try {
-      assertTrue(((String) exportCommandResult.getResultData().getGfJsonObject()
-          .getJSONObject("content").getJSONArray("message").get(0))
-              .contains("file " + stacktracesFile.getCanonicalPath() + " already present"));
-    } catch (GfJsonException e) {
-      fail("Exception while parsing command result", e.getCause());
-    }
+    assertTrue(((String) exportCommandResult.getResultData().getGfJsonObject()
+        .getJSONObject("content").getJSONArray("message").get(0))
+            .contains("file " + stacktracesFile.getCanonicalPath() + " already present"));
   }
 
   /***
@@ -246,7 +242,8 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
    * @throws IOException
    */
   @Test
-  public void testExportStacktraceAutoGenerateFile() throws ClassNotFoundException, IOException {
+  public void testExportStacktraceAutoGenerateFile()
+      throws ClassNotFoundException, IOException, GfJsonException {
     setupSystem();
 
     // test auto generated file when file name is not provided
@@ -257,12 +254,9 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     CommandResult exportCommandResult = executeCommand(exportCommandString);
     getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
     assertTrue(exportCommandResult.getStatus().equals(Status.OK));
-    try {
-      assertTrue(
-          ((String) exportCommandResult.getResultData().getGfJsonObject().getJSONObject("content")
-              .getJSONArray("message").get(0)).contains("stack-trace(s) exported to file:"));
-    } catch (GfJsonException e) {
-      fail("Exception while parsing command result", e.getCause());
-    }
+    assertTrue(
+        ((String) exportCommandResult.getResultData().getGfJsonObject().getJSONObject("content")
+            .getJSONArray("message").get(0)).contains("stack-trace(s) exported to file:"));
+
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
@@ -163,4 +163,57 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
     getLogWriter().info("Output : \n" + commandResultToString(commandResult));
     assertFalse(commandResult.getStatus().equals(Status.OK));
   }
+
+  /***
+   * Tests the behavior of the show stack-trace command when file is already present
+   *
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  @Test
+  public void testExportStacktraceWhenFilePresent() throws ClassNotFoundException, IOException {
+    setupSystem();
+
+    // Test non txt extension file is allowed
+    File stacktracesFile = new File("allStackTraces.log");
+    stacktracesFile.createNewFile();
+    stacktracesFile.deleteOnExit();
+    CommandStringBuilder commandStringBuilder =
+      new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+      stacktracesFile.getCanonicalPath());
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,"true");
+    String exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    CommandResult exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.ERROR));
+
+    stacktracesFile = new File("allStackTraces.log");
+    stacktracesFile.createNewFile();
+    stacktracesFile.deleteOnExit();
+    commandStringBuilder =
+      new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+      stacktracesFile.getCanonicalPath());
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FAIL__IF__FILE__PRESENT,"false");
+    exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
+
+    stacktracesFile = new File("allStackTraces.log");
+    stacktracesFile.createNewFile();
+    stacktracesFile.deleteOnExit();
+    commandStringBuilder =
+      new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+      stacktracesFile.getCanonicalPath());
+    exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowStackTraceDUnitTest.java
@@ -90,6 +90,20 @@ public class ShowStackTraceDUnitTest extends CliCommandTestBase {
   public void testExportStacktrace() throws ClassNotFoundException, IOException {
     setupSystem();
 
+    // Test non txt extension file is allowed
+    File stacktracesFile = new File("allStackTraces.log");
+    stacktracesFile.createNewFile();
+    stacktracesFile.deleteOnExit();
+    CommandStringBuilder commandStringBuilder =
+        new CommandStringBuilder(CliStrings.EXPORT_STACKTRACE);
+    commandStringBuilder.addOption(CliStrings.EXPORT_STACKTRACE__FILE,
+        stacktracesFile.getCanonicalPath());
+    String exportCommandString = commandStringBuilder.toString();
+    getLogWriter().info("CommandString : " + exportCommandString);
+    CommandResult exportCommandResult = executeCommand(exportCommandString);
+    getLogWriter().info("Output : \n" + commandResultToString(exportCommandResult));
+    assertTrue(exportCommandResult.getStatus().equals(Status.OK));
+
     File allStacktracesFile = new File("allStackTraces.txt");
     allStacktracesFile.createNewFile();
     allStacktracesFile.deleteOnExit();

--- a/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
+++ b/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
@@ -1511,7 +1511,8 @@ IS AVAILABLE\n\
 SYNOPSIS\n\
 \ \ \ \ Export the stack trace for a member or members.\n\
 SYNTAX\n\
-\ \ \ \ export stack-traces --file=value [--member=value] [--group=value]\n\
+\ \ \ \ export stack-traces [--member=value] [--group=value] [--file=value]\n\
+\ \ \ \ [--abort-if-file-exists=value]\n\
 PARAMETERS\n\
 \ \ \ \ member\n\
 \ \ \ \ \ \ \ \ Export the stack trace for a member or members.\n\
@@ -1521,7 +1522,11 @@ PARAMETERS\n\
 \ \ \ \ \ \ \ \ Required: false\n\
 \ \ \ \ file\n\
 \ \ \ \ \ \ \ \ Name of the file to which the stack traces will be written.\n\
-\ \ \ \ \ \ \ \ Required: true\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ abort-if-file-exists\n\
+\ \ \ \ \ \ \ \ Abort the command if already exists at locator directory\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ \ \ \ \ Default (if the parameter is not specified): false\n\
 
 gc.help=\
 NAME\n\


### PR DESCRIPTION
Removed mandatory txt file extension when exporting stack trace using gfsh command export stack-traces.
Added message warning user about possible overwrite of file if already present under locator directory.
Added test to check if non txt extension file is allowed.
All tests are passing