### PR TITLE
[GEODE-2167] BundledJarsJUnitTest fails on Windows

### DIFF
--- a/geode-assembly/.gitignore
+++ b/geode-assembly/.gitignore
@@ -1,0 +1,1 @@
+bundled_jars.txt

--- a/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
@@ -28,6 +28,7 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang.SystemUtils;
 import org.apache.geode.test.junit.categories.RestAPITest;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,8 +49,9 @@ public class BundledJarsJUnitTest {
   public void loadExpectedJars() throws IOException {
     String expectedJarFile =
         TestUtil.getResourcePath(BundledJarsJUnitTest.class, "/expected_jars.txt");
-
-    expectedJars = Files.lines(Paths.get(expectedJarFile)).collect(Collectors.toSet());
+    expectedJars = Files
+            .lines(Paths.get(SystemUtils.IS_OS_WINDOWS ? expectedJarFile.substring(1) : expectedJarFile))
+            .collect(Collectors.toSet());
   }
 
   @Test

--- a/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
@@ -50,8 +50,9 @@ public class BundledJarsJUnitTest {
     String expectedJarFile =
         TestUtil.getResourcePath(BundledJarsJUnitTest.class, "/expected_jars.txt");
     expectedJars = Files
-            .lines(Paths.get(SystemUtils.IS_OS_WINDOWS ? expectedJarFile.substring(1) : expectedJarFile))
-            .collect(Collectors.toSet());
+        .lines(
+            Paths.get(SystemUtils.IS_OS_WINDOWS ? expectedJarFile.substring(1) : expectedJarFile))
+        .collect(Collectors.toSet());
   }
 
   @Test

--- a/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/BundledJarsJUnitTest.java
@@ -28,7 +28,6 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang.SystemUtils;
 import org.apache.geode.test.junit.categories.RestAPITest;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,10 +48,8 @@ public class BundledJarsJUnitTest {
   public void loadExpectedJars() throws IOException {
     String expectedJarFile =
         TestUtil.getResourcePath(BundledJarsJUnitTest.class, "/expected_jars.txt");
-    expectedJars = Files
-        .lines(
-            Paths.get(SystemUtils.IS_OS_WINDOWS ? expectedJarFile.substring(1) : expectedJarFile))
-        .collect(Collectors.toSet());
+
+    expectedJars = Files.lines(Paths.get(expectedJarFile)).collect(Collectors.toSet());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/util/test/TestUtil.java
+++ b/geode-core/src/test/java/org/apache/geode/util/test/TestUtil.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.apache.commons.lang.SystemUtils;
 import org.apache.geode.internal.FileUtil;
 
 public class TestUtil {
@@ -46,11 +47,15 @@ public class TestUtil {
         File tmpFile = File.createTempFile(filename, null);
         tmpFile.deleteOnExit();
         FileUtil.copy(resource, tmpFile);
-        return tmpFile.getAbsolutePath();
+        return compatibleWithWindows(tmpFile.getAbsolutePath());
       }
-      return path;
+      return compatibleWithWindows(path);
     } catch (URISyntaxException | IOException e) {
       throw new RuntimeException("Failed getting path to resource " + name, e);
     }
+  }
+
+  private static String compatibleWithWindows(String path) {
+    return SystemUtils.IS_OS_WINDOWS ? path.substring(1) : path;
   }
 }


### PR DESCRIPTION
error message: 
```java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/dev/gemfire/open/geode-assembly/build/resources/test/expected_jars.txt```
expectedJarFile path should be set on Windows properly. We should trim path string to elimination first '/' letter.