### PR TITLE
[GEODE-2144] Improve error message when no security credentials are p…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/Version.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/Version.java
@@ -587,4 +587,7 @@ public final class Version implements Comparable<Version> {
     return bytes;
   }
 
+  public boolean isPre65() {
+    return compareTo(Version.GFE_65) < 0;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AuthIds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AuthIds.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+
+public class AuthIds {
+  private long connectionId;
+  private long uniqueId;
+
+  public AuthIds(byte[] bytes) throws Exception {
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
+    if (bytes.length == 8) {
+      // only connectionid
+      connectionId = dis.readLong();
+    } else if (bytes.length == 16) {
+      // first connectionId and then uniqueID
+      connectionId = dis.readLong();
+      uniqueId = dis.readLong();
+    } else {
+      throw new Exception("Auth ids are not in right form");
+    }
+  }
+
+
+  public long getConnectionId() {
+    return connectionId;
+  }
+
+  public long getUniqueId() {
+    return this.uniqueId;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
 package org.apache.geode.internal.cache.tier.sockets;
 
 import org.apache.geode.internal.i18n.LocalizedStrings;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractor.java
@@ -1,0 +1,28 @@
+package org.apache.geode.internal.cache.tier.sockets;
+
+import org.apache.geode.internal.i18n.LocalizedStrings;
+import org.apache.geode.security.AuthenticationRequiredException;
+
+public class MessageIdExtractor {
+  public long getUniqueIdFromMessage(Message requestMessage, HandShake handshake, long connectionId)
+      throws AuthenticationRequiredException {
+    AuthIds aIds = getAuthIdsFromMessage(requestMessage, handshake);
+    if (connectionId != aIds.getConnectionId()) {
+      throw new AuthenticationRequiredException(
+          LocalizedStrings.HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED.toLocalizedString());
+    }
+    return aIds.getUniqueId();
+  }
+
+  private AuthIds getAuthIdsFromMessage(Message requestMessage, HandShake handshake)
+      throws AuthenticationRequiredException {
+    try {
+      byte[] secureBytes = requestMessage.getSecureBytes();
+      secureBytes = handshake.decryptBytes(secureBytes);
+      return new AuthIds(secureBytes);
+    } catch (Exception ex) {
+      throw new AuthenticationRequiredException(
+          LocalizedStrings.HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED.toLocalizedString(), ex);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -5350,8 +5350,8 @@ public class LocalizedStrings {
       new StringId(4192, "Server expecting SSL connection");
   public static final StringId HandShake_FAILED_TO_ACQUIRE_AUTHINITIALIZE_METHOD_0 =
       new StringId(4194, "Failed to acquire AuthInitialize method {0}");
-  public static final StringId HandShake_NO_SECURITY_PROPERTIES_ARE_PROVIDED =
-      new StringId(4195, "No security-* properties are provided");
+  public static final StringId HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED =
+      new StringId(4195, "No security credentials are provided");
   public static final StringId HandShake_FAILURE_IN_READING_CREDENTIALS =
       new StringId(4196, "Failure in reading credentials");
   public static final StringId HandShake_FAILED_TO_ACQUIRE_AUTHENTICATOR_OBJECT =

--- a/geode-core/src/test/java/org/apache/geode/internal/VersionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/VersionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -44,5 +45,12 @@ public class VersionJUnitTest {
     assertTrue(later.compareTo(earlier.ordinal()) > 0);
     assertTrue(later.compareTo(later.ordinal()) == 0);
     assertTrue(earlier.compareTo(later.ordinal()) < 0);
+  }
+
+  @Test
+  public void testIsPre65() {
+    assertTrue(Version.GFE_61.isPre65());
+    assertFalse(Version.GFE_65.isPre65());
+    assertFalse(Version.GFE_70.isPre65());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HandShakeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HandShakeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.internal.i18n.LocalizedStrings.HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTest.class)
+public class HandShakeTest {
+
+  @Test
+  public void authRequiredHasCredentials() throws Exception {
+    HandShake.throwIfMissingRequiredCredentials(true, true);
+  }
+
+  @Test
+  public void authRequiredHasNoCredentials() throws Exception {
+    assertThatThrownBy(() -> HandShake.throwIfMissingRequiredCredentials(true, false))
+        .isExactlyInstanceOf(AuthenticationRequiredException.class)
+        .hasMessage(HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED.toLocalizedString());
+  }
+
+  @Test
+  public void authNotRequiredHasCredentials() throws Exception {
+    HandShake.throwIfMissingRequiredCredentials(false, true);
+  }
+
+  @Test
+  public void authNotRequiredHasNoCredentials() throws Exception {
+    HandShake.throwIfMissingRequiredCredentials(false, false);
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageIdExtractorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+@Category(UnitTest.class)
+public class MessageIdExtractorTest {
+  @Mock
+  Message requestMessage;
+
+  @Mock
+  HandShake handshake;
+
+  private MessageIdExtractor messageIdExtractor;
+
+  private Long connectionId = 123L;
+  private Long uniqueId = 234L;
+  private byte[] decryptedBytes;
+
+  @Before
+  public void before() throws Exception {
+    this.messageIdExtractor = new MessageIdExtractor();
+    decryptedBytes = byteArrayFromIds(connectionId, uniqueId);
+
+    MockitoAnnotations.initMocks(this);
+
+    when(handshake.decryptBytes(any())).thenReturn(decryptedBytes);
+  }
+
+  @Test
+  public void getUniqueIdFromMessage() throws Exception {
+    assertThat(messageIdExtractor.getUniqueIdFromMessage(requestMessage, handshake, connectionId))
+        .isEqualTo(uniqueId);
+  }
+
+  @Test
+  public void throwsWhenConnectionIdsDoNotMatch() throws Exception {
+    long otherConnectionId = 789L;
+
+    assertThatThrownBy(() -> messageIdExtractor.getUniqueIdFromMessage(requestMessage, handshake,
+        otherConnectionId)).isInstanceOf(AuthenticationRequiredException.class);
+  }
+
+  private byte[] byteArrayFromIds(Long connectionId, Long uniqueId) throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream dis = new DataOutputStream(byteArrayOutputStream);
+    dis.writeLong(connectionId);
+    dis.writeLong(uniqueId);
+    dis.flush();
+    return byteArrayOutputStream.toByteArray();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+
+import static org.apache.geode.internal.i18n.LocalizedStrings.HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.tier.Acceptor;
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+@Category(UnitTest.class)
+public class ServerConnectionTest {
+  @Mock
+  private Message requestMsg;
+
+  @Mock
+  private HandShake handshake;
+
+  @Mock
+  private MessageIdExtractor messageIdExtractor;
+
+  @InjectMocks
+  private ServerConnection serverConnection;
+
+  @Before
+  public void setUp() {
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+
+    InetAddress inetAddress = mock(InetAddress.class);
+    when(inetAddress.getHostAddress()).thenReturn("localhost");
+
+    Socket socket = mock(Socket.class);
+    when(socket.getInetAddress()).thenReturn(inetAddress);
+
+    Cache cache = mock(Cache.class);
+
+    serverConnection = new ServerConnection(socket, cache, null, null, 0, 0, null,
+        Acceptor.PRIMARY_SERVER_TO_CLIENT, acceptor);
+    MockitoAnnotations.initMocks(this);
+  }
+
+
+  @Test
+  public void pre65SecureShouldReturnUserAuthId() {
+    long userAuthId = 12345L;
+    serverConnection.setUserAuthId(userAuthId);
+
+    when(handshake.getVersion()).thenReturn(Version.GFE_61);
+    when(requestMsg.isSecureMode()).thenReturn(true);
+
+    assertThat(serverConnection.getUniqueId()).isEqualTo(userAuthId);
+  }
+
+  @Test
+  public void pre65NonSecureShouldReturnUserAuthId() {
+    long userAuthId = 12345L;
+    serverConnection.setUserAuthId(userAuthId);
+
+    when(handshake.getVersion()).thenReturn(Version.GFE_61);
+    when(requestMsg.isSecureMode()).thenReturn(false);
+
+    assertThat(serverConnection.getUniqueId()).isEqualTo(userAuthId);
+  }
+
+
+  @Test
+  public void post65SecureShouldUseUniqueIdFromMessage() {
+    long uniqueIdFromMessage = 23456L;
+    when(handshake.getVersion()).thenReturn(Version.GFE_82);
+    serverConnection.setRequestMsg(requestMsg);
+
+    assertThat(serverConnection.getRequestMessage()).isSameAs(requestMsg);
+    when(requestMsg.isSecureMode()).thenReturn(true);
+
+    when(messageIdExtractor.getUniqueIdFromMessage(any(Message.class), any(HandShake.class),
+        anyLong())).thenReturn(uniqueIdFromMessage);
+    serverConnection.setMessageIdExtractor(messageIdExtractor);
+
+    assertThat(serverConnection.getUniqueId()).isEqualTo(uniqueIdFromMessage);
+  }
+
+  @Test
+  public void post65NonSecureShouldThrow() {
+    when(handshake.getVersion()).thenReturn(Version.GFE_82);
+    when(requestMsg.isSecureMode()).thenReturn(false);
+
+    assertThatThrownBy(serverConnection::getUniqueId)
+        .isExactlyInstanceOf(AuthenticationRequiredException.class)
+        .hasMessage(HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED.getRawText());
+  }
+
+}


### PR DESCRIPTION
…rovided.

- Improve error message when no security credentials are provided.
- Add tests for the code paths exposing this message.
- Refactor making those code paths more testable.