### PR TITLE
GEODE-789: Added 'create defined indexes', 'clear defined indexes', and  'define index' for CliAvailabilityIndicator

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommands.java
@@ -652,7 +652,8 @@ public class IndexCommands extends AbstractCommandsSupport {
   }
 
   @CliAvailabilityIndicator({CliStrings.LIST_INDEX, CliStrings.CREATE_INDEX,
-      CliStrings.DESTROY_INDEX})
+      CliStrings.DESTROY_INDEX, CliStrings.CREATE_DEFINED_INDEXES, CliStrings.CLEAR_DEFINED_INDEXES,
+      CliStrings.DEFINE_INDEX})
   public boolean indexCommandsAvailable() {
     return (!CliUtil.isGfshVM() || (getGfsh() != null && getGfsh().isConnectedAndReady()));
   }

--- a/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
+++ b/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
@@ -305,7 +305,7 @@ clear-defined-indexes.help=\
 NAME\n\
 \ \ \ \ clear defined indexes\n\
 IS AVAILABLE\n\
-\ \ \ \ true\n\
+\ \ \ \ false\n\
 SYNOPSIS\n\
 \ \ \ \ Clears all the defined indexes.\n\
 SYNTAX\n\
@@ -622,7 +622,7 @@ create-defined-indexes.help=\
 NAME\n\
 \ \ \ \ create defined indexes\n\
 IS AVAILABLE\n\
-\ \ \ \ true\n\
+\ \ \ \ false\n\
 SYNOPSIS\n\
 \ \ \ \ Creates all the defined indexes.\n\
 SYNTAX\n\
@@ -1090,7 +1090,7 @@ define-index.help=\
 NAME\n\
 \ \ \ \ define index\n\
 IS AVAILABLE\n\
-\ \ \ \ true\n\
+\ \ \ \ false\n\
 SYNOPSIS\n\
 \ \ \ \ Define an index that can be used when executing queries.\n\
 SYNTAX\n\


### PR DESCRIPTION
Added 'create defined indexes', 'clear defined indexes', and 'define index' gfsh commands for indexes in CliAvailabilityIndicator so that they would not be available on a disconnected gfsh session. 
Fixed testOfflineHelp.

