### PR TITLE
GEODE-2188: ExampleSecurityManager references SampleSecurityManager i…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
+++ b/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
@@ -46,7 +46,7 @@ import java.util.stream.StreamSupport;
  * A Geode member must be configured with the following:
  *
  * <p>
- * {@code security-manager = org.apache.geode.security.examples.SampleSecurityManager}
+ * {@code security-manager = org.apache.geode.security.examples.ExampleSecurityManager}
  *
  * <p>
  * The class can be initialized with from a JSON resource called {@code security.json}. This file
@@ -130,7 +130,7 @@ public class ExampleSecurityManager implements SecurityManager {
 
     if (!initializeFromJsonResource(jsonPropertyValue)) {
       throw new AuthenticationFailedException(
-          "SampleSecurityManager: unable to find json resource \"" + jsonPropertyValue
+          "ExampleSecurityManager: unable to find json resource \"" + jsonPropertyValue
               + "\" as specified by [" + SECURITY_JSON + "].");
     }
   }
@@ -142,11 +142,11 @@ public class ExampleSecurityManager implements SecurityManager {
 
     User userObj = this.userNameToUser.get(user);
     if (userObj == null) {
-      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+      throw new AuthenticationFailedException("ExampleSecurityManager: wrong username/password");
     }
 
     if (user != null && !userObj.password.equals(password) && !"".equals(user)) {
-      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+      throw new AuthenticationFailedException("ExampleSecurityManager: wrong username/password");
     }
 
     return user;
@@ -165,7 +165,7 @@ public class ExampleSecurityManager implements SecurityManager {
     }
   }
 
-  boolean initializeFromJsonResource(final String jsonResource) {
+  public boolean initializeFromJsonResource(final String jsonResource) {
     try {
       InputStream input = ClassLoader.getSystemResourceAsStream(jsonResource);
       if (input != null) {
@@ -177,7 +177,7 @@ public class ExampleSecurityManager implements SecurityManager {
     return false;
   }
 
-  User getUser(final String user) {
+  public User getUser(final String user) {
     return this.userNameToUser.get(user);
   }
 
@@ -257,15 +257,65 @@ public class ExampleSecurityManager implements SecurityManager {
     return roleMap;
   }
 
-  static class Role {
+  public static class Role {
     List<ResourcePermission> permissions = new ArrayList<>();
+
+    public List<ResourcePermission> getPermissions() {
+      return permissions;
+    }
+
+    public void setPermissions(final List<ResourcePermission> permissions) {
+      this.permissions = permissions;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public String getServerGroup() {
+      return serverGroup;
+    }
+
+    public void setServerGroup(final String serverGroup) {
+      this.serverGroup = serverGroup;
+    }
+
     String name;
     String serverGroup;
   }
 
-  static class User {
+  public static class User {
     String name;
     Set<Role> roles = new HashSet<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public Set<Role> getRoles() {
+      return roles;
+    }
+
+    public void setRoles(final Set<Role> roles) {
+      this.roles = roles;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(final String password) {
+      this.password = password;
+    }
+
     String password;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/ExampleSecurityManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ExampleSecurityManagerTest.java
@@ -18,7 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.geode.security.TestSecurityManager.User;
+import org.apache.geode.examples.security.ExampleSecurityManager;
+import org.apache.geode.examples.security.ExampleSecurityManager.User;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.junit.Before;
@@ -33,9 +34,9 @@ import java.io.InputStream;
 import java.util.Properties;
 
 @Category({IntegrationTest.class, SecurityTest.class})
-public class SampleSecurityManagerTest {
+public class ExampleSecurityManagerTest {
 
-  private TestSecurityManager sampleSecurityManager;
+  private ExampleSecurityManager exampleSecurityManager;
   private String jsonResource;
   private File jsonFile;
   private String json;
@@ -57,24 +58,24 @@ public class SampleSecurityManagerTest {
 
     // string
     this.json = FileUtils.readFileToString(this.jsonFile, "UTF-8");
-    this.sampleSecurityManager = new TestSecurityManager();
+    this.exampleSecurityManager = new ExampleSecurityManager();
   }
 
   @Test
   public void shouldDefaultToSecurityJsonInClasspathIfNullProperties() throws Exception {
-    this.sampleSecurityManager.init(null);
+    this.exampleSecurityManager.init(null);
     verifySecurityManagerState();
   }
 
   @Test
   public void shouldDefaultToSecurityJsonInClasspathIfEmptyProperties() throws Exception {
-    this.sampleSecurityManager.init(new Properties());
+    this.exampleSecurityManager.init(new Properties());
     verifySecurityManagerState();
   }
 
   @Test
   public void shouldInitializeFromJsonResource() throws Exception {
-    this.sampleSecurityManager.initializeFromJsonResource(this.jsonResource);
+    this.exampleSecurityManager.initializeFromJsonResource(this.jsonResource);
     verifySecurityManagerState();
   }
 
@@ -82,22 +83,22 @@ public class SampleSecurityManagerTest {
   public void initShouldUsePropertyAsJsonResource() throws Exception {
     Properties securityProperties = new Properties();
     securityProperties.setProperty(TestSecurityManager.SECURITY_JSON, this.jsonResource);
-    this.sampleSecurityManager.init(securityProperties);
+    this.exampleSecurityManager.init(securityProperties);
     verifySecurityManagerState();
   }
 
   private void verifySecurityManagerState() {
-    User adminUser = this.sampleSecurityManager.getUser("admin");
+    User adminUser = this.exampleSecurityManager.getUser("admin");
     assertThat(adminUser).isNotNull();
-    assertThat(adminUser.name).isEqualTo("admin");
-    assertThat(adminUser.password).isEqualTo("secret");
-    assertThat(adminUser.roles).hasSize(1);
+    assertThat(adminUser.getName()).isEqualTo("admin");
+    assertThat(adminUser.getPassword()).isEqualTo("secret");
+    assertThat(adminUser.getRoles()).hasSize(1);
 
-    User guestUser = this.sampleSecurityManager.getUser("guest");
+    User guestUser = this.exampleSecurityManager.getUser("guest");
     assertThat(guestUser).isNotNull();
-    assertThat(guestUser.name).isEqualTo("guest");
-    assertThat(guestUser.password).isEqualTo("guest");
-    assertThat(guestUser.roles).hasSize(1);
+    assertThat(guestUser.getName()).isEqualTo("guest");
+    assertThat(guestUser.getPassword()).isEqualTo("guest");
+    assertThat(guestUser.getRoles()).hasSize(1);
     // TODO: need to do more verification
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/security/TestSecurityManager.java
+++ b/geode-core/src/test/java/org/apache/geode/security/TestSecurityManager.java
@@ -42,7 +42,7 @@ import java.util.stream.StreamSupport;
  * A Geode member must be configured with the following:
  *
  * <p>
- * {@code security-manager = org.apache.geode.security.examples.SampleSecurityManager}
+ * {@code security-manager = org.apache.geode.security.examples.TestSecurityManager}
  *
  * <p>
  * The class can be initialized with from a JSON resource called {@code security.json}. This file
@@ -125,9 +125,8 @@ public class TestSecurityManager implements SecurityManager {
     }
 
     if (!initializeFromJsonResource(jsonPropertyValue)) {
-      throw new AuthenticationFailedException(
-          "SampleSecurityManager: unable to find json resource \"" + jsonPropertyValue
-              + "\" as specified by [" + SECURITY_JSON + "].");
+      throw new AuthenticationFailedException("TestSecurityManager: unable to find json resource \""
+          + jsonPropertyValue + "\" as specified by [" + SECURITY_JSON + "].");
     }
   }
 
@@ -138,11 +137,11 @@ public class TestSecurityManager implements SecurityManager {
 
     User userObj = this.userNameToUser.get(user);
     if (userObj == null) {
-      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+      throw new AuthenticationFailedException("TestSecurityManager: wrong username/password");
     }
 
     if (user != null && !userObj.password.equals(password) && !"".equals(user)) {
-      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+      throw new AuthenticationFailedException("TestSecurityManager: wrong username/password");
     }
 
     return user;


### PR DESCRIPTION
…n javadoc

This corrects some output messages and javadoc entries after the ExampleSecurityManager was moved.  It also points the old SampleSecurityManagerTest at ExampleSecurityManager.