### PR TITLE
GEODE-1969 : oplog closed while writing to oplog with gemfire.syncWrites=true

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -5186,11 +5186,11 @@ public final class Oplog implements CompactableOplog, Flushable {
           olf.bytesFlushed += flushed;
           bb.clear();
         }
-      }
-      if (doSync) {
-        if (SYNC_WRITES) {
-          // Synch Meta Data as well as content
-          olf.channel.force(true);
+        if (doSync) {
+          if (SYNC_WRITES) {
+            // Synch Meta Data as well as content
+            olf.channel.force(true);
+          }
         }
       }
     } catch (ClosedChannelException ignore) {


### PR DESCRIPTION
Moved the channel force call inside the sync block.

