### PR TITLE
Feature/geode 2103 : Adding --http-service-port and --http-service-bind-address option in start locator command

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommandsJUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommandsJUnitTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.geode.distributed.LocatorLauncher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -554,6 +555,48 @@ public class LauncherLifecycleCommandsJUnitTest {
         .add("-d" + DistributionConfig.GEMFIRE_PREFIX + "" + START_DEV_REST_API + "=" + "true");
     expectedCommandLineElements
         .add("-d" + DistributionConfig.GEMFIRE_PREFIX + "" + HTTP_SERVICE_PORT + "=" + "8080");
+    expectedCommandLineElements.add("-d" + DistributionConfig.GEMFIRE_PREFIX + ""
+        + HTTP_SERVICE_BIND_ADDRESS + "=" + "localhost");
+
+
+    for (String commandLineElement : commandLineElements) {
+      expectedCommandLineElements.remove(commandLineElement.toLowerCase());
+    }
+
+    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
+        expectedCommandLineElements.isEmpty());
+  }
+
+  /**
+   * Verify commandline parameters passed for starting locator
+   * 
+   * @throws Exception
+   */
+  @Test
+  public void testLocatorCommandLineWithRestAPI() throws Exception {
+    LocatorLauncher locatorLauncher =
+        new LocatorLauncher.Builder().setCommand(LocatorLauncher.Command.START)
+            .setMemberName("testLocatorCommandLineWithRestAPI").setBindAddress("localhost")
+            .setPort(11111).build();
+
+    Properties gemfireProperties = new Properties();
+    gemfireProperties.setProperty(HTTP_SERVICE_PORT, "8089");
+    gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
+
+
+    String[] commandLineElements = launcherCommands.createStartLocatorCommandLine(locatorLauncher,
+        null, null, gemfireProperties, null, false, new String[0], null, null);
+
+    assertNotNull(commandLineElements);
+    assertTrue(commandLineElements.length > 0);
+
+    Set<String> expectedCommandLineElements = new HashSet<>(6);
+
+    expectedCommandLineElements.add(locatorLauncher.getCommand().getName());
+    expectedCommandLineElements.add(locatorLauncher.getMemberName().toLowerCase());
+    expectedCommandLineElements.add(String.format("--port=%1$d", locatorLauncher.getPort()));
+    expectedCommandLineElements
+        .add("-d" + DistributionConfig.GEMFIRE_PREFIX + "" + HTTP_SERVICE_PORT + "=" + "8089");
     expectedCommandLineElements.add("-d" + DistributionConfig.GEMFIRE_PREFIX + ""
         + HTTP_SERVICE_BIND_ADDRESS + "=" + "localhost");
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommands.java
@@ -269,7 +269,13 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
           unspecifiedDefaultValue = "false",
           help = CliStrings.START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM__HELP) final boolean loadSharedConfigurationFromDirectory,
       @CliOption(key = CliStrings.START_LOCATOR__CLUSTER__CONFIG__DIR, unspecifiedDefaultValue = "",
-          help = CliStrings.START_LOCATOR__CLUSTER__CONFIG__DIR__HELP) final String clusterConfigDir) {
+          help = CliStrings.START_LOCATOR__CLUSTER__CONFIG__DIR__HELP) final String clusterConfigDir,
+      @CliOption(key = CliStrings.START_LOCATOR__HTTP_SERVICE_PORT,
+          unspecifiedDefaultValue = CliMetaData.ANNOTATION_NULL_VALUE,
+          help = CliStrings.START_LOCATOR__HTTP_SERVICE_PORT__HELP) final Integer httpServicePort,
+      @CliOption(key = CliStrings.START_LOCATOR__HTTP_SERVICE_BIND_ADDRESS,
+          unspecifiedDefaultValue = CliMetaData.ANNOTATION_NULL_VALUE,
+          help = CliStrings.START_LOCATOR__HTTP_SERVICE_BIND_ADDRESS__HELP) final String httpServiceBindAddress) {
     try {
       if (workingDirectory == null) {
         // attempt to use or make sub-directory using memberName...
@@ -324,6 +330,11 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
           StringUtils.valueOf(loadSharedConfigurationFromDirectory, StringUtils.EMPTY_STRING));
       gemfireProperties.setProperty(CLUSTER_CONFIGURATION_DIR,
           StringUtils.valueOf(clusterConfigDir, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(HTTP_SERVICE_PORT,
+          StringUtils.valueOf(httpServicePort, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS,
+          StringUtils.valueOf(httpServiceBindAddress, StringUtils.EMPTY_STRING));
+
 
       // read the OSProcess enable redirect system property here -- TODO: replace with new GFSH
       // argument

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2396,6 +2396,12 @@ public class CliStrings {
   public static final String START_LOCATOR__CLUSTER__CONFIG__DIR = "cluster-config-dir";
   public static final String START_LOCATOR__CLUSTER__CONFIG__DIR__HELP =
       "Directory used by the cluster configuration service to store the cluster configuration on the filesystem";
+  public static final String START_LOCATOR__HTTP_SERVICE_PORT = "http-service-port";
+  public static final String START_LOCATOR__HTTP_SERVICE_PORT__HELP =
+      "Port on which HTTP Service will listen on";
+  public static final String START_LOCATOR__HTTP_SERVICE_BIND_ADDRESS = "http-service-bind-address";
+  public static final String START_LOCATOR__HTTP_SERVICE_BIND_ADDRESS__HELP =
+      "The IP address on which the HTTP Service will be bound.  By default, the Server is bound to all local addresses.";
 
   /* 'start manager' command */
   public static final String START_MANAGER = "start manager";

--- a/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
+++ b/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
@@ -2419,7 +2419,7 @@ SYNTAX\n\
 \ \ \ \ [--port=value] [--dir=value] [--properties-file=value] [--security-properties-file=value]\n\
 \ \ \ \ [--initial-heap=value] [--max-heap=value] [--J=value(,value)*] [--connect(=value)?]\n\
 \ \ \ \ [--enable-cluster-configuration(=value)?] [--load-cluster-configuration-from-dir=value]\n\
-\ \ \ \ [--cluster-config-dir=value]\n\
+\ \ \ \ [--cluster-config-dir=value] [--http-service-port=value] [--http-service-bind-address=value]\n\
 PARAMETERS\n\
 \ \ \ \ name\n\
 \ \ \ \ \ \ \ \ The member name to give this Locator in the Geode cluster.\n\
@@ -2511,6 +2511,13 @@ PARAMETERS\n\
 \ \ \ \ cluster-config-dir\n\
 \ \ \ \ \ \ \ \ Directory used by the cluster configuration service to store the cluster configuration on\n\
 \ \ \ \ \ \ \ \ the filesystem\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ http-service-port\n\
+\ \ \ \ \ \ \ \ Port on which HTTP Service will listen on\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ http-service-bind-address\n\
+\ \ \ \ \ \ \ \ The IP address on which the HTTP Service will be bound.  By default, the Server is bound to\n\
+\ \ \ \ \ \ \ \ all local addresses.\n\
 \ \ \ \ \ \ \ \ Required: false\n\
 
 start-pulse.help=\


### PR DESCRIPTION
Added --http-service-port and --http-service-bind-address options in start locator command. 