### PR TITLE
[GEODE-2227] AutoSerializableJUnitTest.testMultipleClassLoaders fails on Windows

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/pdx/AutoSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/AutoSerializableJUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.pdx;
 
-import org.apache.commons.lang.SystemUtils;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SerializationException;
 import org.apache.geode.cache.CacheFactory;
@@ -1289,8 +1288,7 @@ public class AutoSerializableJUnitTest {
     List<URL> urls = new ArrayList<URL>();
     String classPathStr = System.getProperty("java.class.path");
     if (classPathStr != null) {
-      String[] cpList =
-          SystemUtils.IS_OS_WINDOWS ? classPathStr.split(";") : classPathStr.split(":");
+      String[] cpList = classPathStr.split(System.getProperty("path.separator"));
       for (String u : cpList) {
         urls.add(new File(u).toURI().toURL());
       }

--- a/geode-core/src/test/java/org/apache/geode/pdx/AutoSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/AutoSerializableJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.pdx;
 
+import org.apache.commons.lang.SystemUtils;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SerializationException;
 import org.apache.geode.cache.CacheFactory;
@@ -45,9 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.*;
 
-/**
- * TODO: fails (on Windows 7?)
- */
 @Category({IntegrationTest.class, SerializationTest.class})
 public class AutoSerializableJUnitTest {
 
@@ -1291,7 +1289,8 @@ public class AutoSerializableJUnitTest {
     List<URL> urls = new ArrayList<URL>();
     String classPathStr = System.getProperty("java.class.path");
     if (classPathStr != null) {
-      String[] cpList = classPathStr.split(":");
+      String[] cpList =
+          SystemUtils.IS_OS_WINDOWS ? classPathStr.split(";") : classPathStr.split(":");
       for (String u : cpList) {
         urls.add(new File(u).toURI().toURL());
       }


### PR DESCRIPTION
Parsing the path of classes is not correctly on Windows. The path of library classes on Windows is split by semicolon instead of colon. 