### PR TITLE
GEODE-2326: Adjust testLogger hardcoded value

### DIFF
--- a/src/cppcache/integration-test/testLogger.cpp
+++ b/src/cppcache/integration-test/testLogger.cpp
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #endif
 
-#define LENGTH_OF_BANNER 9
+#define LENGTH_OF_BANNER 16
 
 using namespace gemfire;
 


### PR DESCRIPTION
Fixes the failing logger integration test.  This was caused when we changed the log header to the Apache License.