### PR TITLE
[GEODE-2172] CustomConfigWithCacheIntegrationTest fails with AssertionError on Windows

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/custom/CustomConfiguration.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/custom/CustomConfiguration.java
@@ -57,12 +57,4 @@ public class CustomConfiguration {
         + message + System.lineSeparator() + "throwable=" + System.lineSeparator();
   }
 
-  public static String defineLogStatementRegex(final Level level, final String message,
-      final String throwable) {
-    // CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z}
-    // message=%message%nthrowable=%throwable%n
-    return CONFIG_LAYOUT_PREFIX + ": level=" + level.toString() + " time=" + ".*" + " message="
-        + message + System.lineSeparator() + "throwable=" + throwable + System.lineSeparator();
-  }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/custom/CustomConfiguration.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/custom/CustomConfiguration.java
@@ -54,7 +54,7 @@ public class CustomConfiguration {
     // CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z}
     // message=%message%nthrowable=%throwable%n
     return CONFIG_LAYOUT_PREFIX + ": level=" + level.toString() + " time=" + ".*" + " message="
-        + message + "\nthrowable=\n";
+        + message + System.lineSeparator() + "throwable=" + System.lineSeparator();
   }
 
   public static String defineLogStatementRegex(final Level level, final String message,
@@ -62,7 +62,7 @@ public class CustomConfiguration {
     // CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z}
     // message=%message%nthrowable=%throwable%n
     return CONFIG_LAYOUT_PREFIX + ": level=" + level.toString() + " time=" + ".*" + " message="
-        + message + "\nthrowable=" + throwable + "\n";
+        + message + System.lineSeparator() + "throwable=" + throwable + System.lineSeparator();
   }
 
 }


### PR DESCRIPTION
> The issues is related to incorrect regex pattern. The regex pattern used to match log string contains newline character. To fix this issue, I've replaced Unix newline character in regex pattern into System.lineSeparator(), a Platform-dependent newline character in Java.
> 
> I've run this unit test both on Windows and MacOS. And it passes.

Review Board: [https://reviews.apache.org/r/54586/](https://reviews.apache.org/r/54586/)

Since this has been marked as `Ship it`, this PR here will be easy for merging.