### PR TITLE
GEODE-2300 Document default names for start locator/server

### DIFF
--- a/geode-docs/getting_started/15_minute_quickstart_gfsh.html.md.erb
+++ b/geode-docs/getting_started/15_minute_quickstart_gfsh.html.md.erb
@@ -69,6 +69,8 @@ The *locator* is a Geode process that tells new, connecting members where runnin
     Cluster configuration service is up and running.
     ```
 
+If you run `start locator` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.
+
 ## <a id="topic_FE3F28ED18E145F787431EC87B676A76__section_02C79BFFB5334E78A5856AE1EB1F1F84" class="no-quick-link"></a>Step 3: Start Pulse
 
 Start up the browser-based Pulse monitoring tool. Pulse is a Web Application that provides a graphical dashboard for monitoring vital, real-time health and performance of Geode clusters, members, and regions. See [Geode Pulse](../tools_modules/pulse/chapter_overview.html).
@@ -95,6 +97,8 @@ gfsh>start server --name=server1 --server-port=40411
 ```
 
 This commands starts a cache server named "server1" on the specified port of 40411.
+
+If you run `start server` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.
 
 Observe the changes (new member and server) in Pulse. Try expanding the distributed system icon to see the locator and cache server graphically.
 

--- a/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
@@ -164,7 +164,7 @@ JConsole automatically connects to a running JMX Manager node if one is availabl
 
 Note that you must have a JDK installed (not just a JRE) and the correct PATH and JAVA\_HOME environment variables set.
 
-See [Browsing Geode MBeans through JConsole](../../../managing/management/mbeans_jconsole.html) for an example of using JConsole with the GeodeGeode management and monitoring system.
+See [Browsing Geode MBeans through JConsole](../../../managing/management/mbeans_jconsole.html) for an example of using JConsole with the Geode management and monitoring system.
 
 **Availability:** Online or offline.
 
@@ -297,7 +297,7 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
 <tbody>
 <tr class="odd">
 <td><span class="keyword parmname">\-\-name</span></td>
-<td><em>Required.</em> Name to be used for this GeodeGeode locator service.</td>
+<td>Name to be used for this Geode locator service. If not specified, gfsh generates a random name.</td>
 <td> </td>
 </tr>
 <tr class="even">
@@ -322,7 +322,7 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-locators</span></td>
-<td>List of locators used by this locator to join the appropriate GeodeGeode cluster.</td>
+<td>List of locators used by this locator to join the appropriate Geode cluster.</td>
 <td> </td>
 </tr>
 <tr class="odd">
@@ -332,7 +332,7 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-mcast-address </span></td>
-<td>IP address or hostname used to bind the UPD socket for multi-cast networking so the locator can locate other members in the GeodeGeode cluster. If mcast-port is zero, then mcast-address is ignored.</td>
+<td>IP address or hostname used to bind the UPD socket for multi-cast networking so the locator can locate other members in the Geode cluster. If mcast-port is zero, then mcast-address is ignored.</td>
 <td> </td>
 </tr>
 <tr class="odd">
@@ -364,7 +364,7 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
 <td><span class="keyword parmname">\-\-initial-heap</span></td>
 <td>Size has the same format as the <code class="ph codeph">-Xmx</code>/<code class="ph codeph">-Xms</code> JVM options.
 <div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then GeodeGeode does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
+<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then Geode does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
 </div></td>
 <td> </td>
 </tr>
@@ -372,7 +372,7 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
 <td><span class="keyword parmname">\-\-max-heap</span></td>
 <td>Size has the same format as the <code class="ph codeph">-Xmx</code>/<code class="ph codeph">-Xms</code> JVM options
 <div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then GeodeGeode does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
+<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then Geode does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
 </div></td>
 <td> </td>
 </tr>
@@ -523,7 +523,7 @@ start server --name=value [--assign-buckets(=value)] [--bind-address=value]
 <tbody>
 <tr class="odd">
 <td><span class="keyword parmname">\-\-name</span></td>
-<td><em>Required.</em> Member name for this Geode Cache Server service.</td>
+<td>Member name for this Geode Cache Server service. If not specified, gfsh generates a random name.</td>
 <td> </td>
 </tr>
 <tr class="even">

--- a/geode-docs/tools_modules/gfsh/command_scripting.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command_scripting.html.md.erb
@@ -34,4 +34,4 @@ When you run a gfsh script, interactive parameters are ignored. You can also set
 
 Your command history file can be helpful when you write a gfsh script. A history of commands that have been executed successfully is logged in the `.gfsh.history` file in the home directory of the user running gfsh. You can also export a history file with the `history                     --file=your_file_name` command.
 
-
+When a user runs `start server` or `start locator` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.

--- a/geode-docs/tools_modules/gfsh/getting_started_gfsh.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/getting_started_gfsh.html.md.erb
@@ -117,7 +117,8 @@ start data-browser   start jconsole       start jvisualvm
 start locator        start pulse          start server
 ```
 
-Hitting tab after `start locator` will populate the required `--name` parameter after the command.
+Hitting tab after `start locator` will populate the `--name` parameter after the command.
+(If you do not specify a member name, gfsh will automatically pick a random name. This is useful for automation.)
 
 **Access command history with the Up arrow.**
 

--- a/geode-docs/tools_modules/gfsh/tour_of_gfsh.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/tour_of_gfsh.html.md.erb
@@ -71,7 +71,12 @@ Successfully connected to: [host=ubuntu.local, port=1099]
 Cluster configuration service is up and running.
 ```
 
-In your file system, examine the folder location where you executed `gfsh`. Notice that the `start locator` command has automatically created a working directory (using the name of the locator), and within that working directory, it has created a log file, a status file, and a .pid (containing the locator's process ID) for this locator.
+If you run `start locator` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.
+
+In your file system, examine the folder location where you executed `gfsh`. Notice that the `start
+locator` command has automatically created a working directory (using the name of the locator), and
+within that working directory, it has created a log file, a status file, and a .pid (containing the
+locator's process ID) for this locator.
 
 In addition, because no other JMX Manager exists yet, notice that `gfsh` has automatically started an embedded JMX Manager on port 1099 within the locator and has connected you to that JMX Manager.
 
@@ -178,7 +183,13 @@ JVM Arguments: -Dgemfire.locators=localhost[10334] -Dgemfire.use-cluster-configu
 Class-Path: /home/username/Pivotal_GemFire_810_b50582_Linux/lib/gemfire.jar:/home/username/Pivotal_GemFire_810_b50582_Linux/lib/server-dependencies.jar
 ```
 
-In your file system, examine the folder location where you executed `gfsh`. Notice that just like the `start locator` command, the `start server` command has automatically created a working directory (named after the server), and within that working directory, it has created a log file and a .pid (containing the server's process ID) for this cache server. In addition, it has also written log files.
+If you run `start server` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.
+
+In your file system, examine the folder location where you executed `gfsh`. Notice that just like
+the `start locator` command, the `start server` command has automatically created a working
+directory (named after the server), and within that working directory, it has created a log file and
+a .pid (containing the server's process ID) for this cache server. In addition, it has also written
+log files.
 
 **Step 7: List members.** Use the `list members` command to view the current members of the Apache Geode distributed system you have just created.
 

--- a/geode-docs/topologies_and_comm/cs_configuration/client_server_example_configurations.html.md.erb
+++ b/geode-docs/topologies_and_comm/cs_configuration/client_server_example_configurations.html.md.erb
@@ -42,7 +42,7 @@ Or directly from a command line:
 prompt# gfsh start locator --name=locator_name --port=41111 
 ```
 
-Specify a name for the locator that you wish to start on the localhost.
+Specify a name for the locator that you wish to start on the localhost. If you do not specify the member name, gfsh will automatically pick a random name. This is useful for automation.
 
 The server’s `cache.xml` declares a `cache-server` element, which identifies the JVM as a server in the distributed system.
 


### PR DESCRIPTION
Documented new default naming convention for gfsh start locator and start server commands. Did not attempt to insert at every occurrence of the commands. Focused on introductory sections, and deleted the 'required' designation for the '--name' parameter in reference tables.