### PR TITLE
GEODE-2344: Updated the ordinal to match 9.0.

### DIFF
--- a/src/cppcache/src/CacheImpl.cpp
+++ b/src/cppcache/src/CacheImpl.cpp
@@ -836,14 +836,6 @@ void CacheImpl::processMarker() {
   }
 }
 
-// Version ordinal accessor for unit tests
-void CacheImpl::setVersionOrdinalForTest(int8_t newVer) {
-  Version::m_ordinal = newVer;
-}
-
-// Version ordinal accessor for unit tests
-int8_t CacheImpl::getVersionOrdinalForTest() { return Version::m_ordinal; }
-
 int CacheImpl::getPoolSize(const char* poolName) {
   PoolPtr pool = PoolManager::find(poolName);
   if (pool == NULLPTR) {

--- a/src/cppcache/src/CacheImpl.hpp
+++ b/src/cppcache/src/CacheImpl.hpp
@@ -247,10 +247,6 @@ class CPPCACHE_EXPORT CacheImpl : private NonCopyable, private NonAssignable {
 
   void processMarker();
 
-  // Version ordinal accessors for unit tests
-  static void setVersionOrdinalForTest(int8_t newVer);
-  static int8_t getVersionOrdinalForTest();
-
   // Pool helpers for unit tests
   static int getPoolSize(const char* poolName);
 

--- a/src/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/src/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -82,7 +82,7 @@ void CacheTransactionManagerImpl::commit() {
   if (err != GF_NOERR) {
     // err = rollback(txState, false);
     //		noteCommitFailure(txState, NULLPTR);
-    GfErrTypeThrowException("Error while commiting", err);
+    GfErrTypeThrowException("Error while committing", err);
   } else {
     switch (reply.getMessageType()) {
       case TcrMessage::RESPONSE: {
@@ -262,7 +262,7 @@ void CacheTransactionManagerImpl::rollback() {
   try {
     GfErrType err = rollback(txState, true);
     if (err != GF_NOERR) {
-      GfErrTypeToException("Error while commiting", err);
+      GfErrTypeToException("Error while committing", err);
     }
   } catch (const Exception& ex) {
     // TODO: put a log message

--- a/src/cppcache/src/ClientProxyMembershipID.cpp
+++ b/src/cppcache/src/ClientProxyMembershipID.cpp
@@ -387,6 +387,7 @@ Serializable* ClientProxyMembershipID::fromData(DataInput& input) {
   input.readInt(&durableClntTimeOut);  // durable client timeout
   int32_t vmViewId = 0;
   readVersion(splitbrain, input);
+
   if (vmKind != ClientProxyMembershipID::LONER_DM_TYPE) {
     vmViewId = atoi(uniqueTag.ptr()->asChar());
     initObjectVars(hostname->asChar(), hostAddr, len, true, hostPort,
@@ -399,6 +400,8 @@ Serializable* ClientProxyMembershipID::fromData(DataInput& input) {
                    vmKind, splitbrain, dsName->asChar(), uniqueTag->asChar(),
                    0);
   }
+
+  readAdditionalData(input);
 
   return this;
 }
@@ -449,7 +452,14 @@ Serializable* ClientProxyMembershipID::readEssentialData(DataInput& input) {
                    0, dsName->asChar(), uniqueTag->asChar(), vmViewId);
   }
 
+  readAdditionalData(input);
+
   return this;
+}
+
+void ClientProxyMembershipID::readAdditionalData(DataInput& input) {
+  // Skip unused UUID (16) and weight (0);
+  input.advanceCursor(17);
 }
 
 void ClientProxyMembershipID::increaseSynchCounter() { ++synch_counter; }

--- a/src/cppcache/src/ClientProxyMembershipID.hpp
+++ b/src/cppcache/src/ClientProxyMembershipID.hpp
@@ -138,6 +138,8 @@ class ClientProxyMembershipID : public DSMemberForVersionStamp {
 
   void readVersion(int flags, DataInput& input);
   void writeVersion(int16_t ordinal, DataOutput& output);
+
+  void readAdditionalData(DataInput& input);
 };
 }  // namespace client
 }  // namespace geode

--- a/src/cppcache/src/TcrConnection.cpp
+++ b/src/cppcache/src/TcrConnection.cpp
@@ -153,7 +153,7 @@ bool TcrConnection::InitTcrConnection(
     ACE_TCHAR hostName[256];
     ACE_OS::hostname(hostName, sizeof(hostName) - 1);
 
-    ACE_INET_Addr driver("", hostName, "tcp");
+    ACE_INET_Addr driver(hostName);
     uint32_t hostAddr = driver.get_ip_address();
     uint16_t hostPort = 0;
 
@@ -1277,36 +1277,6 @@ CacheableBytesPtr TcrConnection::readHandshakeRawData(int32_t msgLength,
 // read a byte array
 CacheableBytesPtr TcrConnection::readHandshakeByteArray(
     uint32_t connectTimeout) {
-  /*CacheableBytesPtr codeBytes = readHandshakeData(1, connectTimeout);
-  DataInput codeDI(codeBytes->value(), codeBytes->length());
-  uint8_t code = 0;
-  codeDI.read(&code);
-  uint32_t arraySize = 0;
-  if (code == 0xFF) {
-  return NULLPTR;
-  } else {
-  int32_t tempLen = code;
-  if (tempLen > 252) {  // 252 is java's ((byte)-4 && 0xFF)
-  if (code == 0xFE) {
-  CacheableBytesPtr lenBytes = readHandshakeData(2, connectTimeout);
-  DataInput lenDI(lenBytes->value(), lenBytes->length());
-  uint16_t val;
-  lenDI.readInt(&val);
-  tempLen = val;
-  } else if (code == 0xFD) {
-  CacheableBytesPtr lenBytes = readHandshakeData(4, connectTimeout);
-  DataInput lenDI(lenBytes->value(), lenBytes->length());
-  uint32_t val;
-  lenDI.readInt(&val);
-  tempLen = val;
-  } else {
-  GF_SAFE_DELETE(m_conn);
-  throwException(IllegalStateException("unexpected array length code"));
-  }
-  }
-  arraySize = tempLen;
-  }*/
-
   uint32_t arraySize = readHandshakeArraySize(connectTimeout);
   return readHandshakeRawData(arraySize, connectTimeout);
 }

--- a/src/cppcache/src/ThinClientPoolDM.cpp
+++ b/src/cppcache/src/ThinClientPoolDM.cpp
@@ -175,7 +175,7 @@ ThinClientPoolDM::ThinClientPoolDM(const char* name,
 
   ACE_TCHAR hostName[256];
   ACE_OS::hostname(hostName, sizeof(hostName) - 1);
-  ACE_INET_Addr driver("", hostName, "tcp");
+  ACE_INET_Addr driver(hostName);
   uint32_t hostAddr = driver.get_ip_address();
   uint16_t hostPort = 0;
   const char* durableId = (sysProp != NULL) ? sysProp->durableClientId() : NULL;

--- a/src/cppcache/src/Version.cpp
+++ b/src/cppcache/src/Version.cpp
@@ -17,24 +17,12 @@
 #include "Version.hpp"
 #include "CacheImpl.hpp"
 
-#define VERSION_ORDINAL_56 0
-#define VERSION_ORDINAL_57 1
-#define VERSION_ORDINAL_TEST 2   // for GFE dunit testing
-#define VERSION_ORDINAL_58 3     // since NC 3000
-#define VERSION_ORDINAL_603 4    // since NC 3003
-#define VERSION_ORDINAL_61 5     // since NC ThinClientDelta branch
-#define VERSION_ORDINAL_65 6     // since NC 3500
-#define VERSION_ORDINAL_651 7    // since NC 3510
-#define VERSION_ORDINAL_66 16    // since NC 3600
-#define VERSION_ORDINAL_662 17   // since NC 3620
-#define VERSION_ORDINAL_6622 18  // since NC 3622
-#define VERSION_ORDINAL_7000 19  // since NC 7000
-#define VERSION_ORDINAL_7001 20  // since NC 7001
-#define VERSION_ORDINAL_80 30    // since NC 8000
-#define VERSION_ORDINAL_81 35    // since NC 8100
+namespace apache {
+namespace geode {
+namespace client {
 
-#define VERSION_ORDINAL_NOT_SUPPORTED 59  // for GFE dunit testing
+int8_t Version::m_ordinal = 45;
 
-using namespace apache::geode::client;
-
-int8_t Version::m_ordinal = VERSION_ORDINAL_81;
+}
+}
+}

--- a/src/cppcache/src/Version.hpp
+++ b/src/cppcache/src/Version.hpp
@@ -27,10 +27,6 @@ class Version {
   // getter for ordinal
   static int8_t getOrdinal() { return Version::m_ordinal; }
 
-  friend void apache::geode::client::CacheImpl::setVersionOrdinalForTest(
-      int8_t newOrdinal);
-  friend int8_t apache::geode::client::CacheImpl::getVersionOrdinalForTest();
-
  private:
   static int8_t m_ordinal;
 


### PR DESCRIPTION
- Switch to the correct constructor to avoid errors.
- Remove unnecessary mechanism to modify version ordinal.
- Remove commented-out code.
- Account for extra bytes in the handshaking after 8.2.
- Refactor accommodating UUID and weight during handshake.