### PR TITLE
GEODE-2411: Remove references to Gemfire from include guards

### DIFF
--- a/src/cppcache/include/gfcpp/Assert.hpp
+++ b/src/cppcache/include/gfcpp/Assert.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_ASSERT_H_
+#define GEODE_GFCPP_ASSERT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_ASSERT_HPP_
-#define _GEMFIRE_ASSERT_HPP_
 
 #include "gfcpp_globals.hpp"
 
@@ -95,4 +97,4 @@ class CPPCACHE_EXPORT Assert {
 #define GF_DEV_ASSERT(x)
 #endif
 
-#endif
+#endif // GEODE_GFCPP_ASSERT_H_

--- a/src/cppcache/include/gfcpp/AttributesFactory.hpp
+++ b/src/cppcache/include/gfcpp/AttributesFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_ATTRIBUTESFACTORY_H__
-#define __GEMFIRE_ATTRIBUTESFACTORY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_ATTRIBUTESFACTORY_H_
+#define GEODE_GFCPP_ATTRIBUTESFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -375,4 +378,5 @@ class CPPCACHE_EXPORT AttributesFactory : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_ATTRIBUTESFACTORY_H__
+
+#endif // GEODE_GFCPP_ATTRIBUTESFACTORY_H_

--- a/src/cppcache/include/gfcpp/AttributesMutator.hpp
+++ b/src/cppcache/include/gfcpp/AttributesMutator.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_ATTRIBUTESMUTATOR_H__
-#define __GEMFIRE_ATTRIBUTESMUTATOR_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_ATTRIBUTESMUTATOR_H_
+#define GEODE_GFCPP_ATTRIBUTESMUTATOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -186,4 +189,5 @@ class CPPCACHE_EXPORT AttributesMutator : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_ATTRIBUTESMUTATOR_H__
+
+#endif // GEODE_GFCPP_ATTRIBUTESMUTATOR_H_

--- a/src/cppcache/include/gfcpp/AuthInitialize.hpp
+++ b/src/cppcache/include/gfcpp/AuthInitialize.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_AUTHINITIALIZE_H__
-#define __GEMFIRE_AUTHINITIALIZE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_AUTHINITIALIZE_H_
+#define GEODE_GFCPP_AUTHINITIALIZE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -62,4 +65,4 @@ class CPPCACHE_EXPORT AuthInitialize
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_AUTHINITIALIZE_H__
+#endif // GEODE_GFCPP_AUTHINITIALIZE_H_

--- a/src/cppcache/include/gfcpp/Cache.hpp
+++ b/src/cppcache/include/gfcpp/Cache.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHE_H__
-#define __GEMFIRE_CACHE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHE_H_
+#define GEODE_GFCPP_CACHE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -246,4 +249,5 @@ class CPPCACHE_EXPORT Cache : public GemFireCache {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHE_H__
+
+#endif // GEODE_GFCPP_CACHE_H_

--- a/src/cppcache/include/gfcpp/CacheAttributes.hpp
+++ b/src/cppcache/include/gfcpp/CacheAttributes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEATTRIBUTES_H__
-#define __GEMFIRE_CACHEATTRIBUTES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEATTRIBUTES_H_
+#define GEODE_GFCPP_CACHEATTRIBUTES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -102,4 +105,4 @@ class CPPCACHE_EXPORT CacheAttributes : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CACHEATTRIBUTES_H__
+#endif // GEODE_GFCPP_CACHEATTRIBUTES_H_

--- a/src/cppcache/include/gfcpp/CacheFactory.hpp
+++ b/src/cppcache/include/gfcpp/CacheFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEFACTORY_H__
-#define __GEMFIRE_CACHEFACTORY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEFACTORY_H_
+#define GEODE_GFCPP_CACHEFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -499,4 +502,4 @@ class CPPCACHE_EXPORT CacheFactory : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CACHEFACTORY_H__
+#endif // GEODE_GFCPP_CACHEFACTORY_H_

--- a/src/cppcache/include/gfcpp/CacheListener.hpp
+++ b/src/cppcache/include/gfcpp/CacheListener.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHELISTENER_H__
-#define __GEMFIRE_CACHELISTENER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHELISTENER_H_
+#define GEODE_GFCPP_CACHELISTENER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -206,4 +209,5 @@ class CPPCACHE_EXPORT CacheListener : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHELISTENER_H__
+
+#endif // GEODE_GFCPP_CACHELISTENER_H_

--- a/src/cppcache/include/gfcpp/CacheLoader.hpp
+++ b/src/cppcache/include/gfcpp/CacheLoader.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHELOADER_H__
-#define __GEMFIRE_CACHELOADER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHELOADER_H_
+#define GEODE_GFCPP_CACHELOADER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -98,4 +101,5 @@ class CPPCACHE_EXPORT CacheLoader : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHELOADER_H__
+
+#endif // GEODE_GFCPP_CACHELOADER_H_

--- a/src/cppcache/include/gfcpp/CacheStatistics.hpp
+++ b/src/cppcache/include/gfcpp/CacheStatistics.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHESTATISTICS_H__
-#define __GEMFIRE_CACHESTATISTICS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHESTATISTICS_H_
+#define GEODE_GFCPP_CACHESTATISTICS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -107,4 +110,5 @@ class CPPCACHE_EXPORT CacheStatistics : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHESTATISTICS_H__
+
+#endif // GEODE_GFCPP_CACHESTATISTICS_H_

--- a/src/cppcache/include/gfcpp/CacheTransactionManager.hpp
+++ b/src/cppcache/include/gfcpp/CacheTransactionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHETRANSACTIONMANAGER_H_
+#define GEODE_GFCPP_CACHETRANSACTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef CACHETRANSACTIONMANAGER_H_
-#define CACHETRANSACTIONMANAGER_H_
 
 /* The specification of function behaviors is found in the corresponding .cpp
  * file.
@@ -200,4 +203,5 @@ class CPPCACHE_EXPORT CacheTransactionManager
 }  // namespace geode
 }  // namespace apache
 
-#endif /* CACHETRANSACTIONMANAGER_H_ */
+
+#endif // GEODE_GFCPP_CACHETRANSACTIONMANAGER_H_

--- a/src/cppcache/include/gfcpp/CacheWriter.hpp
+++ b/src/cppcache/include/gfcpp/CacheWriter.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEWRITER_H__
-#define __GEMFIRE_CACHEWRITER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEWRITER_H_
+#define GEODE_GFCPP_CACHEWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -182,4 +185,4 @@ class CPPCACHE_EXPORT CacheWriter : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEWRITER_H_

--- a/src/cppcache/include/gfcpp/Cacheable.hpp
+++ b/src/cppcache/include/gfcpp/Cacheable.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEABLE_H__
-#define __GEMFIRE_CACHEABLE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLE_H_
+#define GEODE_GFCPP_CACHEABLE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -40,4 +43,4 @@ inline CacheablePtr createValue(const TVALUE* value);
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CACHEABLE_H__
+#endif // GEODE_GFCPP_CACHEABLE_H_

--- a/src/cppcache/include/gfcpp/Cacheable.inl
+++ b/src/cppcache/include/gfcpp/Cacheable.inl
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEABLE_I__
-#define __GEMFIRE_CACHEABLE_I__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLE_INL_
+#define GEODE_GFCPP_CACHEABLE_INL_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -49,4 +52,4 @@ inline CacheablePtr createValue( const TVALUE* value )
 }  // namespace geode
 }  // namespace apache
 
-#endif //ifndef __GEMFIRE_CACHEABLE_I__
+#endif // GEODE_GFCPP_CACHEABLE_INL_

--- a/src/cppcache/include/gfcpp/CacheableBuiltins.hpp
+++ b/src/cppcache/include/gfcpp/CacheableBuiltins.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLE_BUILTINS_HPP_
-#define _GEMFIRE_CACHEABLE_BUILTINS_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEBUILTINS_H_
+#define GEODE_GFCPP_CACHEABLEBUILTINS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -681,4 +683,4 @@ _GF_CACHEABLE_CONTAINER_TYPE_(_HashSetOfCacheableKey, CacheableLinkedHashSet);
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_CACHEABLE_BUILTINS_HPP_
+#endif // GEODE_GFCPP_CACHEABLEBUILTINS_H_

--- a/src/cppcache/include/gfcpp/CacheableDate.hpp
+++ b/src/cppcache/include/gfcpp/CacheableDate.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_CACHEABLEDATE_HPP_
-#define _GEMFIRE_CACHEABLEDATE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEDATE_H_
+#define GEODE_GFCPP_CACHEABLEDATE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -147,4 +150,4 @@ inline CacheablePtr createValue(const timeval& value) {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEABLEDATE_H_

--- a/src/cppcache/include/gfcpp/CacheableEnum.hpp
+++ b/src/cppcache/include/gfcpp/CacheableEnum.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEENUM_H_
+#define GEODE_GFCPP_CACHEABLEENUM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CACHEABLE_ENUM_HPP
-#define CACHEABLE_ENUM_HPP
 
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
@@ -140,4 +143,5 @@ class CPPCACHE_EXPORT CacheableEnum : public CacheableKey {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // CACHEABLE_ENUM_HPP
+
+#endif // GEODE_GFCPP_CACHEABLEENUM_H_

--- a/src/cppcache/include/gfcpp/CacheableFileName.hpp
+++ b/src/cppcache/include/gfcpp/CacheableFileName.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLEFILENAME_HPP_
-#define _GEMFIRE_CACHEABLEFILENAME_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEFILENAME_H_
+#define GEODE_GFCPP_CACHEABLEFILENAME_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -116,4 +118,4 @@ class CPPCACHE_EXPORT CacheableFileName : public CacheableString {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEABLEFILENAME_H_

--- a/src/cppcache/include/gfcpp/CacheableKey.hpp
+++ b/src/cppcache/include/gfcpp/CacheableKey.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEABLEKEY_H__
-#define __GEMFIRE_CACHEABLEKEY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEKEY_H_
+#define GEODE_GFCPP_CACHEABLEKEY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -81,4 +84,4 @@ inline CacheableKeyPtr createKey(const TKEY* value);
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEABLEKEY_H_

--- a/src/cppcache/include/gfcpp/CacheableKey.inl
+++ b/src/cppcache/include/gfcpp/CacheableKey.inl
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEABLEKEY_I__
-#define __GEMFIRE_CACHEABLEKEY_I__
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEKEY_INL_
+#define GEODE_GFCPP_CACHEABLEKEY_INL_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -49,4 +52,4 @@ inline CacheableKeyPtr createKey( const TKEY* value )
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEABLEKEY_INL_

--- a/src/cppcache/include/gfcpp/CacheableKeys.hpp
+++ b/src/cppcache/include/gfcpp/CacheableKeys.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLEKEYS_HPP_
-#define _GEMFIRE_CACHEABLEKEYS_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEKEYS_H_
+#define GEODE_GFCPP_CACHEABLEKEYS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -94,4 +96,4 @@ inline uint32_t hashcode(const double value) {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_CACHEABLEKEYS_HPP_
+#endif // GEODE_GFCPP_CACHEABLEKEYS_H_

--- a/src/cppcache/include/gfcpp/CacheableObjectArray.hpp
+++ b/src/cppcache/include/gfcpp/CacheableObjectArray.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLEOBJECTARRAY_HPP_
-#define _GEMFIRE_CACHEABLEOBJECTARRAY_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEOBJECTARRAY_H_
+#define GEODE_GFCPP_CACHEABLEOBJECTARRAY_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -101,4 +103,4 @@ class CPPCACHE_EXPORT CacheableObjectArray : public Cacheable,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_CACHEABLEOBJECTARRAY_HPP_
+#endif // GEODE_GFCPP_CACHEABLEOBJECTARRAY_H_

--- a/src/cppcache/include/gfcpp/CacheableString.hpp
+++ b/src/cppcache/include/gfcpp/CacheableString.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLESTRING_HPP_
-#define _GEMFIRE_CACHEABLESTRING_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLESTRING_H_
+#define GEODE_GFCPP_CACHEABLESTRING_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -305,4 +307,4 @@ inline CacheablePtr createValueArr(const wchar_t* value) {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_CACHEABLESTRING_H_

--- a/src/cppcache/include/gfcpp/CacheableUndefined.hpp
+++ b/src/cppcache/include/gfcpp/CacheableUndefined.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLEUNDEFINED_HPP_
-#define _GEMFIRE_CACHEABLEUNDEFINED_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_CACHEABLEUNDEFINED_H_
+#define GEODE_GFCPP_CACHEABLEUNDEFINED_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -93,4 +95,4 @@ class CPPCACHE_EXPORT CacheableUndefined : public Cacheable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_CACHEABLEUNDEFINED_HPP_
+#endif // GEODE_GFCPP_CACHEABLEUNDEFINED_H_

--- a/src/cppcache/include/gfcpp/CqAttributes.hpp
+++ b/src/cppcache/include/gfcpp/CqAttributes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_ATTRIBUTES_H__
-#define __GEMFIRE_CQ_ATTRIBUTES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQATTRIBUTES_H_
+#define GEODE_GFCPP_CQATTRIBUTES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -58,4 +61,4 @@ class CPPCACHE_EXPORT CqAttributes : virtual public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_ATTRIBUTES_H__
+#endif // GEODE_GFCPP_CQATTRIBUTES_H_

--- a/src/cppcache/include/gfcpp/CqAttributesFactory.hpp
+++ b/src/cppcache/include/gfcpp/CqAttributesFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_ATTRIBUTES_FACTORY_H__
-#define __GEMFIRE_CQ_ATTRIBUTES_FACTORY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQATTRIBUTESFACTORY_H_
+#define GEODE_GFCPP_CQATTRIBUTESFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -100,4 +103,4 @@ class CPPCACHE_EXPORT CqAttributesFactory : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_ATTRIBUTES_FACTORY_H__
+#endif // GEODE_GFCPP_CQATTRIBUTESFACTORY_H_

--- a/src/cppcache/include/gfcpp/CqAttributesMutator.hpp
+++ b/src/cppcache/include/gfcpp/CqAttributesMutator.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_H__
-#define __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQATTRIBUTESMUTATOR_H_
+#define GEODE_GFCPP_CQATTRIBUTESMUTATOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -71,4 +74,4 @@ class CPPCACHE_EXPORT CqAttributesMutator : virtual public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_H__
+#endif // GEODE_GFCPP_CQATTRIBUTESMUTATOR_H_

--- a/src/cppcache/include/gfcpp/CqEvent.hpp
+++ b/src/cppcache/include/gfcpp/CqEvent.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_EVENT_H__
-#define __GEMFIRE_CQ_EVENT_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQEVENT_H_
+#define GEODE_GFCPP_CQEVENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -105,4 +108,4 @@ class CPPCACHE_EXPORT CqEvent {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //#ifndef __GEMFIRE_CQ_EVENT_H__
+#endif // GEODE_GFCPP_CQEVENT_H_

--- a/src/cppcache/include/gfcpp/CqListener.hpp
+++ b/src/cppcache/include/gfcpp/CqListener.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_LISTENER_H__
-#define __GEMFIRE_CQ_LISTENER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQLISTENER_H_
+#define GEODE_GFCPP_CQLISTENER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -93,4 +96,4 @@ class CPPCACHE_EXPORT CqListener : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //#ifndef __GEMFIRE_CQ_LISTENER_H__
+#endif // GEODE_GFCPP_CQLISTENER_H_

--- a/src/cppcache/include/gfcpp/CqOperation.hpp
+++ b/src/cppcache/include/gfcpp/CqOperation.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_OPERATION_H__
-#define __GEMFIRE_CQ_OPERATION_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQOPERATION_H_
+#define GEODE_GFCPP_CQOPERATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -48,4 +51,5 @@ class CPPCACHE_EXPORT CqOperation {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CQ_OPERATION_H__
+
+#endif // GEODE_GFCPP_CQOPERATION_H_

--- a/src/cppcache/include/gfcpp/CqQuery.hpp
+++ b/src/cppcache/include/gfcpp/CqQuery.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_QUERY_H__
-#define __GEMFIRE_CQ_QUERY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQQUERY_H_
+#define GEODE_GFCPP_CQQUERY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -178,4 +181,4 @@ class CPPCACHE_EXPORT CqQuery : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_QUERY_H__
+#endif // GEODE_GFCPP_CQQUERY_H_

--- a/src/cppcache/include/gfcpp/CqResults.hpp
+++ b/src/cppcache/include/gfcpp/CqResults.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQRESULTS_H__
-#define __GEMFIRE_CQRESULTS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQRESULTS_H_
+#define GEODE_GFCPP_CQRESULTS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -42,4 +45,4 @@ class CPPCACHE_EXPORT CqResults : public SelectResults {};
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQRESULTS_H__
+#endif // GEODE_GFCPP_CQRESULTS_H_

--- a/src/cppcache/include/gfcpp/CqServiceStatistics.hpp
+++ b/src/cppcache/include/gfcpp/CqServiceStatistics.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_SERVICE_STATISTICS_H__
-#define __GEMFIRE_CQ_SERVICE_STATISTICS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQSERVICESTATISTICS_H_
+#define GEODE_GFCPP_CQSERVICESTATISTICS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -73,4 +76,4 @@ class CPPCACHE_EXPORT CqServiceStatistics : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_SERVICE_STATISTICS_H__
+#endif // GEODE_GFCPP_CQSERVICESTATISTICS_H_

--- a/src/cppcache/include/gfcpp/CqState.hpp
+++ b/src/cppcache/include/gfcpp/CqState.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_STATE_H__
-#define __GEMFIRE_CQ_STATE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQSTATE_H_
+#define GEODE_GFCPP_CQSTATE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -78,4 +81,4 @@ class CPPCACHE_EXPORT CqState {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_STATE_H__
+#endif // GEODE_GFCPP_CQSTATE_H_

--- a/src/cppcache/include/gfcpp/CqStatistics.hpp
+++ b/src/cppcache/include/gfcpp/CqStatistics.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_STATISTICS_H__
-#define __GEMFIRE_CQ_STATISTICS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQSTATISTICS_H_
+#define GEODE_GFCPP_CQSTATISTICS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -69,4 +72,4 @@ class CPPCACHE_EXPORT CqStatistics : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_STATISTICS_H__
+#endif // GEODE_GFCPP_CQSTATISTICS_H_

--- a/src/cppcache/include/gfcpp/CqStatusListener.hpp
+++ b/src/cppcache/include/gfcpp/CqStatusListener.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_STATUS_LISTENER_HPP__
-#define __GEMFIRE_CQ_STATUS_LISTENER_HPP__
+#pragma once
+
+#ifndef GEODE_GFCPP_CQSTATUSLISTENER_H_
+#define GEODE_GFCPP_CQSTATUSLISTENER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -47,4 +50,4 @@ class CPPCACHE_EXPORT CqStatusListener : public CqListener {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //#ifndef __GEMFIRE_CQ_STATUS_LISTENER_HPP__
+#endif // GEODE_GFCPP_CQSTATUSLISTENER_H_

--- a/src/cppcache/include/gfcpp/DataInput.hpp
+++ b/src/cppcache/include/gfcpp/DataInput.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_DATAINPUT_H__
-#define __GEMFIRE_DATAINPUT_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_DATAINPUT_H_
+#define GEODE_GFCPP_DATAINPUT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1077,4 +1079,4 @@ class CPPCACHE_EXPORT DataInput {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_DATAINPUT_H__
+#endif // GEODE_GFCPP_DATAINPUT_H_

--- a/src/cppcache/include/gfcpp/DataOutput.hpp
+++ b/src/cppcache/include/gfcpp/DataOutput.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_DATAOUTPUT_H__
-#define __GEMFIRE_DATAOUTPUT_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_DATAOUTPUT_H_
+#define GEODE_GFCPP_DATAOUTPUT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -818,4 +820,4 @@ class CPPCACHE_EXPORT DataOutput {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_DATAOUTPUT_H__
+#endif // GEODE_GFCPP_DATAOUTPUT_H_

--- a/src/cppcache/include/gfcpp/Delta.hpp
+++ b/src/cppcache/include/gfcpp/Delta.hpp
@@ -1,5 +1,8 @@
-#ifndef DELTA_HPP_
-#define DELTA_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_DELTA_H_
+#define GEODE_GFCPP_DELTA_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -94,4 +97,5 @@ class Delta {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* DELTA_HPP_ */
+
+#endif // GEODE_GFCPP_DELTA_H_

--- a/src/cppcache/include/gfcpp/DiskPolicyType.hpp
+++ b/src/cppcache/include/gfcpp/DiskPolicyType.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_DISKPOLICYTYPE_H__
-#define __GEMFIRE_DISKPOLICYTYPE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_DISKPOLICYTYPE_H_
+#define GEODE_GFCPP_DISKPOLICYTYPE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -69,4 +72,5 @@ class CPPCACHE_EXPORT DiskPolicyType {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_DISKPOLICYTYPE_H__
+
+#endif // GEODE_GFCPP_DISKPOLICYTYPE_H_

--- a/src/cppcache/include/gfcpp/DistributedSystem.hpp
+++ b/src/cppcache/include/gfcpp/DistributedSystem.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_DISTRIBUTEDSYSTEM_H__
-#define __GEMFIRE_DISTRIBUTEDSYSTEM_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_DISTRIBUTEDSYSTEM_H_
+#define GEODE_GFCPP_DISTRIBUTEDSYSTEM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -123,4 +126,4 @@ class CPPCACHE_EXPORT DistributedSystem : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_DISTRIBUTEDSYSTEM_H__
+#endif // GEODE_GFCPP_DISTRIBUTEDSYSTEM_H_

--- a/src/cppcache/include/gfcpp/EntryEvent.hpp
+++ b/src/cppcache/include/gfcpp/EntryEvent.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_ENTRYEVENT_HPP_
-#define _GEMFIRE_ENTRYEVENT_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_ENTRYEVENT_H_
+#define GEODE_GFCPP_ENTRYEVENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -90,4 +93,4 @@ class CPPCACHE_EXPORT EntryEvent : public apache::geode::client::SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_ENTRYEVENT_H_

--- a/src/cppcache/include/gfcpp/Exception.hpp
+++ b/src/cppcache/include/gfcpp/Exception.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_EXCEPTION_H__
-#define __GEMFIRE_EXCEPTION_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_EXCEPTION_H_
+#define GEODE_GFCPP_EXCEPTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -122,4 +125,4 @@ class CPPCACHE_EXPORT Exception : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_EXCEPTION_H__
+#endif // GEODE_GFCPP_EXCEPTION_H_

--- a/src/cppcache/include/gfcpp/ExceptionTypes.hpp
+++ b/src/cppcache/include/gfcpp/ExceptionTypes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_EXCEPTIONTYPES_H__
-#define __GEMFIRE_EXCEPTIONTYPES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_EXCEPTIONTYPES_H_
+#define GEODE_GFCPP_EXCEPTIONTYPES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -407,4 +410,4 @@ extern void CPPCACHE_EXPORT GfErrTypeThrowException(const char* str,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_EXCEPTIONTYPES_H__
+#endif // GEODE_GFCPP_EXCEPTIONTYPES_H_

--- a/src/cppcache/include/gfcpp/Execution.hpp
+++ b/src/cppcache/include/gfcpp/Execution.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_EXECUTION_H_
+#define GEODE_GFCPP_EXECUTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_EXECUTION_H__
-#define __GEMFIRE_EXECUTION_H__
 
 /*
  * The specification of function behaviors is found in the corresponding .cpp
@@ -110,4 +112,5 @@ class CPPCACHE_EXPORT Execution : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //__GEMFIRE_EXECUTION_H__
+
+#endif // GEODE_GFCPP_EXECUTION_H_

--- a/src/cppcache/include/gfcpp/ExpirationAction.hpp
+++ b/src/cppcache/include/gfcpp/ExpirationAction.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_EXPIRATIONACTION_H__
-#define __GEMFIRE_EXPIRATIONACTION_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_EXPIRATIONACTION_H_
+#define GEODE_GFCPP_EXPIRATIONACTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -110,4 +113,5 @@ class CPPCACHE_EXPORT ExpirationAction {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_EXPIRATIONACTION_H__
+
+#endif // GEODE_GFCPP_EXPIRATIONACTION_H_

--- a/src/cppcache/include/gfcpp/ExpirationAttributes.hpp
+++ b/src/cppcache/include/gfcpp/ExpirationAttributes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_EXPIRATIONATTRIBUTES_H__
-#define __GEMFIRE_EXPIRATIONATTRIBUTES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_EXPIRATIONATTRIBUTES_H_
+#define GEODE_GFCPP_EXPIRATIONATTRIBUTES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -96,4 +99,5 @@ class CPPCACHE_EXPORT ExpirationAttributes {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_EXPIRATIONATTRIBUTES_H__
+
+#endif // GEODE_GFCPP_EXPIRATIONATTRIBUTES_H_

--- a/src/cppcache/include/gfcpp/FixedPartitionResolver.hpp
+++ b/src/cppcache/include/gfcpp/FixedPartitionResolver.hpp
@@ -1,5 +1,8 @@
-#ifndef GEMFIRE_FIXED_PARTITION_RESOLVER
-#define GEMFIRE_FIXED_PARTITION_RESOLVER
+#pragma once
+
+#ifndef GEODE_GFCPP_FIXEDPARTITIONRESOLVER_H_
+#define GEODE_GFCPP_FIXEDPARTITIONRESOLVER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -89,4 +92,5 @@ class CPPCACHE_EXPORT FixedPartitionResolver : public PartitionResolver {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_GFCPP_FIXEDPARTITIONRESOLVER_H_

--- a/src/cppcache/include/gfcpp/FunctionService.hpp
+++ b/src/cppcache/include/gfcpp/FunctionService.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_FUNCTIONSERVICE_H_
+#define GEODE_GFCPP_FUNCTIONSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_FUNCTION_SERVICE_H__
-#define __GEMFIRE_FUNCTION_SERVICE_H__
 
 /*
  * The specification of function behaviors is found in the corresponding
@@ -188,4 +190,4 @@ class CPPCACHE_EXPORT FunctionService : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_FUNCTION_SERVICE_H__
+#endif // GEODE_GFCPP_FUNCTIONSERVICE_H_

--- a/src/cppcache/include/gfcpp/GemFireCache.hpp
+++ b/src/cppcache/include/gfcpp/GemFireCache.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_GEMFIRECACHE_H_
+#define GEODE_GFCPP_GEMFIRECACHE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_GEMFIRECACHE_H__
-#define __GEMFIRE_GEMFIRECACHE_H__
 
 #include "gfcpp_globals.hpp"
 #include "gf_types.hpp"
@@ -79,4 +82,5 @@ class CPPCACHE_EXPORT GemFireCache : public RegionService {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_GEMFIRECACHE_H__
+
+#endif // GEODE_GFCPP_GEMFIRECACHE_H_

--- a/src/cppcache/include/gfcpp/GeodeCppCache.hpp
+++ b/src/cppcache/include/gfcpp/GeodeCppCache.hpp
@@ -1,5 +1,8 @@
-#ifndef __APACHE_GEODECPPCACHE_H__
-#define __APACHE_GEODECPPCACHE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_GEODECPPCACHE_H_
+#define GEODE_GFCPP_GEODECPPCACHE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -80,4 +83,5 @@
 #include "PdxFieldTypes.hpp"
 
 #include "GeodeCppCache.inl"
-#endif  // define __APACHE_GEODECPPCACHE_H__
+
+#endif // GEODE_GFCPP_GEODECPPCACHE_H_

--- a/src/cppcache/include/gfcpp/GeodeCppCache.inl
+++ b/src/cppcache/include/gfcpp/GeodeCppCache.inl
@@ -1,5 +1,5 @@
-#ifndef __APACHE_GEODECPPCACHE_I__
-#define __APACHE_GEODECPPCACHE_I__
+#ifndef __APACHE_GEODECPPCACHE_INL_
+#define __APACHE_GEODECPPCACHE_INL_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,4 +24,4 @@
 #include "Cacheable.inl"
 #include "CacheableKey.inl"
 
-#endif // define __APACHE_GEODECPPCACHE_I__
+#endif // define __APACHE_GEODECPPCACHE_INL_

--- a/src/cppcache/include/gfcpp/GeodeTypeIds.hpp
+++ b/src/cppcache/include/gfcpp/GeodeTypeIds.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_GEODETYPEIDS_H_
+#define GEODE_GFCPP_GEODETYPEIDS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEODE_GEODETYPEIDS_HPP_
-#define _GEODE_GEODETYPEIDS_HPP_
 
 namespace apache {
 namespace geode {
@@ -82,4 +85,5 @@ class GeodeTypeIds {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_GFCPP_GEODETYPEIDS_H_

--- a/src/cppcache/include/gfcpp/HashFunction.hpp
+++ b/src/cppcache/include/gfcpp/HashFunction.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_HASHFUNCTION_HPP_
-#define _GEMFIRE_HASHFUNCTION_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_HASHFUNCTION_H_
+#define GEODE_GFCPP_HASHFUNCTION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -76,4 +78,4 @@ inline bool equalToFunction(const TKEY& x, const TKEY& y) {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_HASHFUNCTION_H_

--- a/src/cppcache/include/gfcpp/HashMapOfSharedBase.hpp
+++ b/src/cppcache/include/gfcpp/HashMapOfSharedBase.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_HASHMAPOFSHAREDBASE_HPP_
-#define _GEMFIRE_HASHMAPOFSHAREDBASE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_HASHMAPOFSHAREDBASE_H_
+#define GEODE_GFCPP_HASHMAPOFSHAREDBASE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -156,4 +158,4 @@ class CPPCACHE_EXPORT HashMapOfSharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_HASHMAPOFSHAREDBASE_H_

--- a/src/cppcache/include/gfcpp/HashMapT.hpp
+++ b/src/cppcache/include/gfcpp/HashMapT.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_HASHMAPT_HPP_
-#define _GEMFIRE_HASHMAPT_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_HASHMAPT_H_
+#define GEODE_GFCPP_HASHMAPT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -219,4 +221,4 @@ typedef SharedPtr<HashMapOfException> HashMapOfExceptionPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_HASHMAPT_H_

--- a/src/cppcache/include/gfcpp/HashSetOfSharedBase.hpp
+++ b/src/cppcache/include/gfcpp/HashSetOfSharedBase.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_HASHSETOFSHAREDBASE_HPP_
-#define _GEMFIRE_HASHSETOFSHAREDBASE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_HASHSETOFSHAREDBASE_H_
+#define GEODE_GFCPP_HASHSETOFSHAREDBASE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -148,4 +150,4 @@ class CPPCACHE_EXPORT HashSetOfSharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_HASHSETOFSHAREDBASE_H_

--- a/src/cppcache/include/gfcpp/HashSetT.hpp
+++ b/src/cppcache/include/gfcpp/HashSetT.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_HASHSETT_HPP_
-#define _GEMFIRE_HASHSETT_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_HASHSETT_H_
+#define GEODE_GFCPP_HASHSETT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -175,4 +177,4 @@ typedef SharedPtr<HashSetOfCacheableKey> HashSetOfCacheableKeyPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_HASHSETT_H_

--- a/src/cppcache/include/gfcpp/InternalCacheTransactionManager2PC.hpp
+++ b/src/cppcache/include/gfcpp/InternalCacheTransactionManager2PC.hpp
@@ -1,5 +1,8 @@
-#ifndef INTERNALCACHETRANSACTIONMANAGER2PC_H_
-#define INTERNALCACHETRANSACTIONMANAGER2PC_H_
+#pragma once
+
+#ifndef GEODE_GFCPP_INTERNALCACHETRANSACTIONMANAGER2PC_H_
+#define GEODE_GFCPP_INTERNALCACHETRANSACTIONMANAGER2PC_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -70,4 +73,5 @@ class CPPCACHE_EXPORT InternalCacheTransactionManager2PC
 }  // namespace geode
 }  // namespace apache
 
-#endif /* INTERNALCACHETRANSACTIONMANAGER2PC_H_ */
+
+#endif // GEODE_GFCPP_INTERNALCACHETRANSACTIONMANAGER2PC_H_

--- a/src/cppcache/include/gfcpp/Log.hpp
+++ b/src/cppcache/include/gfcpp/Log.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_LOG_HPP_
-#define _GEMFIRE_LOG_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_LOG_H_
+#define GEODE_GFCPP_LOG_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -669,6 +671,4 @@ class CPPCACHE_EXPORT LogVarargs {
 
 /******************************************************************************/
 
-#endif
-
-/******************************************************************************/
+#endif // GEODE_GFCPP_LOG_H_

--- a/src/cppcache/include/gfcpp/PartitionResolver.hpp
+++ b/src/cppcache/include/gfcpp/PartitionResolver.hpp
@@ -1,5 +1,8 @@
-#ifndef GEMFIRE_PARTITION_RESOLVER
-#define GEMFIRE_PARTITION_RESOLVER
+#pragma once
+
+#ifndef GEODE_GFCPP_PARTITIONRESOLVER_H_
+#define GEODE_GFCPP_PARTITIONRESOLVER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -104,4 +107,5 @@ class CPPCACHE_EXPORT PartitionResolver : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_GFCPP_PARTITIONRESOLVER_H_

--- a/src/cppcache/include/gfcpp/PdxAutoSerializer.hpp
+++ b/src/cppcache/include/gfcpp/PdxAutoSerializer.hpp
@@ -1,5 +1,8 @@
-#ifndef PDX_AUTO_SERIALIZER_HPP
-#define PDX_AUTO_SERIALIZER_HPP
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXAUTOSERIALIZER_H_
+#define GEODE_GFCPP_PDXAUTOSERIALIZER_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -524,4 +527,5 @@ inline void readPdxObject(apache::geode::client::PdxReaderPtr& pr,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_SERIALIZER_HPP_
+
+#endif // GEODE_GFCPP_PDXAUTOSERIALIZER_H_

--- a/src/cppcache/include/gfcpp/PdxFieldTypes.hpp
+++ b/src/cppcache/include/gfcpp/PdxFieldTypes.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXFIELDTYPES_HPP_
-#define __GEMFIRE_PDXFIELDTYPES_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXFIELDTYPES_H_
+#define GEODE_GFCPP_PDXFIELDTYPES_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -52,4 +54,5 @@ class CPPCACHE_EXPORT PdxFieldTypes {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* __GEMFIRE_PDXFIELDTYPES_HPP_ */
+
+#endif // GEODE_GFCPP_PDXFIELDTYPES_H_

--- a/src/cppcache/include/gfcpp/PdxInstance.hpp
+++ b/src/cppcache/include/gfcpp/PdxInstance.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXINSTANCE_HPP_
-#define __GEMFIRE_PDXINSTANCE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXINSTANCE_H_
+#define GEODE_GFCPP_PDXINSTANCE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -612,4 +614,5 @@ class CPPCACHE_EXPORT PdxInstance : public PdxSerializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* __GEMFIRE_PDXINSTANCE_HPP_ */
+
+#endif // GEODE_GFCPP_PDXINSTANCE_H_

--- a/src/cppcache/include/gfcpp/PdxInstanceFactory.hpp
+++ b/src/cppcache/include/gfcpp/PdxInstanceFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __PDXINSTANCE_FACTORY_HPP_
-#define __PDXINSTANCE_FACTORY_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXINSTANCEFACTORY_H_
+#define GEODE_GFCPP_PDXINSTANCEFACTORY_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -471,4 +474,5 @@ class CPPCACHE_EXPORT PdxInstanceFactory : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __PDXINSTANCE_FACTORY_HPP_ */
+
+#endif // GEODE_GFCPP_PDXINSTANCEFACTORY_H_

--- a/src/cppcache/include/gfcpp/PdxReader.hpp
+++ b/src/cppcache/include/gfcpp/PdxReader.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXREADER_H__
-#define __GEMFIRE_PDXREADER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXREADER_H_
+#define GEODE_GFCPP_PDXREADER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -414,4 +416,5 @@ class CPPCACHE_EXPORT PdxReader : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXREADER_HPP_ */
+
+#endif // GEODE_GFCPP_PDXREADER_H_

--- a/src/cppcache/include/gfcpp/PdxSerializable.hpp
+++ b/src/cppcache/include/gfcpp/PdxSerializable.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXSERIALIZABLE_H__
-#define __GEMFIRE_PDXSERIALIZABLE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXSERIALIZABLE_H_
+#define GEODE_GFCPP_PDXSERIALIZABLE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -109,4 +111,4 @@ class CPPCACHE_EXPORT PdxSerializable : public CacheableKey {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* PDXSERIALIZABLE_HPP_ */
+#endif // GEODE_GFCPP_PDXSERIALIZABLE_H_

--- a/src/cppcache/include/gfcpp/PdxSerializer.hpp
+++ b/src/cppcache/include/gfcpp/PdxSerializer.hpp
@@ -1,5 +1,8 @@
-#ifndef PDXSERIALIZER_HPP_
-#define PDXSERIALIZER_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXSERIALIZER_H_
+#define GEODE_GFCPP_PDXSERIALIZER_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -87,4 +90,5 @@ class CPPCACHE_EXPORT PdxSerializer : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* PDXSERIALIZER_HPP_ */
+
+#endif // GEODE_GFCPP_PDXSERIALIZER_H_

--- a/src/cppcache/include/gfcpp/PdxUnreadFields.hpp
+++ b/src/cppcache/include/gfcpp/PdxUnreadFields.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXUNREADFIELDS_HPP_
-#define __GEMFIRE_PDXUNREADFIELDS_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXUNREADFIELDS_H_
+#define GEODE_GFCPP_PDXUNREADFIELDS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -48,4 +50,4 @@ class CPPCACHE_EXPORT PdxUnreadFields : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __GEMFIRE_PDXUNREADFIELDS_HPP_ */
+#endif // GEODE_GFCPP_PDXUNREADFIELDS_H_

--- a/src/cppcache/include/gfcpp/PdxWrapper.hpp
+++ b/src/cppcache/include/gfcpp/PdxWrapper.hpp
@@ -1,5 +1,8 @@
-#ifndef _PDXWRAPPER_HPP_
-#define _PDXWRAPPER_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXWRAPPER_H_
+#define GEODE_GFCPP_PDXWRAPPER_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -133,4 +136,5 @@ class CPPCACHE_EXPORT PdxWrapper : public PdxSerializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* _PDXWRAPPER_HPP_ */
+
+#endif // GEODE_GFCPP_PDXWRAPPER_H_

--- a/src/cppcache/include/gfcpp/PdxWriter.hpp
+++ b/src/cppcache/include/gfcpp/PdxWriter.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXWRITER_H__
-#define __GEMFIRE_PDXWRITER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_PDXWRITER_H_
+#define GEODE_GFCPP_PDXWRITER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -445,4 +447,5 @@ class CPPCACHE_EXPORT PdxWriter : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXWRITER_HPP_ */
+
+#endif // GEODE_GFCPP_PDXWRITER_H_

--- a/src/cppcache/include/gfcpp/PersistenceManager.hpp
+++ b/src/cppcache/include/gfcpp/PersistenceManager.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_PERSISTENCEMANAGER_H__
-#define __GEMFIRE_PERSISTENCEMANAGER_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_PERSISTENCEMANAGER_H_
+#define GEODE_GFCPP_PERSISTENCEMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -133,4 +136,5 @@ class CPPCACHE_EXPORT PersistenceManager : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_PERSISTENCEMANAGER_H__
+
+#endif // GEODE_GFCPP_PERSISTENCEMANAGER_H_

--- a/src/cppcache/include/gfcpp/Pool.hpp
+++ b/src/cppcache/include/gfcpp/Pool.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_POOL_HPP__
-#define __GEMFIRE_POOL_HPP__
+#pragma once
+
+#ifndef GEODE_GFCPP_POOL_H_
+#define GEODE_GFCPP_POOL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -282,4 +285,4 @@ class CPPCACHE_EXPORT Pool : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_POOL_HPP__
+#endif // GEODE_GFCPP_POOL_H_

--- a/src/cppcache/include/gfcpp/PoolFactory.hpp
+++ b/src/cppcache/include/gfcpp/PoolFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_POOL_FACTORY_HPP__
-#define __GEMFIRE_POOL_FACTORY_HPP__
+#pragma once
+
+#ifndef GEODE_GFCPP_POOLFACTORY_H_
+#define GEODE_GFCPP_POOLFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -532,4 +535,5 @@ class CPPCACHE_EXPORT PoolFactory : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_POOL_FACTORY_HPP__
+
+#endif // GEODE_GFCPP_POOLFACTORY_H_

--- a/src/cppcache/include/gfcpp/PoolManager.hpp
+++ b/src/cppcache/include/gfcpp/PoolManager.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_POOL_MANAGER_HPP__
-#define __GEMFIRE_POOL_MANAGER_HPP__
+#pragma once
+
+#ifndef GEODE_GFCPP_POOLMANAGER_H_
+#define GEODE_GFCPP_POOLMANAGER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -95,4 +97,4 @@ class CPPCACHE_EXPORT PoolManager {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_POOL_MANAGER_HPP__
+#endif // GEODE_GFCPP_POOLMANAGER_H_

--- a/src/cppcache/include/gfcpp/Properties.hpp
+++ b/src/cppcache/include/gfcpp/Properties.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_PROPERTIES_H__
-#define __GEMFIRE_PROPERTIES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_PROPERTIES_H_
+#define GEODE_GFCPP_PROPERTIES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -157,4 +160,5 @@ class CPPCACHE_EXPORT Properties : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_PROPERTIES_H__
+
+#endif // GEODE_GFCPP_PROPERTIES_H_

--- a/src/cppcache/include/gfcpp/Query.hpp
+++ b/src/cppcache/include/gfcpp/Query.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_QUERY_H__
-#define __GEMFIRE_QUERY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_QUERY_H_
+#define GEODE_GFCPP_QUERY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -118,4 +121,4 @@ class CPPCACHE_EXPORT Query : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_QUERY_H__
+#endif // GEODE_GFCPP_QUERY_H_

--- a/src/cppcache/include/gfcpp/QueryService.hpp
+++ b/src/cppcache/include/gfcpp/QueryService.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_QUERYSERVICE_H__
-#define __GEMFIRE_QUERYSERVICE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_QUERYSERVICE_H_
+#define GEODE_GFCPP_QUERYSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -171,4 +174,4 @@ class CPPCACHE_EXPORT QueryService : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_QUERYSERVICE_H__
+#endif // GEODE_GFCPP_QUERYSERVICE_H_

--- a/src/cppcache/include/gfcpp/Region.hpp
+++ b/src/cppcache/include/gfcpp/Region.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_REGION_H__
-#define __GEMFIRE_REGION_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_REGION_H_
+#define GEODE_GFCPP_REGION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1450,4 +1452,4 @@ class CPPCACHE_EXPORT Region : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGION_H__
+#endif // GEODE_GFCPP_REGION_H_

--- a/src/cppcache/include/gfcpp/RegionAttributes.hpp
+++ b/src/cppcache/include/gfcpp/RegionAttributes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REGIONATTRIBUTES_H__
-#define __GEMFIRE_REGIONATTRIBUTES_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONATTRIBUTES_H_
+#define GEODE_GFCPP_REGIONATTRIBUTES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -397,4 +400,4 @@ class CPPCACHE_EXPORT RegionAttributes : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONATTRIBUTES_H__
+#endif // GEODE_GFCPP_REGIONATTRIBUTES_H_

--- a/src/cppcache/include/gfcpp/RegionEntry.hpp
+++ b/src/cppcache/include/gfcpp/RegionEntry.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REGIONENTRY_H__
-#define __GEMFIRE_REGIONENTRY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONENTRY_H_
+#define GEODE_GFCPP_REGIONENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -105,4 +108,4 @@ class CPPCACHE_EXPORT RegionEntry : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_REGIONENTRY_H_

--- a/src/cppcache/include/gfcpp/RegionEvent.hpp
+++ b/src/cppcache/include/gfcpp/RegionEvent.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_REGIONEVENT_HPP_
-#define _GEMFIRE_REGIONEVENT_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONEVENT_H_
+#define GEODE_GFCPP_REGIONEVENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -71,4 +74,4 @@ class CPPCACHE_EXPORT RegionEvent {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_REGIONEVENT_H_

--- a/src/cppcache/include/gfcpp/RegionFactory.hpp
+++ b/src/cppcache/include/gfcpp/RegionFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REGIONFACTORY_H__
-#define __GEMFIRE_REGIONFACTORY_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONFACTORY_H_
+#define GEODE_GFCPP_REGIONFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -265,4 +268,4 @@ class CPPCACHE_EXPORT RegionFactory : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONFACTORY_H__
+#endif // GEODE_GFCPP_REGIONFACTORY_H_

--- a/src/cppcache/include/gfcpp/RegionService.hpp
+++ b/src/cppcache/include/gfcpp/RegionService.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONSERVICE_H_
+#define GEODE_GFCPP_REGIONSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_RegionService_H__
-#define __GEMFIRE_RegionService_H__
 
 #include "gfcpp_globals.hpp"
 #include "gf_types.hpp"
@@ -117,4 +120,5 @@ class CPPCACHE_EXPORT RegionService : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_RegionService_H__
+
+#endif // GEODE_GFCPP_REGIONSERVICE_H_

--- a/src/cppcache/include/gfcpp/RegionShortcut.hpp
+++ b/src/cppcache/include/gfcpp/RegionShortcut.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_REGIONSHORTCUT_H__
-#define __GEMFIRE_REGIONSHORTCUT_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_REGIONSHORTCUT_H_
+#define GEODE_GFCPP_REGIONSHORTCUT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -74,4 +76,4 @@ enum RegionShortcut {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONSHORTCUT_H__
+#endif // GEODE_GFCPP_REGIONSHORTCUT_H_

--- a/src/cppcache/include/gfcpp/ResultCollector.hpp
+++ b/src/cppcache/include/gfcpp/ResultCollector.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_RESULTCOLLECTOR_H__
-#define __GEMFIRE_RESULTCOLLECTOR_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_RESULTCOLLECTOR_H_
+#define GEODE_GFCPP_RESULTCOLLECTOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -107,4 +110,5 @@ class CPPCACHE_EXPORT ResultCollector : public SharedBase {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_RESULTCOLLECTOR_H__
+
+#endif // GEODE_GFCPP_RESULTCOLLECTOR_H_

--- a/src/cppcache/include/gfcpp/ResultSet.hpp
+++ b/src/cppcache/include/gfcpp/ResultSet.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_RESULTSET_H__
-#define __GEMFIRE_RESULTSET_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_RESULTSET_H_
+#define GEODE_GFCPP_RESULTSET_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -81,4 +84,4 @@ class CPPCACHE_EXPORT ResultSet : public SelectResults {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_RESULTSET_H__
+#endif // GEODE_GFCPP_RESULTSET_H_

--- a/src/cppcache/include/gfcpp/SelectResults.hpp
+++ b/src/cppcache/include/gfcpp/SelectResults.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_SELECTRESULTS_H__
-#define __GEMFIRE_SELECTRESULTS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_SELECTRESULTS_H_
+#define GEODE_GFCPP_SELECTRESULTS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -84,4 +87,4 @@ class CPPCACHE_EXPORT SelectResults : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_SELECTRESULTS_H__
+#endif // GEODE_GFCPP_SELECTRESULTS_H_

--- a/src/cppcache/include/gfcpp/SelectResultsIterator.hpp
+++ b/src/cppcache/include/gfcpp/SelectResultsIterator.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_SELECTRESULTSITERATOR_H__
-#define __GEMFIRE_SELECTRESULTSITERATOR_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_SELECTRESULTSITERATOR_H_
+#define GEODE_GFCPP_SELECTRESULTSITERATOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -98,4 +101,4 @@ class CPPCACHE_EXPORT SelectResultsIterator : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_SELECTRESULTSITERATOR_H__
+#endif // GEODE_GFCPP_SELECTRESULTSITERATOR_H_

--- a/src/cppcache/include/gfcpp/Serializable.hpp
+++ b/src/cppcache/include/gfcpp/Serializable.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_SERIALIZABLE_H__
-#define __GEMFIRE_SERIALIZABLE_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_SERIALIZABLE_H_
+#define GEODE_GFCPP_SERIALIZABLE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -166,4 +169,4 @@ class CPPCACHE_EXPORT Serializable : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_SERIALIZABLE_H__
+#endif // GEODE_GFCPP_SERIALIZABLE_H_

--- a/src/cppcache/include/gfcpp/Serializer.hpp
+++ b/src/cppcache/include/gfcpp/Serializer.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_SERIALIZER_HPP_
-#define _GEMFIRE_SERIALIZER_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_SERIALIZER_H_
+#define GEODE_GFCPP_SERIALIZER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -452,4 +454,4 @@ inline float zeroObject<float>() {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_SERIALIZER_HPP_
+#endif // GEODE_GFCPP_SERIALIZER_H_

--- a/src/cppcache/include/gfcpp/SharedBase.hpp
+++ b/src/cppcache/include/gfcpp/SharedBase.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_SHAREDBASE_HPP_
-#define _GEMFIRE_SHAREDBASE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_SHAREDBASE_H_
+#define GEODE_GFCPP_SHAREDBASE_H_
 
 // SharedBase.hpp     -*- mode: c++ -*-
 
@@ -86,4 +88,4 @@ class CPPCACHE_EXPORT NullSharedBase : public SharedBase {
 
 #define NULLPTR ::apache::geode::client::NullSharedBase::s_instancePtr
 
-#endif  //#define _GEMFIRE_SHAREDBASE_HPP_
+#endif // GEODE_GFCPP_SHAREDBASE_H_

--- a/src/cppcache/include/gfcpp/SharedPtr.hpp
+++ b/src/cppcache/include/gfcpp/SharedPtr.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_SHAREDPTR_HPP_
-#define _GEMFIRE_SHAREDPTR_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_SHAREDPTR_H_
+#define GEODE_GFCPP_SHAREDPTR_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -280,4 +282,4 @@ bool instanceOf(const SharedPtr<Other>& other) {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_SHAREDPTR_H_

--- a/src/cppcache/include/gfcpp/SharedPtrHelper.hpp
+++ b/src/cppcache/include/gfcpp/SharedPtrHelper.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_SPEHELPER_HPP_
-#define _GEMFIRE_SPEHELPER_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_SHAREDPTRHELPER_H_
+#define GEODE_GFCPP_SHAREDPTRHELPER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -78,4 +80,4 @@ SharedBase* getSB(Src* ptr) {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_SHAREDPTRHELPER_H_

--- a/src/cppcache/include/gfcpp/Struct.hpp
+++ b/src/cppcache/include/gfcpp/Struct.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_STRUCT_H__
-#define __GEMFIRE_STRUCT_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_STRUCT_H_
+#define GEODE_GFCPP_STRUCT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -157,4 +160,4 @@ class CPPCACHE_EXPORT Struct : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_STRUCT_H__
+#endif // GEODE_GFCPP_STRUCT_H_

--- a/src/cppcache/include/gfcpp/StructSet.hpp
+++ b/src/cppcache/include/gfcpp/StructSet.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_STRUCTSET_H__
-#define __GEMFIRE_STRUCTSET_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_STRUCTSET_H_
+#define GEODE_GFCPP_STRUCTSET_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -99,4 +102,4 @@ class CPPCACHE_EXPORT StructSet : public CqResults {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_STRUCTSET_H__
+#endif // GEODE_GFCPP_STRUCTSET_H_

--- a/src/cppcache/include/gfcpp/SystemProperties.hpp
+++ b/src/cppcache/include/gfcpp/SystemProperties.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_SYSTEMPROPERTIES_HPP_
-#define _GEMFIRE_SYSTEMPROPERTIES_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_SYSTEMPROPERTIES_H_
+#define GEODE_GFCPP_SYSTEMPROPERTIES_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -507,4 +509,4 @@ class CPPCACHE_EXPORT SystemProperties {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_SYSTEMPROPERTIES_H_

--- a/src/cppcache/include/gfcpp/TransactionId.hpp
+++ b/src/cppcache/include/gfcpp/TransactionId.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_TRANSACTIONID_H_
+#define GEODE_GFCPP_TRANSACTIONID_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TRANSACTIONID_H_
-#define TRANSACTIONID_H_
 
 #include "SharedBase.hpp"
 
@@ -44,4 +47,5 @@ class CPPCACHE_EXPORT TransactionId : public apache::geode::client::SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TRANSACTIONID_H_ */
+
+#endif // GEODE_GFCPP_TRANSACTIONID_H_

--- a/src/cppcache/include/gfcpp/TypeHelper.hpp
+++ b/src/cppcache/include/gfcpp/TypeHelper.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_TYPEHELPER_HPP_
-#define _GEMFIRE_TYPEHELPER_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_TYPEHELPER_H_
+#define GEODE_GFCPP_TYPEHELPER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -149,4 +151,4 @@ struct UnwrapSharedPtr<SharedArrayPtr<T, ID> > {
       apache::geode::client::TypeHelper::SuperSubclass<TARGET, \
                                                        SRC>::result>::value
 
-#endif  // _GEMFIRE_TYPEHELPER_HPP_
+#endif // GEODE_GFCPP_TYPEHELPER_H_

--- a/src/cppcache/include/gfcpp/UserData.hpp
+++ b/src/cppcache/include/gfcpp/UserData.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_USERDATA_H__
-#define __GEMFIRE_USERDATA_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_USERDATA_H_
+#define GEODE_GFCPP_USERDATA_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -34,4 +37,4 @@ typedef SharedPtr<UserData> UserDataPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_USERDATA_H__
+#endif // GEODE_GFCPP_USERDATA_H_

--- a/src/cppcache/include/gfcpp/UserFunctionExecutionException.hpp
+++ b/src/cppcache/include/gfcpp/UserFunctionExecutionException.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPP_USERFUNCTIONEXECUTIONEXCEPTION_H_
+#define GEODE_GFCPP_USERFUNCTIONEXECUTIONEXCEPTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef USER_FUNCTION_EXECUTION_EXCEPTION
-#define USER_FUNCTION_EXECUTION_EXCEPTION
 
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
@@ -118,4 +121,5 @@ class UserFunctionExecutionException : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_GFCPP_USERFUNCTIONEXECUTIONEXCEPTION_H_

--- a/src/cppcache/include/gfcpp/VectorOfSharedBase.hpp
+++ b/src/cppcache/include/gfcpp/VectorOfSharedBase.hpp
@@ -1,6 +1,7 @@
+#pragma once
 
-#ifndef _GEMFIRE_VECTOROFSHAREDBASE_HPP_
-#define _GEMFIRE_VECTOROFSHAREDBASE_HPP_
+#ifndef GEODE_GFCPP_VECTOROFSHAREDBASE_H_
+#define GEODE_GFCPP_VECTOROFSHAREDBASE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -169,4 +170,4 @@ class CPPCACHE_EXPORT VectorOfSharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_VECTOROFSHAREDBASE_H_

--- a/src/cppcache/include/gfcpp/VectorT.hpp
+++ b/src/cppcache/include/gfcpp/VectorT.hpp
@@ -1,6 +1,7 @@
+#pragma once
 
-#ifndef _GEMFIRE_VECTORT_HPP_
-#define _GEMFIRE_VECTORT_HPP_
+#ifndef GEODE_GFCPP_VECTORT_H_
+#define GEODE_GFCPP_VECTORT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -256,4 +257,4 @@ typedef SharedPtr<VectorOfCacheableKey> VectorOfCacheableKeyPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_GFCPP_VECTORT_H_

--- a/src/cppcache/include/gfcpp/WritablePdxInstance.hpp
+++ b/src/cppcache/include/gfcpp/WritablePdxInstance.hpp
@@ -1,5 +1,8 @@
-#ifndef __WRITABLE_PDXINSTANCE_HPP_
-#define __WRITABLE_PDXINSTANCE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_WRITABLEPDXINSTANCE_H_
+#define GEODE_GFCPP_WRITABLEPDXINSTANCE_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -535,4 +538,5 @@ class CPPCACHE_EXPORT WritablePdxInstance : public PdxInstance {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __WRITABLE_PDXINSTANCE_HPP_ */
+
+#endif // GEODE_GFCPP_WRITABLEPDXINSTANCE_H_

--- a/src/cppcache/include/gfcpp/gf_base.hpp
+++ b/src/cppcache/include/gfcpp/gf_base.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_GF_BASE_HPP_
-#define _GEMFIRE_GF_BASE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_GF_BASE_H_
+#define GEODE_GFCPP_GF_BASE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -352,4 +355,4 @@ void operator delete[](void *p);
     x = NULL;                   \
   }
 
-#endif
+#endif // GEODE_GFCPP_GF_BASE_H_

--- a/src/cppcache/include/gfcpp/gf_types.hpp
+++ b/src/cppcache/include/gfcpp/gf_types.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_GF_TYPEDEF_H__
-#define __GEMFIRE_GF_TYPEDEF_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_GF_TYPES_H_
+#define GEODE_GFCPP_GF_TYPES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -104,4 +107,5 @@ _GF_PTR_DEF_(InternalCacheTransactionManager2PC,
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_GF_TYPEDEF_H__
+
+#endif // GEODE_GFCPP_GF_TYPES_H_

--- a/src/cppcache/include/gfcpp/gfcpp_globals.hpp
+++ b/src/cppcache/include/gfcpp/gfcpp_globals.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_GFCPP_GLOBALS_H__
-#define __GEMFIRE_GFCPP_GLOBALS_H__
+#pragma once
+
+#ifndef GEODE_GFCPP_GFCPP_GLOBALS_H_
+#define GEODE_GFCPP_GFCPP_GLOBALS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -113,4 +116,4 @@ extern void CPPCACHE_EXPORT setNewAndDelete(pNew, pDelete);
 #include "Log.hpp"
 #include "Assert.hpp"
 
-#endif  // __GEMFIRE_GFCPP_GLOBALS_H__
+#endif // GEODE_GFCPP_GFCPP_GLOBALS_H_

--- a/src/cppcache/include/gfcpp/statistics/StatisticDescriptor.hpp
+++ b/src/cppcache/include/gfcpp/statistics/StatisticDescriptor.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICDESCRIPTOR_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICDESCRIPTOR_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_STATISTICS_STATISTICDESCRIPTOR_H_
+#define GEODE_GFCPP_STATISTICS_STATISTICDESCRIPTOR_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -88,4 +90,4 @@ class CPPCACHE_EXPORT StatisticDescriptor {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_STATISTICDESCRIPTOR_HPP_
+#endif // GEODE_GFCPP_STATISTICS_STATISTICDESCRIPTOR_H_

--- a/src/cppcache/include/gfcpp/statistics/Statistics.hpp
+++ b/src/cppcache/include/gfcpp/statistics/Statistics.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICS_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICS_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_STATISTICS_STATISTICS_H_
+#define GEODE_GFCPP_STATISTICS_STATISTICS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -526,4 +529,4 @@ class CPPCACHE_EXPORT Statistics {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_STATISTICS_HPP_
+#endif // GEODE_GFCPP_STATISTICS_STATISTICS_H_

--- a/src/cppcache/include/gfcpp/statistics/StatisticsFactory.hpp
+++ b/src/cppcache/include/gfcpp/statistics/StatisticsFactory.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICSFACTORY_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICSFACTORY_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_STATISTICS_STATISTICSFACTORY_H_
+#define GEODE_GFCPP_STATISTICS_STATISTICSFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -217,4 +220,4 @@ class CPPCACHE_EXPORT StatisticsFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //  _GEMFIRE__STATISTICS_STATISTICSFACTORY_HPP_
+#endif // GEODE_GFCPP_STATISTICS_STATISTICSFACTORY_H_

--- a/src/cppcache/include/gfcpp/statistics/StatisticsType.hpp
+++ b/src/cppcache/include/gfcpp/statistics/StatisticsType.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICSTYPE_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICSTYPE_HPP_
+#pragma once
+
+#ifndef GEODE_GFCPP_STATISTICS_STATISTICSTYPE_H_
+#define GEODE_GFCPP_STATISTICS_STATISTICSTYPE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -93,4 +96,4 @@ class CPPCACHE_EXPORT StatisticsType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_STATISTICSTYPE_H__
+#endif // GEODE_GFCPP_STATISTICS_STATISTICSTYPE_H_

--- a/src/cppcache/integration-test/BBNamingContext.hpp
+++ b/src/cppcache/integration-test/BBNamingContext.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_BBNAMINGCONTEXT_H_
+#define GEODE_INTEGRATION_TEST_BBNAMINGCONTEXT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
 // move them there.
 // This will avoid pulling in a lot of framework headers to cause compilation
 // grieve, especially with the stl stuff.
-#ifndef __BB_NAMING_CONTEXT__
-#define __BB_NAMING_CONTEXT__
 #include <stdlib.h>
 #include <string>
 class BBNamingContextClientImpl;
@@ -43,4 +46,5 @@ class BBNamingContextServer {
   BBNamingContextServer();
   ~BBNamingContextServer();
 };
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_BBNAMINGCONTEXT_H_

--- a/src/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/src/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_BUILTINCACHEABLEWRAPPERS_H_
+#define GEODE_INTEGRATION_TEST_BUILTINCACHEABLEWRAPPERS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GF_TEST_BUILTIN_CACHEABLEWRAPPERS_HPP_
-#define _GF_TEST_BUILTIN_CACHEABLEWRAPPERS_HPP_
 
 #include "CacheableWrapper.hpp"
 extern "C" {
@@ -1311,4 +1314,5 @@ void registerBuiltins(bool isRegisterFileName = false) {
 }
 }  // namespace CacheableHelper
 
-#endif  // _GF_TEST_BUILTIN_CACHEABLEWRAPPERS_HPP_
+
+#endif // GEODE_INTEGRATION_TEST_BUILTINCACHEABLEWRAPPERS_H_

--- a/src/cppcache/integration-test/CacheHelper.hpp
+++ b/src/cppcache/integration-test/CacheHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_CACHEHELPER_H_
+#define GEODE_INTEGRATION_TEST_CACHEHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_CACHEHELPER_HPP
-#define TEST_CACHEHELPER_HPP
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <stdlib.h>
@@ -327,4 +330,5 @@ int CacheHelper::staticLocatorHostPort1 = CacheHelper::getRandomAvailablePort();
 int CacheHelper::staticLocatorHostPort2 = CacheHelper::getRandomAvailablePort();
 int CacheHelper::staticLocatorHostPort3 = CacheHelper::getRandomAvailablePort();
 #endif
-#endif  // TEST_CACHEHELPER_HPP
+
+#endif // GEODE_INTEGRATION_TEST_CACHEHELPER_H_

--- a/src/cppcache/integration-test/CacheImplHelper.hpp
+++ b/src/cppcache/integration-test/CacheImplHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_CACHEIMPLHELPER_H_
+#define GEODE_INTEGRATION_TEST_CACHEIMPLHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_CACHEIMPLHELPER_HPP
-#define TEST_CACHEIMPLHELPER_HPP
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <stdlib.h>
@@ -63,4 +66,5 @@ class CacheImplHelper : public CacheHelper {
     ASSERT(regionPtr != NULLPTR, "failed to create region.");
   }
 };
-#endif  // TEST_CACHEHELPER_HPP
+
+#endif // GEODE_INTEGRATION_TEST_CACHEIMPLHELPER_H_

--- a/src/cppcache/integration-test/CacheableWrapper.hpp
+++ b/src/cppcache/integration-test/CacheableWrapper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_CACHEABLEWRAPPER_H_
+#define GEODE_INTEGRATION_TEST_CACHEABLEWRAPPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GF_TEST_CACHEABLEWRAPPER_HPP_
-#define _GF_TEST_CACHEABLEWRAPPER_HPP_
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string>
@@ -129,4 +132,5 @@ std::string CacheableWrapperFactory::getTypeForId(int8_t typeId) {
   }
 }
 
-#endif  // _GF_TEST_CACHEABLEWRAPPER_HPP_
+
+#endif // GEODE_INTEGRATION_TEST_CACHEABLEWRAPPER_H_

--- a/src/cppcache/integration-test/DeltaEx.hpp
+++ b/src/cppcache/integration-test/DeltaEx.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_DELTAEX_H_
+#define GEODE_INTEGRATION_TEST_DELTAEX_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DELTAEX_HPP
-#define __DELTAEX_HPP
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -147,4 +150,5 @@ class PdxDeltaEx : public PdxSerializable, public Delta {
   }
 };
 typedef SharedPtr<PdxDeltaEx> PdxDeltaExPtr;
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_DELTAEX_H_

--- a/src/cppcache/integration-test/LocatorHelper.hpp
+++ b/src/cppcache/integration-test/LocatorHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_LOCATORHELPER_H_
+#define GEODE_INTEGRATION_TEST_LOCATORHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -141,3 +146,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseLocator1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_LOCATORHELPER_H_

--- a/src/cppcache/integration-test/QueryHelper.hpp
+++ b/src/cppcache/integration-test/QueryHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_QUERYHELPER_H_
+#define GEODE_INTEGRATION_TEST_QUERYHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_QUERYHELPER_HPP
-#define TEST_QUERYHELPER_HPP
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <stdlib.h>
@@ -373,4 +376,5 @@ bool QueryHelper::verifySS(SelectResultsPtr& structSet, int expectedRows,
   return false;
 }
 
-#endif  // TEST_QUERYHELPER_HPP
+
+#endif // GEODE_INTEGRATION_TEST_QUERYHELPER_H_

--- a/src/cppcache/integration-test/QueryStrings.hpp
+++ b/src/cppcache/integration-test/QueryStrings.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_QUERYSTRINGS_H_
+#define GEODE_INTEGRATION_TEST_QUERYSTRINGS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_QUERYSTRINGS_HPP
-#define TEST_QUERYSTRINGS_HPP
 
 #include <cstring>
 
@@ -726,4 +729,5 @@ const int constantExpectedRowsCQRS[1] = {35};
 
 }  // namespace testData
 
-#endif  // TEST_QUERYSTRINGS_HPP
+
+#endif // GEODE_INTEGRATION_TEST_QUERYSTRINGS_H_

--- a/src/cppcache/integration-test/TallyListener.hpp
+++ b/src/cppcache/integration-test/TallyListener.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_TALLYLISTENER_H_
+#define GEODE_INTEGRATION_TEST_TALLYLISTENER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _TEST_TALLYLISTENER_HPP_
-#define _TEST_TALLYLISTENER_HPP_
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string>
@@ -220,4 +223,5 @@ void TallyListener::afterRegionClear(const EntryEvent& event) {
   checkcallbackArg(event);
 }
 
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_TALLYLISTENER_H_

--- a/src/cppcache/integration-test/TallyLoader.hpp
+++ b/src/cppcache/integration-test/TallyLoader.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_TALLYLOADER_H_
+#define GEODE_INTEGRATION_TEST_TALLYLOADER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _TEST_TALLYLOADER_HPP_
-#define _TEST_TALLYLOADER_HPP_ 1
 
 #include <gfcpp/GeodeCppCache.hpp>
 
@@ -69,4 +72,5 @@ class TallyLoader : virtual public CacheLoader {
   }
 };
 
-#endif  //_TEST_TALLYLOADER_HPP_
+
+#endif // GEODE_INTEGRATION_TEST_TALLYLOADER_H_

--- a/src/cppcache/integration-test/TallyWriter.hpp
+++ b/src/cppcache/integration-test/TallyWriter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_TALLYWRITER_H_
+#define GEODE_INTEGRATION_TEST_TALLYWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _TEST_TALLYWRITER_HPP_
-#define _TEST_TALLYWRITER_HPP_ 1
 
 #include <gfcpp/GeodeCppCache.hpp>
 
@@ -150,4 +153,5 @@ class TallyWriter : virtual public CacheWriter {
   }
 };
 
-#endif  //_TEST_TALLYWRITER_HPP_
+
+#endif // GEODE_INTEGRATION_TEST_TALLYWRITER_H_

--- a/src/cppcache/integration-test/ThinClientCQ.hpp
+++ b/src/cppcache/integration-test/ThinClientCQ.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTCQ_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTCQ_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: vrao
  */
 
-#ifndef _THINCLIENTCQ_HPP_
-#define _THINCLIENTCQ_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -59,4 +62,5 @@ void createRegionForCQMU(const char* name, bool ackMode,
   createRegionAndAttachPool(name, ackMode, name, caching);
 }
 
-#endif /* _THINCLIENTCQ_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTCQ_H_

--- a/src/cppcache/integration-test/ThinClientCallbackArg.hpp
+++ b/src/cppcache/integration-test/ThinClientCallbackArg.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTCALLBACKARG_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTCALLBACKARG_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTCALLBACKARG_HPP_
-#define THINCLIENTCALLBACKARG_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -190,4 +193,5 @@ void runCallbackArg() {
 
   CALL_TASK(CloseLocator1);
 }
-#endif /*THINCLIENTCALLBACKARG_HPP_*/
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTCALLBACKARG_H_

--- a/src/cppcache/integration-test/ThinClientDistOps.hpp
+++ b/src/cppcache/integration-test/ThinClientDistOps.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDISTOPS_HPP_
-#define THINCLIENTDISTOPS_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -905,4 +908,5 @@ void runDistOpsDontUpdateLocatorList() {
   CALL_TASK(CloseLocator1);
 }
 
-#endif /* THINCLIENTDISTOPS_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS_H_

--- a/src/cppcache/integration-test/ThinClientDistOps2.hpp
+++ b/src/cppcache/integration-test/ThinClientDistOps2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef THINCLIENTDISTOPS2_HPP_
-#define THINCLIENTDISTOPS2_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -381,4 +384,5 @@ DUNIT_TASK_DEFINITION(SERVER2, CloseServer2)
   }
 END_TASK_DEFINITION
 
-#endif /* THINCLIENTDISTOPS2_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDISTOPS2_H_

--- a/src/cppcache/integration-test/ThinClientDurable.hpp
+++ b/src/cppcache/integration-test/ThinClientDurable.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLE_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLE_HPP_
-#define THINCLIENTDURABLE_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -491,4 +494,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServers)
   }
 END_TASK_DEFINITION
 
-#endif /* THINCLIENTDURABLE_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLE_H_

--- a/src/cppcache/integration-test/ThinClientDurableConnect.hpp
+++ b/src/cppcache/integration-test/ThinClientDurableConnect.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLECONNECT_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLECONNECT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLECONNECT_HPP_
-#define THINCLIENTDURABLECONNECT_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -349,4 +352,5 @@ void doThinClientDurableConnect(bool poolConfig = true,
   CALL_TASK(CloseLocator);
 }
 
-#endif /* THINCLIENTDURABLECONNECT_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLECONNECT_H_

--- a/src/cppcache/integration-test/ThinClientDurableFailover.hpp
+++ b/src/cppcache/integration-test/ThinClientDurableFailover.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLEFAILOVER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLEFAILOVER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLEFAILOVER_HPP_
-#define THINCLIENTDURABLEFAILOVER_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -410,4 +413,5 @@ void doThinClientDurableFailoverClientClosedRedundancy() {
   CALL_TASK(CloseLocator);
 }
 
-#endif /* THINCLIENTDURABLEFAILOVER_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLEFAILOVER_H_

--- a/src/cppcache/integration-test/ThinClientDurableInit.hpp
+++ b/src/cppcache/integration-test/ThinClientDurableInit.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINIT_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINIT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLEINIT_HPP_
-#define THINCLIENTDURABLEINIT_HPP_
 
 bool isLocalServer = false;
 
@@ -107,4 +110,5 @@ void initClientAndTwoRegionsAndTwoPools(int ClientIdx, int redundancy,
     LOG("Exception occured while sending readyForEvents");
   }
 }
-#endif /* THINCLIENTDURABLEINIT_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINIT_H_

--- a/src/cppcache/integration-test/ThinClientDurableInterest.hpp
+++ b/src/cppcache/integration-test/ThinClientDurableInterest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINTEREST_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINTEREST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLEINTEREST_HPP_
-#define THINCLIENTDURABLEINTEREST_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -360,4 +363,5 @@ DUNIT_TASK_DEFINITION(SERVER1, closeServer)
   }
 END_TASK_DEFINITION
 
-#endif /* THINCLIENTDURABLEINTEREST_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLEINTEREST_H_

--- a/src/cppcache/integration-test/ThinClientDurableReconnect.hpp
+++ b/src/cppcache/integration-test/ThinClientDurableReconnect.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTDURABLERECONNECT_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTDURABLERECONNECT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTDURABLERECONNECT_HPP_
-#define THINCLIENTDURABLERECONNECT_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -167,4 +170,5 @@ void doThinClientDurableReconnect() {
   closeLocator();
 }
 
-#endif /* THINCLIENTDURABLERECONNECT_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTDURABLERECONNECT_H_

--- a/src/cppcache/integration-test/ThinClientFailover.hpp
+++ b/src/cppcache/integration-test/ThinClientFailover.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -418,3 +423,5 @@ void runThinClientFailover(bool isSticky = false) {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER_H_

--- a/src/cppcache/integration-test/ThinClientFailover2.hpp
+++ b/src/cppcache/integration-test/ThinClientFailover2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -542,3 +547,5 @@ void runThinClientFailover2() {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER2_H_

--- a/src/cppcache/integration-test/ThinClientFailover3.hpp
+++ b/src/cppcache/integration-test/ThinClientFailover3.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER3_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER3_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -367,3 +372,5 @@ DUNIT_TASK_DEFINITION(SERVER2, CloseServer2and3)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVER3_H_

--- a/src/cppcache/integration-test/ThinClientFailoverInterest.hpp
+++ b/src/cppcache/integration-test/ThinClientFailoverInterest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -422,3 +427,5 @@ void runThinClientFailoverInterest() {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST_H_

--- a/src/cppcache/integration-test/ThinClientFailoverInterest2.hpp
+++ b/src/cppcache/integration-test/ThinClientFailoverInterest2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -451,3 +456,5 @@ void runThinClientFailoverInterest2() {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTEREST2_H_

--- a/src/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
+++ b/src/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTERESTALLWITHCACHE_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTERESTALLWITHCACHE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -514,3 +519,5 @@ DUNIT_TASK_DEFINITION(SERVER2, CloseServer2)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERINTERESTALLWITHCACHE_H_

--- a/src/cppcache/integration-test/ThinClientFailoverRegex.hpp
+++ b/src/cppcache/integration-test/ThinClientFailoverRegex.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERREGEX_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERREGEX_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -501,3 +506,5 @@ void runThinClientFailOverRegex() {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTFAILOVERREGEX_H_

--- a/src/cppcache/integration-test/ThinClientGatewayTest.hpp
+++ b/src/cppcache/integration-test/ThinClientGatewayTest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTGATEWAYTEST_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTGATEWAYTEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef THINCLIENTGATEWAYTEST_HPP_
-#define THINCLIENTGATEWAYTEST_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -186,4 +189,5 @@ void runListenerInit(bool poolConfig = true, bool isLocator = true) {
   CALL_TASK(StopLocator1);
   CALL_TASK(StopLocator2);
 }
-#endif /*THINCLIENTGATEWAYTEST_HPP_*/
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTGATEWAYTEST_H_

--- a/src/cppcache/integration-test/ThinClientHeapLRU.hpp
+++ b/src/cppcache/integration-test/ThinClientHeapLRU.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTHEAPLRU_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTHEAPLRU_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTHEAPLRU_HPP_
-#define THINCLIENTHEAPLRU_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -251,4 +254,5 @@ void runHeapLRU(bool poolConfig = true, bool isLocator = true) {
     CALL_TASK(CloseLocator1);
   }
 }
-#endif /* THINCLIENTHEAPLRU_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTHEAPLRU_H_

--- a/src/cppcache/integration-test/ThinClientHelper.hpp
+++ b/src/cppcache/integration-test/ThinClientHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTHELPER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_THINCLIENTHELPER_HPP
-#define TEST_THINCLIENTHELPER_HPP
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <ace/OS.h>
@@ -702,4 +705,5 @@ class RegionOperations {
   RegionPtr m_regionPtr;
 };
 
-#endif  // TEST_THINCLIENTHELPER_HPP
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTHELPER_H_

--- a/src/cppcache/integration-test/ThinClientInterest1.hpp
+++ b/src/cppcache/integration-test/ThinClientInterest1.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTEREST1_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTEREST1_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -101,3 +106,5 @@ DUNIT_TASK_DEFINITION(SERVER1, StopServer)
     LOG("SERVER stopped");
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTEREST1_H_

--- a/src/cppcache/integration-test/ThinClientInterest2.hpp
+++ b/src/cppcache/integration-test/ThinClientInterest2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTEREST2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTEREST2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -92,3 +97,5 @@ DUNIT_TASK_DEFINITION(SERVER1, StopServer)
     LOG("SERVER stopped");
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTEREST2_H_

--- a/src/cppcache/integration-test/ThinClientInterest3.hpp
+++ b/src/cppcache/integration-test/ThinClientInterest3.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -171,3 +176,5 @@ DUNIT_TASK_DEFINITION(SERVER1, StopServer)
     LOG("SERVER stopped");
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3_H_

--- a/src/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
+++ b/src/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3CACHELESS_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3CACHELESS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -144,3 +149,5 @@ DUNIT_TASK_DEFINITION(SERVER1, StopServer)
     LOG("SERVER stopped");
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTEREST3CACHELESS_H_

--- a/src/cppcache/integration-test/ThinClientInterestList.hpp
+++ b/src/cppcache/integration-test/ThinClientInterestList.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -414,3 +419,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST_H_

--- a/src/cppcache/integration-test/ThinClientInterestList2.hpp
+++ b/src/cppcache/integration-test/ThinClientInterestList2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -400,3 +405,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTINTERESTLIST2_H_

--- a/src/cppcache/integration-test/ThinClientListenerInit.hpp
+++ b/src/cppcache/integration-test/ThinClientListenerInit.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTLISTENERINIT_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTLISTENERINIT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTDISTOPS_HPP_
-#define THINCLIENTDISTOPS_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -250,4 +253,5 @@ DUNIT_TASK_DEFINITION(CLIENT1, CloseCache1)
   { cleanProc(); }
 END_TASK_DEFINITION
 
-#endif /*THINCLIENTLISTENERINIT_HPP_*/
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTLISTENERINIT_H_

--- a/src/cppcache/integration-test/ThinClientListenerWriter.hpp
+++ b/src/cppcache/integration-test/ThinClientListenerWriter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTLISTENERWRITER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTLISTENERWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTLISTENERWRITER_HPP_
-#define THINCLIENTLISTENERWRITER_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -500,4 +503,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
   }
 END_TASK_DEFINITION
 
-#endif /*THINCLIENTLISTENERWRITER_HPP_*/
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTLISTENERWRITER_H_

--- a/src/cppcache/integration-test/ThinClientLocalCacheLoader.hpp
+++ b/src/cppcache/integration-test/ThinClientLocalCacheLoader.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTLOCALCACHELOADER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTLOCALCACHELOADER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTCACHELOADER_HPP_
-#define THINCLIENTCACHELOADER_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -261,4 +264,5 @@ void runCacheLoaderTest() {
   CALL_TASK(CloseCache1);
   CALL_TASK(StopServer)
 }
-#endif /*THINCLIENTCACHELOADER_HPP_*/
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTLOCALCACHELOADER_H_

--- a/src/cppcache/integration-test/ThinClientNotification.hpp
+++ b/src/cppcache/integration-test/ThinClientNotification.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTNOTIFICATION_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTNOTIFICATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -488,3 +493,5 @@ void doThinClientNotification() {
   CALL_TASK(CloseServer1);
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTNOTIFICATION_H_

--- a/src/cppcache/integration-test/ThinClientPdxSerializer.hpp
+++ b/src/cppcache/integration-test/ThinClientPdxSerializer.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -378,3 +383,5 @@ DUNIT_TASK_DEFINITION(LOCATOR, CloseLocator)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZER_H_

--- a/src/cppcache/integration-test/ThinClientPdxSerializers.hpp
+++ b/src/cppcache/integration-test/ThinClientPdxSerializers.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZERS_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZERS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __PDXSERIALIZERS__
-#define __PDXSERIALIZERS__
 
 static const char *CLASSNAME1 = "PdxTests.PdxType";
 static const char *CLASSNAME2 = "PdxTests.Address";
@@ -295,4 +298,5 @@ class TestPdxSerializer : public PdxSerializer {
   }
 };
 
-#endif  // __PDXSERIALIZERS__
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPDXSERIALIZERS_H_

--- a/src/cppcache/integration-test/ThinClientPutAll.hpp
+++ b/src/cppcache/integration-test/ThinClientPutAll.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPUTALL_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPUTALL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef THINCLIENTPUTALL_HPP_
-#define THINCLIENTPUTALL_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -835,4 +838,5 @@ void runPutAll1(bool concurrencyCheckEnabled = true) {
   CALL_TASK(CloseServer2);
   CALL_TASK(CloseLocator1);
 }
-#endif /* THINCLIENTPUTALL_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPUTALL_H_

--- a/src/cppcache/integration-test/ThinClientPutAllTimeout.hpp
+++ b/src/cppcache/integration-test/ThinClientPutAllTimeout.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPUTALLTIMEOUT_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPUTALLTIMEOUT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -241,3 +246,5 @@ DUNIT_TASK_DEFINITION(SERVER1, StopServer)
     LOG("SERVER stopped");
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPUTALLTIMEOUT_H_

--- a/src/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
+++ b/src/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPUTALLWITHCALLBACK_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPUTALLWITHCALLBACK_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef ThinClientPutAllWITHCALLBACK_HPP_
-#define ThinClientPutAllWITHCALLBACK_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -795,4 +798,5 @@ DUNIT_TASK_DEFINITION(SERVER2, CloseServer2)
   }
 END_TASK_DEFINITION
 
-#endif /* ThinClientPutAllWITHCALLBACK_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPUTALLWITHCALLBACK_H_

--- a/src/cppcache/integration-test/ThinClientPutGetAll.hpp
+++ b/src/cppcache/integration-test/ThinClientPutGetAll.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTPUTGETALL_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTPUTGETALL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef THINCLIENTPUTGETALL_HPP_
-#define THINCLIENTPUTGETALL_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -609,4 +612,5 @@ void runPutGetAll() {
 
   CALL_TASK(CloseLocator1);
 }
-#endif /* THINCLIENTPUTGETALL_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTPUTGETALL_H_

--- a/src/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
+++ b/src/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTRIWITHLOCALREGIONDESTROY_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTRIWITHLOCALREGIONDESTROY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -494,3 +499,5 @@ void testSubregionForLocalRegionDestroy() {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTRIWITHLOCALREGIONDESTROY_H_

--- a/src/cppcache/integration-test/ThinClientRegex.hpp
+++ b/src/cppcache/integration-test/ThinClientRegex.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTREGEX_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTREGEX_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -419,3 +424,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTREGEX_H_

--- a/src/cppcache/integration-test/ThinClientRegex2.hpp
+++ b/src/cppcache/integration-test/ThinClientRegex2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTREGEX2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTREGEX2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -456,3 +461,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTREGEX2_H_

--- a/src/cppcache/integration-test/ThinClientRegex3.hpp
+++ b/src/cppcache/integration-test/ThinClientRegex3.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTREGEX3_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTREGEX3_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -407,3 +412,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTREGEX3_H_

--- a/src/cppcache/integration-test/ThinClientRemoveAll.hpp
+++ b/src/cppcache/integration-test/ThinClientRemoveAll.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTREMOVEALL_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTREMOVEALL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef THINCLIENTREMOVEALL_HPP_
-#define THINCLIENTREMOVEALL_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -422,4 +425,5 @@ DUNIT_TASK_DEFINITION(SERVER2, CloseServer2)
   }
 END_TASK_DEFINITION
 
-#endif /* THINCLIENTREMOVEALL_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTREMOVEALL_H_

--- a/src/cppcache/integration-test/ThinClientSSL.hpp
+++ b/src/cppcache/integration-test/ThinClientSSL.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSSL_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTSSL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -500,3 +505,5 @@ void doThinClientSSL(bool poolConfig = true, bool poolLocators = true) {
 
   CALL_TASK(CloseLocator1_With_SSL);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTSSL_H_

--- a/src/cppcache/integration-test/ThinClientSSLWithPassword.hpp
+++ b/src/cppcache/integration-test/ThinClientSSLWithPassword.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSSLWITHPASSWORD_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTSSLWITHPASSWORD_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -514,3 +519,5 @@ void doThinClientSSLWithPassword() {
 
   CALL_TASK(CloseLocator1_With_SSL);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTSSLWITHPASSWORD_H_

--- a/src/cppcache/integration-test/ThinClientSecurity.hpp
+++ b/src/cppcache/integration-test/ThinClientSecurity.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSECURITY_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTSECURITY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: vrao
  */
 
-#ifndef THINCLIENTSECURITY_HPP_
-#define THINCLIENTSECURITY_HPP_
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -76,4 +79,5 @@ RegionServicePtr getVirtualCache(PropertiesPtr creds, PoolPtr pool) {
   return cachePtr->createAuthenticatedView(creds, pool->getName());
 }
 
-#endif /* THINCLIENTSECURITY_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTSECURITY_H_

--- a/src/cppcache/integration-test/ThinClientSecurityHelper.hpp
+++ b/src/cppcache/integration-test/ThinClientSecurityHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -253,3 +258,5 @@ class putThread : public ACE_Task_Base {
   bool m_regInt;
   int m_waitTime;
 };
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_

--- a/src/cppcache/integration-test/ThinClientTXFailover.hpp
+++ b/src/cppcache/integration-test/ThinClientTXFailover.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTTXFAILOVER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTTXFAILOVER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -424,3 +429,5 @@ void runThinClientFailover(bool isSticky = false) {
 
   CALL_TASK(CloseLocator1);
 }
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTTXFAILOVER_H_

--- a/src/cppcache/integration-test/ThinClientTasks_C2S2.hpp
+++ b/src/cppcache/integration-test/ThinClientTasks_C2S2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTTASKS_C2S2_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTTASKS_C2S2_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTTASKS_C2S2_HPP_
-#define THINCLIENTTASKS_C2S2_HPP_
 
 // define our own names for the 4 test processes
 #define PROCESS1 s1p1
@@ -91,4 +94,5 @@ void startServer() { CALL_TASK(startServerWithLocator); }
 
 void closeLocator() { CALL_TASK(CloseLocator); }
 
-#endif /* THINCLIENTTASKS_C2S2_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTTASKS_C2S2_H_

--- a/src/cppcache/integration-test/ThinClientTransactions.hpp
+++ b/src/cppcache/integration-test/ThinClientTransactions.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONS_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTTRANSACTIONS_HPP_
-#define THINCLIENTTRANSACTIONS_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -1107,4 +1110,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
   }
 END_TASK_DEFINITION
 
-#endif /* THINCLIENTTRANSACTIONS_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONS_H_

--- a/src/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/src/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONSXA_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONSXA_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef THINCLIENTTRANSACTIONS_HPP_
-#define THINCLIENTTRANSACTIONS_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -1163,4 +1166,5 @@ void runTransactionOps(bool poolConfig = true, bool isLocator = true,
   CALL_TASK(CloseLocator1);
 }
 
-#endif /* THINCLIENTTRANSACTIONS_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTTRANSACTIONSXA_H_

--- a/src/cppcache/integration-test/ThinClientVersionedOps.hpp
+++ b/src/cppcache/integration-test/ThinClientVersionedOps.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTVERSIONEDOPS_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTVERSIONEDOPS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -581,3 +586,5 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServers_With_Locator)
     }
   }
 END_TASK_DEFINITION
+
+#endif // GEODE_INTEGRATION_TEST_THINCLIENTVERSIONEDOPS_H_

--- a/src/cppcache/integration-test/TimeBomb.hpp
+++ b/src/cppcache/integration-test/TimeBomb.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_TIMEBOMB_H_
+#define GEODE_INTEGRATION_TEST_TIMEBOMB_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _TEST_TIMEBOMB_HPP_
-#define _TEST_TIMEBOMB_HPP_
 
 #include <ace/Task.h>
 #include <ace/OS.h>
@@ -108,4 +111,5 @@ class TimeBomb : public ACE_Task_Base {
   ~TimeBomb() {}
 };
 
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_TIMEBOMB_H_

--- a/src/cppcache/integration-test/fw_dunit.hpp
+++ b/src/cppcache/integration-test/fw_dunit.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_FW_DUNIT_H_
+#define GEODE_INTEGRATION_TEST_FW_DUNIT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DUNIT_FW_DUNIT_H__
-#define __DUNIT_FW_DUNIT_H__
 
 /***
 
@@ -362,4 +365,5 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) { return dunit::dmain(argc, argv); }
 
 #include "no_cout.hpp"
 
-#endif  // __DUNIT_FW_DUNIT_H__
+
+#endif // GEODE_INTEGRATION_TEST_FW_DUNIT_H_

--- a/src/cppcache/integration-test/fw_helper.hpp
+++ b/src/cppcache/integration-test/fw_helper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_FW_HELPER_H_
+#define GEODE_INTEGRATION_TEST_FW_HELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -67,8 +72,6 @@ fwtest_Name is defined for you, as a (const char *) with the value given to
 BEGIN_TEST.
 
 */
-#ifndef _FW_HELPER_HPP_
-#define _FW_HELPER_HPP_
 
 #ifdef WIN32
 // Must include WinSock2 so winsock.h doesn't get included.
@@ -228,4 +231,5 @@ int main(int argc, char* argv[])
   }                 \
   a_##x;
 
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_FW_HELPER_H_

--- a/src/cppcache/integration-test/fw_perf.hpp
+++ b/src/cppcache/integration-test/fw_perf.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_FW_PERF_H_
+#define GEODE_INTEGRATION_TEST_FW_PERF_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _FWPERF_H_
-#define _FWPERF_H_
 
 /**
 
@@ -243,4 +246,5 @@ class Thread : public ACE_Task_Base {
 //};
 }  // namespace perf
 
-#endif
+
+#endif // GEODE_INTEGRATION_TEST_FW_PERF_H_

--- a/src/cppcache/integration-test/fw_spawn.hpp
+++ b/src/cppcache/integration-test/fw_spawn.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_FW_SPAWN_H_
+#define GEODE_INTEGRATION_TEST_FW_SPAWN_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TEST_FW_SPAWN_H__
-#define __TEST_FW_SPAWN_H__
 // Spawn.cpp,v 1.4 2004/01/07 22:40:16 shuston Exp
 
 // @TODO, this out this include list..
@@ -123,4 +126,5 @@
 
 };  // namespace dunit.
 
-#endif  // __TEST_FW_SPAWN_H__
+
+#endif // GEODE_INTEGRATION_TEST_FW_SPAWN_H_

--- a/src/cppcache/integration-test/locator_globals.hpp
+++ b/src/cppcache/integration-test/locator_globals.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_LOCATOR_GLOBALS_H_
+#define GEODE_INTEGRATION_TEST_LOCATOR_GLOBALS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef CPPCACHE_INTEGRATION_TEST_LOCATOR_GLOBALS_HPP_
-#define CPPCACHE_INTEGRATION_TEST_LOCATOR_GLOBALS_HPP_
 
 static int numberOfLocators = 1;
 bool isLocalServer = false;
@@ -24,4 +27,5 @@ bool isLocator = false;
 const char* locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
-#endif /* CPPCACHE_INTEGRATION_TEST_LOCATOR_GLOBALS_HPP_ */
+
+#endif // GEODE_INTEGRATION_TEST_LOCATOR_GLOBALS_H_

--- a/src/cppcache/integration-test/no_cout.hpp
+++ b/src/cppcache/integration-test/no_cout.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_NO_COUT_H_
+#define GEODE_INTEGRATION_TEST_NO_COUT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -74,3 +79,5 @@ extern NOCout::FLAGS flush;
 extern NOCout::FLAGS hex;
 extern NOCout::FLAGS dec;
 }  // namespace test
+
+#endif // GEODE_INTEGRATION_TEST_NO_COUT_H_

--- a/src/cppcache/integration-test/testCache.cpp
+++ b/src/cppcache/integration-test/testCache.cpp
@@ -26,14 +26,12 @@ using namespace apache::geode::client;
 using namespace test;
 BEGIN_TEST(CacheFunction)
   char* host_name = (char*)"TESTCACHE";
-  char* host = NULL;
   uint16_t port ATTR_UNUSED = 0;
   const uint32_t totalSubRegions = 3;
   char* regionName = (char*)"TESTCACHE_ROOT_REGION";
   char* subRegionName1 = (char*)"TESTCACHE_SUB_REGION1";
   char* subRegionName2 = (char*)"TESTCACHE_SUB_REGION2";
   char* subRegionName21 = (char*)"TESTCACHE_SUB_REGION21";
-  bool exception_occured = false;
   CachePtr cptr;
   if (cptr != NULLPTR) {
     cout << "cptr is not null" << endl;

--- a/src/cppcache/integration-test/testThinClientHAFailover.cpp
+++ b/src/cppcache/integration-test/testThinClientHAFailover.cpp
@@ -302,7 +302,6 @@ const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
 const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
 
 const bool USE_ACK = true;
-const bool NO_ACK = false;
 void initClientAndRegion(int redundancy) {
   PropertiesPtr pp = Properties::create();
   g_redundancyLevel = redundancy;

--- a/src/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
+++ b/src/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
@@ -281,7 +281,6 @@ const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
 const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
 
 const bool USE_ACK = true;
-const bool NO_ACK = false;
 void initClientAndRegion(int redundancy) {
   g_redundancyLevel = redundancy;
   PropertiesPtr pp = Properties::create();

--- a/src/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
+++ b/src/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
@@ -286,7 +286,6 @@ const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
 const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
 
 const bool USE_ACK = true;
-const bool NO_ACK = false;
 #include "ThinClientTasks_C2S2.hpp"
 void createCommRegions(int redundancy) {
   PropertiesPtr pp = Properties::create();

--- a/src/cppcache/integration-test/testThinClientPdxEnum.cpp
+++ b/src/cppcache/integration-test/testThinClientPdxEnum.cpp
@@ -14,13 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* testThinClientPdxEnum.cpp
-*
-*/
-
-#ifndef TEST_THIN_CLIENT_PDX_ENUM_HPP_
-#define TEST_THIN_CLIENT_PDX_ENUM_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -181,5 +174,3 @@ DUNIT_MAIN
     CALL_TASK(CloseLocator1)
   }
 END_MAIN
-
-#endif /* TEST_THIN_CLIENT_PDX_ENUM_HPP_ */

--- a/src/cppcache/integration-test/testThinClientPdxInstance.cpp
+++ b/src/cppcache/integration-test/testThinClientPdxInstance.cpp
@@ -14,13 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* testThinClientPdxInstance.cpp
-*
-*/
-
-#ifndef TESTTHINCLIENTPDXINSTANCE_HPP_
-#define TESTTHINCLIENTPDXINSTANCE_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -2754,5 +2747,3 @@ DUNIT_MAIN
         2);  // Locator, caching = false, PdxReadSerialized = true
   }
 END_MAIN
-
-#endif /* TESTTHINCLIENTPDXINSTANCE_HPP_ */

--- a/src/cppcache/integration-test/testThinClientRemoveOps.cpp
+++ b/src/cppcache/integration-test/testThinClientRemoveOps.cpp
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TESTTHINCLIENTREMOVEOPS_HPP_
-#define TESTTHINCLIENTREMOVEOPS_HPP_
 
 #include "fw_dunit.hpp"
 #include <gfcpp/GeodeCppCache.hpp>
@@ -1737,5 +1735,3 @@ DUNIT_MAIN
     runRemoveOps1();
   }
 END_MAIN
-
-#endif /* TESTTHINCLIENTREMOVEOPS_HPP_ */

--- a/src/cppcache/integration-test/testUtils.hpp
+++ b/src/cppcache/integration-test/testUtils.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_TESTUTILS_H_
+#define GEODE_INTEGRATION_TEST_TESTUTILS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __UNIT_TEST_TEST_UTILS__
-#define __UNIT_TEST_TEST_UTILS__
 #include <gfcpp/GeodeCppCache.hpp>
 
 /* use CacheHelper to gain the impl pointer from cache or region object
@@ -185,4 +188,5 @@ class TestUtils {
   }
 };
 }  // namespace unitTests
-#endif  // define __UNIT_TEST_TEST_UTILS__
+
+#endif // GEODE_INTEGRATION_TEST_TESTUTILS_H_

--- a/src/cppcache/src/AdminRegion.hpp
+++ b/src/cppcache/src/AdminRegion.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_ADMINREGION_H_
+#define GEODE_ADMINREGION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _ADMIN_REGION_HPP_INCLUDED_
-#define _ADMIN_REGION_HPP_INCLUDED_
 
 #include <gfcpp/gf_types.hpp>
 #include "ThinClientCacheDistributionManager.hpp"
@@ -80,4 +83,5 @@ typedef SharedPtr<AdminRegion> AdminRegionPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_ADMINREGION_H_

--- a/src/cppcache/src/AppDomainContext.hpp
+++ b/src/cppcache/src/AppDomainContext.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_APPDOMAINCONTEXT_H_
+#define GEODE_APPDOMAINCONTEXT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __gemfire_AppDomainContext_h__
-#define __gemfire_AppDomainContext_h__
 
 #include <functional>
 
@@ -37,4 +39,4 @@ extern AppDomainContext::factory createAppDomainContext;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __gemfire_AppDomainContext_h__
+#endif // GEODE_APPDOMAINCONTEXT_H_

--- a/src/cppcache/src/AtomicInc.hpp
+++ b/src/cppcache/src/AtomicInc.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_ATOMICINC_H_
+#define GEODE_ATOMICINC_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_IMPL_ATOMICINC_HPP_
-#define _GEMFIRE_IMPL_ATOMICINC_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 
@@ -84,4 +87,4 @@ class CPPCACHE_EXPORT AtomicInc {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_ATOMICINC_H_

--- a/src/cppcache/src/AutoDelete.hpp
+++ b/src/cppcache/src/AutoDelete.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_AUTODELETE_HPP_
-#define _GEMFIRE_AUTODELETE_HPP_
+#pragma once
+
+#ifndef GEODE_AUTODELETE_H_
+#define GEODE_AUTODELETE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -68,4 +70,4 @@ class DeleteArray {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // #ifndef _GEMFIRE_AUTODELETE_HPP_
+#endif // GEODE_AUTODELETE_H_

--- a/src/cppcache/src/BucketServerLocation.hpp
+++ b/src/cppcache/src/BucketServerLocation.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_BUCKETSERVERLOCATION_H_
+#define GEODE_BUCKETSERVERLOCATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __BUCKET_SERVER_LOCATION__
-#define __BUCKET_SERVER_LOCATION__
 
 #include "ServerLocation.hpp"
 #include <string>
@@ -174,4 +177,5 @@ class BucketServerLocation : public ServerLocation {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_BUCKETSERVERLOCATION_H_

--- a/src/cppcache/src/CacheImpl.hpp
+++ b/src/cppcache/src/CacheImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEIMPL_H__
-#define __GEMFIRE_CACHEIMPL_H__
+#pragma once
+
+#ifndef GEODE_CACHEIMPL_H_
+#define GEODE_CACHEIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
 
@@ -336,4 +340,5 @@ class CPPCACHE_EXPORT CacheImpl : private NonCopyable, private NonAssignable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHEIMPL_H__
+
+#endif // GEODE_CACHEIMPL_H_

--- a/src/cppcache/src/CachePerfStats.hpp
+++ b/src/cppcache/src/CachePerfStats.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CACHEPERFSTATS_H_
+#define GEODE_CACHEPERFSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_CACHEPERFSTATS_H__
-#define __GEMFIRE_CACHEPERFSTATS_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
@@ -360,4 +362,4 @@ class CPPCACHE_EXPORT CachePerfStats {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_CACHEPERFSTATS_H__
+#endif // GEODE_CACHEPERFSTATS_H_

--- a/src/cppcache/src/CacheRegionHelper.hpp
+++ b/src/cppcache/src/CacheRegionHelper.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_IMPL_CACHEHELPER_H__
-#define __GEMFIRE_IMPL_CACHEHELPER_H__
+#pragma once
+
+#ifndef GEODE_CACHEREGIONHELPER_H_
+#define GEODE_CACHEREGIONHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -47,4 +50,5 @@ class CacheRegionHelper {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_IMPL_CACHEHELPER_H__
+
+#endif // GEODE_CACHEREGIONHELPER_H_

--- a/src/cppcache/src/CacheTransactionManagerImpl.hpp
+++ b/src/cppcache/src/CacheTransactionManagerImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CACHETRANSACTIONMANAGERIMPL_H_
+#define GEODE_CACHETRANSACTIONMANAGERIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef CACHETRANSACTIONMANAGERIMPL_H_
-#define CACHETRANSACTIONMANAGERIMPL_H_
 
 #include <gfcpp/CacheTransactionManager.hpp>
 #include <gfcpp/HashSetOfSharedBase.hpp>
@@ -108,4 +111,5 @@ class CacheTransactionManagerImpl
 }  // namespace geode
 }  // namespace apache
 
-#endif /* CACHETRANSACTIONMANAGERIMPL_H_ */
+
+#endif // GEODE_CACHETRANSACTIONMANAGERIMPL_H_

--- a/src/cppcache/src/CacheXml.hpp
+++ b/src/cppcache/src/CacheXml.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEXML_HPP__
-#define __GEMFIRE_CACHEXML_HPP__
+#pragma once
+
+#ifndef GEODE_CACHEXML_H_
+#define GEODE_CACHEXML_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -213,4 +216,5 @@ class CPPCACHE_EXPORT CacheXml {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHEXML_HPP__
+
+#endif // GEODE_CACHEXML_H_

--- a/src/cppcache/src/CacheXmlCreation.hpp
+++ b/src/cppcache/src/CacheXmlCreation.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_CACHEXMLCREATION_HPP_
-#define _GEMFIRE_CACHEXMLCREATION_HPP_
+#pragma once
+
+#ifndef GEODE_CACHEXMLCREATION_H_
+#define GEODE_CACHEXMLCREATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -93,4 +96,4 @@ class CPPCACHE_EXPORT CacheXmlCreation {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // #ifndef  _GEMFIRE_CACHEXMLCREATION_HPP_
+#endif // GEODE_CACHEXMLCREATION_H_

--- a/src/cppcache/src/CacheXmlParser.hpp
+++ b/src/cppcache/src/CacheXmlParser.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CACHEXMLPARSER_HPP__
-#define __GEMFIRE_CACHEXMLPARSER_HPP__
+#pragma once
+
+#ifndef GEODE_CACHEXMLPARSER_H_
+#define GEODE_CACHEXMLPARSER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -153,4 +156,6 @@ class CPPCACHE_EXPORT CacheXmlParser : public CacheXml {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_CACHEXMLPARSER_HPP__
+
+
+#endif // GEODE_CACHEXMLPARSER_H_

--- a/src/cppcache/src/CacheableObjectPartList.hpp
+++ b/src/cppcache/src/CacheableObjectPartList.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_CACHEABLEOBJECTPARTLIST_HPP_
-#define _GEMFIRE_CACHEABLEOBJECTPARTLIST_HPP_
+#pragma once
+
+#ifndef GEODE_CACHEABLEOBJECTPARTLIST_H_
+#define GEODE_CACHEABLEOBJECTPARTLIST_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -144,4 +146,4 @@ typedef SharedPtr<CacheableObjectPartList> CacheableObjectPartListPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_CACHEABLEOBJECTPARTLIST_HPP_
+#endif // GEODE_CACHEABLEOBJECTPARTLIST_H_

--- a/src/cppcache/src/CacheableToken.hpp
+++ b/src/cppcache/src/CacheableToken.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CACHEABLETOKEN_H_
+#define GEODE_CACHEABLETOKEN_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_CacheableToken_HPP_
-#define _GEMFIRE_CacheableToken_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cacheable.hpp>
@@ -130,4 +133,4 @@ class CPPCACHE_EXPORT CacheableToken : public Cacheable {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_CACHEABLETOKEN_H_

--- a/src/cppcache/src/CachedDeserializableHelper.hpp
+++ b/src/cppcache/src/CachedDeserializableHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CACHEDDESERIALIZABLEHELPER_H_
+#define GEODE_CACHEDDESERIALIZABLEHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CACHEDDESERIALIZABLEHELPER_HPP_
-#define CACHEDDESERIALIZABLEHELPER_HPP_
 
 #include <gfcpp/Cacheable.hpp>
 #include <gfcpp/DataInput.hpp>
@@ -99,4 +102,5 @@ typedef SharedPtr<CachedDeserializableHelper> CachedDeserializableHelperPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // CACHEDDESERIALIZABLEHELPER_HPP_
+
+#endif // GEODE_CACHEDDESERIALIZABLEHELPER_H_

--- a/src/cppcache/src/ClientConnectionRequest.hpp
+++ b/src/cppcache/src/ClientConnectionRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTCONNECTIONREQUEST_H_
+#define GEODE_CLIENTCONNECTIONREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __CLIENT_CONNECTION_REQUEST__
-#define __CLIENT_CONNECTION_REQUEST__
 #include "ServerLocationRequest.hpp"
 #include "TcrEndpoint.hpp"
 #include <string>
@@ -65,4 +68,5 @@ class ClientConnectionRequest : public ServerLocationRequest {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_CLIENTCONNECTIONREQUEST_H_

--- a/src/cppcache/src/ClientConnectionResponse.hpp
+++ b/src/cppcache/src/ClientConnectionResponse.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTCONNECTIONRESPONSE_H_
+#define GEODE_CLIENTCONNECTIONRESPONSE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __CLIENT_CONNECTION_RESPONSE__
-#define __CLIENT_CONNECTION_RESPONSE__
 #include "ServerLocationResponse.hpp"
 #include "ServerLocation.hpp"
 #include <gfcpp/SharedPtr.hpp>
@@ -48,4 +51,5 @@ typedef SharedPtr<ClientConnectionResponse> ClientConnectionResponsePtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_CLIENTCONNECTIONRESPONSE_H_

--- a/src/cppcache/src/ClientHealthStats.hpp
+++ b/src/cppcache/src/ClientHealthStats.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTHEALTHSTATS_H_
+#define GEODE_CLIENTHEALTHSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _CLIENT_HEALTH_STATS_HPP_INCLUDED_
-#define _CLIENT_HEALTH_STATS_HPP_INCLUDED_
 
 #include <gfcpp/gf_types.hpp>
 #include <gfcpp/Serializable.hpp>
@@ -88,4 +91,5 @@ class ClientHealthStats : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // _CLIENT_HEALTH_STATS_HPP_INCLUDED_
+
+#endif // GEODE_CLIENTHEALTHSTATS_H_

--- a/src/cppcache/src/ClientMetadata.hpp
+++ b/src/cppcache/src/ClientMetadata.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTMETADATA_H_
+#define GEODE_CLIENTMETADATA_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CLIENT_METADATA
-#define CLIENT_METADATA
 
 #include <gfcpp/PartitionResolver.hpp>
 #include "ServerLocation.hpp"
@@ -105,4 +108,5 @@ class CPPCACHE_EXPORT ClientMetadata : public SharedBase, public NonAssignable {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_CLIENTMETADATA_H_

--- a/src/cppcache/src/ClientMetadataService.hpp
+++ b/src/cppcache/src/ClientMetadataService.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTMETADATASERVICE_H_
+#define GEODE_CLIENTMETADATASERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CLIENT_METADATA_SERVICE
-#define CLIENT_METADATA_SERVICE
 
 #include <ace/Task.h>
 #include "ClientMetadata.hpp"
@@ -207,4 +210,5 @@ class ClientMetadataService : public ACE_Task_Base,
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_CLIENTMETADATASERVICE_H_

--- a/src/cppcache/src/ClientProxyMembershipID.hpp
+++ b/src/cppcache/src/ClientProxyMembershipID.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTPROXYMEMBERSHIPID_H_
+#define GEODE_CLIENTPROXYMEMBERSHIPID_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __CLIENTPROXYMEMBERSHIPID_HPP__
-#define __CLIENTPROXYMEMBERSHIPID_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/DataOutput.hpp>
@@ -145,4 +148,5 @@ class ClientProxyMembershipID : public DSMemberForVersionStamp {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __CLIENTPROXYMEMBERSHIPID_HPP__
+
+#endif // GEODE_CLIENTPROXYMEMBERSHIPID_H_

--- a/src/cppcache/src/ClientReplacementRequest.hpp
+++ b/src/cppcache/src/ClientReplacementRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CLIENTREPLACEMENTREQUEST_H_
+#define GEODE_CLIENTREPLACEMENTREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __CLIENT_REPLACEMENT_REQUEST__
-#define __CLIENT_REPLACEMENT_REQUEST__
 #include "ServerLocationRequest.hpp"
 #include "ClientConnectionRequest.hpp"
 #include "TcrEndpoint.hpp"
@@ -43,4 +46,5 @@ class ClientReplacementRequest : public ClientConnectionRequest {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_CLIENTREPLACEMENTREQUEST_H_

--- a/src/cppcache/src/ConcurrentEntriesMap.hpp
+++ b/src/cppcache/src/ConcurrentEntriesMap.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CONCURRENTENTRIESMAP_H_
+#define GEODE_CONCURRENTENTRIESMAP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_CONCURRENTENTRIESMAP_H__
-#define __GEMFIRE_IMPL_CONCURRENTENTRIESMAP_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "EntriesMap.hpp"
@@ -166,4 +169,4 @@ class CPPCACHE_EXPORT ConcurrentEntriesMap : public EntriesMap {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_CONCURRENTENTRIESMAP_H__
+#endif // GEODE_CONCURRENTENTRIESMAP_H_

--- a/src/cppcache/src/Condition.hpp
+++ b/src/cppcache/src/Condition.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CONDITION_H_
+#define GEODE_CONDITION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_IMPL_CONDITION_HPP_
-#define _GEMFIRE_IMPL_CONDITION_HPP_ 1
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <ace/Condition_Recursive_Thread_Mutex.h>
@@ -74,4 +77,4 @@ class CPPCACHE_EXPORT Condition {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_CONDITION_H_

--- a/src/cppcache/src/ConnectCounter.hpp
+++ b/src/cppcache/src/ConnectCounter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CONNECTCOUNTER_H_
+#define GEODE_CONNECTCOUNTER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_IMPL_CONNECTCOUNTER_HPP_
-#define _GEMFIRE_IMPL_CONNECTCOUNTER_HPP_ 1
 
 #include <gfcpp/gfcpp_globals.hpp>
 
@@ -36,4 +39,4 @@ class CPPCACHE_EXPORT ConnectCounter {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_CONNECTCOUNTER_H_

--- a/src/cppcache/src/Connector.hpp
+++ b/src/cppcache/src/Connector.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CONNECTOR_H_
+#define GEODE_CONNECTOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __CONNECTOR_HPP__
-#define __CONNECTOR_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/ExceptionTypes.hpp>
@@ -105,4 +108,5 @@ class Connector {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __CONNECTOR_HPP__
+
+#endif // GEODE_CONNECTOR_H_

--- a/src/cppcache/src/CppCacheLibrary.hpp
+++ b/src/cppcache/src/CppCacheLibrary.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CPPCACHELIBRARY_H_
+#define GEODE_CPPCACHELIBRARY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_CPPCACHELIBRARY_H__
-#define __GEMFIRE_IMPL_CPPCACHELIBRARY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <string>
@@ -51,4 +54,4 @@ class CPPCACHE_EXPORT CppCacheLibrary {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_CPPCACHELIBRARY_H__
+#endif // GEODE_CPPCACHELIBRARY_H_

--- a/src/cppcache/src/CqAttributesImpl.hpp
+++ b/src/cppcache/src/CqAttributesImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_ATTRIBUTES_IMPL_H__
-#define __GEMFIRE_CQ_ATTRIBUTES_IMPL_H__
+#pragma once
+
+#ifndef GEODE_CQATTRIBUTESIMPL_H_
+#define GEODE_CQATTRIBUTESIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -76,4 +79,4 @@ class CPPCACHE_EXPORT CqAttributesImpl : public CqAttributes {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_ATTRIBUTES_IMPL_H__
+#endif // GEODE_CQATTRIBUTESIMPL_H_

--- a/src/cppcache/src/CqAttributesMutatorImpl.hpp
+++ b/src/cppcache/src/CqAttributesMutatorImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_IMPL_H__
-#define __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_IMPL_H__
+#pragma once
+
+#ifndef GEODE_CQATTRIBUTESMUTATORIMPL_H_
+#define GEODE_CQATTRIBUTESMUTATORIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -79,4 +82,4 @@ class CPPCACHE_EXPORT CqAttributesMutatorImpl : public CqAttributesMutator {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_ATTRIBUTES_MUTATOR_IMPL_H__
+#endif // GEODE_CQATTRIBUTESMUTATORIMPL_H_

--- a/src/cppcache/src/CqEventImpl.hpp
+++ b/src/cppcache/src/CqEventImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_EVENT_IMPL_H__
-#define __GEMFIRE_CQ_EVENT_IMPL_H__
+#pragma once
+
+#ifndef GEODE_CQEVENTIMPL_H_
+#define GEODE_CQEVENTIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -102,4 +105,4 @@ class CqEventImpl : public CqEvent {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_EVENT_IMPL_H__
+#endif // GEODE_CQEVENTIMPL_H_

--- a/src/cppcache/src/CqQueryImpl.hpp
+++ b/src/cppcache/src/CqQueryImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_QUERY_IMPL_H__
-#define __GEMFIRE_CQ_QUERY_IMPL_H__
+#pragma once
+
+#ifndef GEODE_CQQUERYIMPL_H_
+#define GEODE_CQQUERYIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -272,4 +275,4 @@ class CqQueryImpl : public CqQuery {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_QUERY_IMPL_H__
+#endif // GEODE_CQQUERYIMPL_H_

--- a/src/cppcache/src/CqQueryVsdStats.hpp
+++ b/src/cppcache/src/CqQueryVsdStats.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CQQUERYVSDSTATS_H_
+#define GEODE_CQQUERYVSDSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_CQ_QUERY_STATS_H__
-#define __GEMFIRE_CQ_QUERY_STATS_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
@@ -106,4 +109,4 @@ class CqQueryStatType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_CQ_QUERY_STATS_H__
+#endif // GEODE_CQQUERYVSDSTATS_H_

--- a/src/cppcache/src/CqService.hpp
+++ b/src/cppcache/src/CqService.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_CQ_SERVICE_H__
-#define __GEMFIRE_CQ_SERVICE_H__
+#pragma once
+
+#ifndef GEODE_CQSERVICE_H_
+#define GEODE_CQSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -261,4 +264,4 @@ typedef SharedPtr<CqService> CqServicePtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_CQ_SERVICE_H__
+#endif // GEODE_CQSERVICE_H_

--- a/src/cppcache/src/CqServiceVsdStats.hpp
+++ b/src/cppcache/src/CqServiceVsdStats.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CQSERVICEVSDSTATS_H_
+#define GEODE_CQSERVICEVSDSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_CQ_SERVICE_STATS_H__
-#define __GEMFIRE_CQ_SERVICE_STATS_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
@@ -143,4 +145,4 @@ class CqServiceStatType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_CQ_SERVICE_STATS_H__
+#endif // GEODE_CQSERVICEVSDSTATS_H_

--- a/src/cppcache/src/DSMemberForVersionStamp.hpp
+++ b/src/cppcache/src/DSMemberForVersionStamp.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_DSMEMBERFORVERSIONSTAMP_H_
+#define GEODE_DSMEMBERFORVERSIONSTAMP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DSMemberForVersionStamp_HPP__
-#define __DSMemberForVersionStamp_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/CacheableKey.hpp>
@@ -43,4 +46,5 @@ class DSMemberForVersionStamp : public CacheableKey {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __DSMemberForVersionStamp_HPP__
+
+#endif // GEODE_DSMEMBERFORVERSIONSTAMP_H_

--- a/src/cppcache/src/DiffieHellman.hpp
+++ b/src/cppcache/src/DiffieHellman.hpp
@@ -1,5 +1,8 @@
-#ifndef __DIFFIEHELLMAN__
-#define __DIFFIEHELLMAN__
+#pragma once
+
+#ifndef GEODE_DIFFIEHELLMAN_H_
+#define GEODE_DIFFIEHELLMAN_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -109,4 +112,5 @@ class DiffieHellman {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __DIFFIEHELLMAN__
+
+#endif // GEODE_DIFFIEHELLMAN_H_

--- a/src/cppcache/src/DiskStoreId.hpp
+++ b/src/cppcache/src/DiskStoreId.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_DISKSTOREID_H_
+#define GEODE_DISKSTOREID_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DiskStoreId_HPP__
-#define __DiskStoreId_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/DataInput.hpp>
@@ -111,4 +114,5 @@ class DiskStoreId : public DSMemberForVersionStamp {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __DiskStoreId_HPP__
+
+#endif // GEODE_DISKSTOREID_H_

--- a/src/cppcache/src/DiskVersionTag.hpp
+++ b/src/cppcache/src/DiskVersionTag.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_DISKVERSIONTAG_H_
+#define GEODE_DISKVERSIONTAG_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DISKVERSIONTAG_HPP__
-#define __DISKVERSIONTAG_HPP__
 
 #include "VersionTag.hpp"
 #include "GeodeTypeIdsImpl.hpp"
@@ -78,4 +81,5 @@ class DiskVersionTag : public VersionTag {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __DISKVERSIONTAG_HPP__
+
+#endif // GEODE_DISKVERSIONTAG_H_

--- a/src/cppcache/src/DistributedSystemImpl.hpp
+++ b/src/cppcache/src/DistributedSystemImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __IMPL_DISTRIBUTEDSYSTEM_H__
-#define __IMPL_DISTRIBUTEDSYSTEM_H__
+#pragma once
+
+#ifndef GEODE_DISTRIBUTEDSYSTEMIMPL_H_
+#define GEODE_DISTRIBUTEDSYSTEMIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -138,4 +141,5 @@ class CPPCACHE_EXPORT DistributedSystemImpl : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __IMPL_DISTRIBUTEDSYSTEM_H__
+
+#endif // GEODE_DISTRIBUTEDSYSTEMIMPL_H_

--- a/src/cppcache/src/EntriesMap.hpp
+++ b/src/cppcache/src/EntriesMap.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_ENTRIESMAP_H_
+#define GEODE_ENTRIESMAP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_ENTRIESMAP_H__
-#define __GEMFIRE_IMPL_ENTRIESMAP_H__
 
 // This needs to be ace free so that the region can include it.
 
@@ -175,4 +178,4 @@ class CPPCACHE_EXPORT EntriesMap {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_ENTRIESMAP_H__
+#endif // GEODE_ENTRIESMAP_H_

--- a/src/cppcache/src/EntriesMapFactory.hpp
+++ b/src/cppcache/src/EntriesMapFactory.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_ENTRIESMAPFACTORY_H_
+#define GEODE_ENTRIESMAPFACTORY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_ENTRIESMAPFACTORY_H__
-#define __GEMFIRE_IMPL_ENTRIESMAPFACTORY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "EntriesMap.hpp"
@@ -42,4 +45,4 @@ class CPPCACHE_EXPORT EntriesMapFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_ENTRIESMAPFACTORY_H__
+#endif // GEODE_ENTRIESMAPFACTORY_H_

--- a/src/cppcache/src/EntryExpiryHandler.hpp
+++ b/src/cppcache/src/EntryExpiryHandler.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_ENTRYEXPIRYTASK_H__
-#define _GEMFIRE_ENTRYEXPIRYTASK_H__
+#pragma once
+
+#ifndef GEODE_ENTRYEXPIRYHANDLER_H_
+#define GEODE_ENTRYEXPIRYHANDLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -73,4 +76,5 @@ class CPPCACHE_EXPORT EntryExpiryHandler : public ACE_Event_Handler {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef _GEMFIRE_ENTRYEXPIRYTASK_H__
+
+#endif // GEODE_ENTRYEXPIRYHANDLER_H_

--- a/src/cppcache/src/EnumInfo.hpp
+++ b/src/cppcache/src/EnumInfo.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_ENUMINFO_H_
+#define GEODE_ENUMINFO_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef ENUM_INFO_HPP
-#define ENUM_INFO_HPP
 
 #include <gfcpp/GeodeTypeIds.hpp>
 #include <gfcpp/CacheableString.hpp>
@@ -63,4 +66,5 @@ typedef SharedPtr<EnumInfo> EnumInfoPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ENUM_INFO_HPP
+
+#endif // GEODE_ENUMINFO_H_

--- a/src/cppcache/src/EventId.hpp
+++ b/src/cppcache/src/EventId.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_EVENTID_HPP_
-#define _GEMFIRE_EVENTID_HPP_
+#pragma once
+
+#ifndef GEODE_EVENTID_H_
+#define GEODE_EVENTID_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -151,4 +154,4 @@ class CPPCACHE_EXPORT EventId : public Cacheable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE_EVENTID_HPP_
+#endif // GEODE_EVENTID_H_

--- a/src/cppcache/src/EventIdMap.hpp
+++ b/src/cppcache/src/EventIdMap.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EVENTIDMAP_H_
+#define GEODE_EVENTIDMAP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __EVENT_ID_MAP_HPP__
-#define __EVENT_ID_MAP_HPP__
 
 #include <ace/ACE.h>
 #include <ace/Time_Value.h>
@@ -200,4 +203,5 @@ class CPPCACHE_EXPORT EventSequence : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __EVENT_ID_MAP_HPP__
+
+#endif // GEODE_EVENTIDMAP_H_

--- a/src/cppcache/src/EventType.hpp
+++ b/src/cppcache/src/EventType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EVENTTYPE_H_
+#define GEODE_EVENTTYPE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _EVENTTYPE_H__
-#define _EVENTTYPE_H__
 
 namespace apache {
 namespace geode {
@@ -43,4 +46,5 @@ enum RegionEventType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _EVENTTYPE_H__
+
+#endif // GEODE_EVENTTYPE_H_

--- a/src/cppcache/src/EvictionController.hpp
+++ b/src/cppcache/src/EvictionController.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EVICTIONCONTROLLER_H_
+#define GEODE_EVICTIONCONTROLLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _EVICTIONCONTROLLER_H__
-#define _EVICTIONCONTROLLER_H__
 
 #include <ace/ACE.h>
 #include <ace/OS.h>
@@ -118,4 +121,5 @@ class CPPCACHE_EXPORT EvictionController : public ACE_Task_Base,
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //_EVICTIONCONTROLLER_H__
+
+#endif // GEODE_EVICTIONCONTROLLER_H_

--- a/src/cppcache/src/EvictionThread.hpp
+++ b/src/cppcache/src/EvictionThread.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EVICTIONTHREAD_H_
+#define GEODE_EVICTIONTHREAD_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _EVICTIONTHREAD_H__
-#define _EVICTIONTHREAD_H__
 
 #include <ace/ACE.h>
 #include <ace/OS.h>
@@ -66,4 +69,5 @@ class CPPCACHE_EXPORT EvictionThread : public ACE_Task_Base {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_EVICTIONTHREAD_H__
+
+#endif // GEODE_EVICTIONTHREAD_H_

--- a/src/cppcache/src/ExecutionImpl.hpp
+++ b/src/cppcache/src/ExecutionImpl.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_EXECUTION_IMPL_H__
-#define __GEMFIRE_EXECUTION_IMPL_H__
+#pragma once
+
+#ifndef GEODE_EXECUTIONIMPL_H_
+#define GEODE_EXECUTIONIMPL_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -110,4 +112,5 @@ class ExecutionImpl : public Execution {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //__GEMFIRE_EXECUTION_IMPL_H__
+
+#endif // GEODE_EXECUTIONIMPL_H_

--- a/src/cppcache/src/ExpMapEntry.hpp
+++ b/src/cppcache/src/ExpMapEntry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EXPMAPENTRY_H_
+#define GEODE_EXPMAPENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_EXPMAPENTRY_H__
-#define __GEMFIRE_IMPL_EXPMAPENTRY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "MapEntry.hpp"
@@ -92,4 +95,4 @@ class CPPCACHE_EXPORT ExpEntryFactory : public EntryFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_EXPMAPENTRY_H__
+#endif // GEODE_EXPMAPENTRY_H_

--- a/src/cppcache/src/ExpiryHandler_T.hpp
+++ b/src/cppcache/src/ExpiryHandler_T.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_EXPIRYHANDLER_T_H_
+#define GEODE_EXPIRYHANDLER_T_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,8 +25,6 @@
  *@version 1.0
  */
 
-#ifndef EXPIRYHANDLER_T_HPP
-#define EXPIRYHANDLER_T_HPP
 
 #include "ace/Event_Handler.h"
 #include <gfcpp/Log.hpp>
@@ -69,4 +72,5 @@ class CPPCACHE_EXPORT ExpiryHandler_T : public ACE_Event_Handler {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // !defined (EXPIRYHANDLER_T_HPP)
+
+#endif // GEODE_EXPIRYHANDLER_T_H_

--- a/src/cppcache/src/ExpiryTaskManager.hpp
+++ b/src/cppcache/src/ExpiryTaskManager.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_EXPIRYTASKMANAGER_H__
-#define _GEMFIRE_EXPIRYTASKMANAGER_H__
+#pragma once
+
+#ifndef GEODE_EXPIRYTASKMANAGER_H_
+#define GEODE_EXPIRYTASKMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -271,4 +274,4 @@ class CPPCACHE_EXPORT ExpiryTaskManager : public ACE_Task_Base {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef _GEMFIRE_EXPIRYTASKMANAGER_H__
+#endif // GEODE_EXPIRYTASKMANAGER_H_

--- a/src/cppcache/src/FairQueue.hpp
+++ b/src/cppcache/src/FairQueue.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_FAIRQUEUE_H_
+#define GEODE_FAIRQUEUE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_FAIRQUEUE_HPP_
-#define _GEMFIRE_FAIRQUEUE_HPP_
 
 #include <deque>
 #include <ace/ACE.h>
@@ -173,4 +176,4 @@ class FairQueue {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef _GEMFIRE_FAIRQUEUE_HPP_
+#endif // GEODE_FAIRQUEUE_H_

--- a/src/cppcache/src/FarSideEntryOp.hpp
+++ b/src/cppcache/src/FarSideEntryOp.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_FARSIDEENTRYOP_H_
+#define GEODE_FARSIDEENTRYOP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef FARSIDEENTRYOP_HPP_
-#define FARSIDEENTRYOP_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/gf_types.hpp>
@@ -122,4 +125,5 @@ class FarSideEntryOp : public apache::geode::client::SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* FARSIDEENTRYOP_HPP_ */
+
+#endif // GEODE_FARSIDEENTRYOP_H_

--- a/src/cppcache/src/FixedPartitionAttributesImpl.hpp
+++ b/src/cppcache/src/FixedPartitionAttributesImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_FIXEDPARTITIONATTRIBUTESIMPL_H_
+#define GEODE_FIXEDPARTITIONATTRIBUTESIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __FIXED_PARTITION_ATTRIBUTES__IMPL__
-#define __FIXED_PARTITION_ATTRIBUTES__IMPL__
 
 #include <gfcpp/Serializable.hpp>
 #include <gfcpp/DataInput.hpp>
@@ -122,4 +125,5 @@ class FixedPartitionAttributesImpl : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_FIXEDPARTITIONATTRIBUTESIMPL_H_

--- a/src/cppcache/src/FunctionServiceImpl.hpp
+++ b/src/cppcache/src/FunctionServiceImpl.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_FUNCTION_SERVICEIMPL_H__
-#define __GEMFIRE_FUNCTION_SERVICEIMPL_H__
+#pragma once
+
+#ifndef GEODE_FUNCTIONSERVICEIMPL_H_
+#define GEODE_FUNCTIONSERVICEIMPL_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -63,4 +65,5 @@ class CPPCACHE_EXPORT FunctionServiceImpl : public FunctionService {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //__GEMFIRE_FUNCTION_SERVICEIMPL_H__
+
+#endif // GEODE_FUNCTIONSERVICEIMPL_H_

--- a/src/cppcache/src/GF_TASK_T.hpp
+++ b/src/cppcache/src/GF_TASK_T.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GF_TASK_T_H_
+#define GEODE_GF_TASK_T_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
 *@version 1.0
 */
 
-#ifndef __GF_TASK_T_HPP__
-#define __GF_TASK_T_HPP__
 
 #include "DistributedSystemImpl.hpp"
 #include <ace/Task.h>
@@ -80,4 +83,5 @@ class CPPCACHE_EXPORT GF_TASK_T : public ACE_Task_Base {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __GF_TASK_T_HPP__
+
+#endif // GEODE_GF_TASK_T_H_

--- a/src/cppcache/src/GatewayEventCallbackArgument.hpp
+++ b/src/cppcache/src/GatewayEventCallbackArgument.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GATEWAYEVENTCALLBACKARGUMENT_H_
+#define GEODE_GATEWAYEVENTCALLBACKARGUMENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GATEWAYEVENTCALLBACKARGUMENT_HPP__
-#define __GATEWAYEVENTCALLBACKARGUMENT_HPP__
 
 #include <gfcpp/Serializable.hpp>
 #include "GeodeTypeIdsImpl.hpp"
@@ -66,4 +69,5 @@ class GatewayEventCallbackArgument : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GATEWAYEVENTCALLBACKARGUMENT_HPP__
+
+#endif // GEODE_GATEWAYEVENTCALLBACKARGUMENT_H_

--- a/src/cppcache/src/GatewaySenderEventCallbackArgument.hpp
+++ b/src/cppcache/src/GatewaySenderEventCallbackArgument.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_
+#define GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __GATEWAYSENDEREVENTCALLBACKARGUMENT_HPP__
-#define __GATEWAYSENDEREVENTCALLBACKARGUMENT_HPP__
 
 #include <gfcpp/Serializable.hpp>
 #include "GeodeTypeIdsImpl.hpp"
@@ -71,4 +74,5 @@ class GatewaySenderEventCallbackArgument : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GATEWAYSENDEREVENTCALLBACKARGUMENT_HPP__
+
+#endif // GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_

--- a/src/cppcache/src/GeodeTypeIdsImpl.hpp
+++ b/src/cppcache/src/GeodeTypeIdsImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GEODETYPEIDSIMPL_H_
+#define GEODE_GEODETYPEIDSIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEODE_GEODETYPEIDSIMPL_HPP_
-#define _GEODE_GEODETYPEIDSIMPL_HPP_
 
 namespace apache {
 namespace geode {
@@ -79,4 +82,5 @@ class GeodeTypeIdsImpl {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_GEODETYPEIDSIMPL_H_

--- a/src/cppcache/src/GetAllServersRequest.hpp
+++ b/src/cppcache/src/GetAllServersRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GETALLSERVERSREQUEST_H_
+#define GEODE_GETALLSERVERSREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GET_All_SERVERS_REQUEST_HPP_INCLUDED__
-#define __GET_All_SERVERS_REQUEST_HPP_INCLUDED__
 
 #include <gfcpp/Serializable.hpp>
 #include <gfcpp/DataInput.hpp>
@@ -50,4 +53,5 @@ class GetAllServersRequest : public Serializable {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_GETALLSERVERSREQUEST_H_

--- a/src/cppcache/src/GetAllServersResponse.hpp
+++ b/src/cppcache/src/GetAllServersResponse.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GETALLSERVERSRESPONSE_H_
+#define GEODE_GETALLSERVERSRESPONSE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GET_All_SERVERS_RESPONSE_HPP_INCLUDED__
-#define __GET_All_SERVERS_RESPONSE_HPP_INCLUDED__
 
 #include <gfcpp/Serializable.hpp>
 #include "ServerLocation.hpp"
@@ -52,4 +55,5 @@ typedef SharedPtr<GetAllServersResponse> GetAllServersResponsePtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_GETALLSERVERSRESPONSE_H_

--- a/src/cppcache/src/HostAsm.hpp
+++ b/src/cppcache/src/HostAsm.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_UTIL_IMPL_HOSTASM_HPP__
-#define __GEMFIRE_UTIL_IMPL_HOSTASM_HPP__
+#pragma once
+
+#ifndef GEODE_HOSTASM_H_
+#define GEODE_HOSTASM_H_
+
 #ifdef __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -442,4 +445,5 @@ return true;
 #ifdef __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 #pragma clang diagnostic pop
 #endif
-#endif
+
+#endif // GEODE_HOSTASM_H_

--- a/src/cppcache/src/IntQueue.hpp
+++ b/src/cppcache/src/IntQueue.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTQUEUE_H_
+#define GEODE_INTQUEUE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if !defined(IMPL_INTQUEUE_INCLUDED)
-#define IMPL_INTQUEUE_INCLUDED
 
 #include <deque>
 #include <ace/ACE.h>
@@ -117,4 +120,4 @@ class CPPCACHE_EXPORT IntQueue {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // !defined (IMPL_INTQUEUE_INCLUDED)
+#endif // GEODE_INTQUEUE_H_

--- a/src/cppcache/src/InterestResultPolicy.hpp
+++ b/src/cppcache/src/InterestResultPolicy.hpp
@@ -1,6 +1,8 @@
+#pragma once
 
-#ifndef __GEMFIRE_INTERESTRESULTPOLICY_H__
-#define __GEMFIRE_INTERESTRESULTPOLICY_H__
+#ifndef GEODE_INTERESTRESULTPOLICY_H_
+#define GEODE_INTERESTRESULTPOLICY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -49,4 +51,5 @@ class CPPCACHE_EXPORT InterestResultPolicy {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_INTERESTRESULTPOLICY_H__
+
+#endif // GEODE_INTERESTRESULTPOLICY_H_

--- a/src/cppcache/src/InternalCacheTransactionManager2PCImpl.hpp
+++ b/src/cppcache/src/InternalCacheTransactionManager2PCImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_
+#define GEODE_INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: sshcherbakov
  */
 
-#ifndef INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_
-#define INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_
 
 #include <gfcpp/InternalCacheTransactionManager2PC.hpp>
 #include "CacheTransactionManagerImpl.hpp"
@@ -54,4 +57,5 @@ class InternalCacheTransactionManager2PCImpl
 }  // namespace geode
 }  // namespace apache
 
-#endif /* INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_ */
+
+#endif // GEODE_INTERNALCACHETRANSACTIONMANAGER2PCIMPL_H_

--- a/src/cppcache/src/InternalDataView.hpp
+++ b/src/cppcache/src/InternalDataView.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_INTERNALDATAVIEW_H_
+#define GEODE_INTERNALDATAVIEW_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef INTERNALDATAVIEW_HPP_
-#define INTERNALDATAVIEW_HPP_
 
 namespace apache {
 namespace geode {
@@ -37,4 +40,5 @@ class InternalDataView {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* INTERNALDATAVIEW_HPP_ */
+
+#endif // GEODE_INTERNALDATAVIEW_H_

--- a/src/cppcache/src/LRUAction.hpp
+++ b/src/cppcache/src/LRUAction.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRUACTION_H_
+#define GEODE_LRUACTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRUACTION_H__
-#define __GEMFIRE_IMPL_LRUACTION_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cache.hpp>
@@ -179,4 +182,4 @@ class CPPCACHE_EXPORT LRUOverFlowToDiskAction : public virtual LRUAction {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_LRUACTION_H__
+#endif // GEODE_LRUACTION_H_

--- a/src/cppcache/src/LRUEntriesMap.hpp
+++ b/src/cppcache/src/LRUEntriesMap.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRUENTRIESMAP_H_
+#define GEODE_LRUENTRIESMAP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRUENTRIESMAP_H__
-#define __GEMFIRE_IMPL_LRUENTRIESMAP_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cache.hpp>
@@ -134,4 +137,4 @@ class CPPCACHE_EXPORT LRUEntriesMap : public ConcurrentEntriesMap,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_LRUENTRIESMAP_H__
+#endif // GEODE_LRUENTRIESMAP_H_

--- a/src/cppcache/src/LRUExpMapEntry.hpp
+++ b/src/cppcache/src/LRUExpMapEntry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRUEXPMAPENTRY_H_
+#define GEODE_LRUEXPMAPENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRUEXPMAPENTRY_H__
-#define __GEMFIRE_IMPL_LRUEXPMAPENTRY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "MapEntry.hpp"
@@ -97,4 +100,4 @@ class CPPCACHE_EXPORT LRUExpEntryFactory : public EntryFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_IMPL_LRUEXPMAPENTRY_H__
+#endif // GEODE_LRUEXPMAPENTRY_H_

--- a/src/cppcache/src/LRUList.hpp
+++ b/src/cppcache/src/LRUList.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRULIST_H_
+#define GEODE_LRULIST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRULIST_H__
-#define __GEMFIRE_IMPL_LRULIST_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
@@ -150,4 +153,4 @@ class LRUList {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_LRULIST_H__
+#endif // GEODE_LRULIST_H_

--- a/src/cppcache/src/LRULocalDestroyAction.hpp
+++ b/src/cppcache/src/LRULocalDestroyAction.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRULOCALDESTROYACTION_H_
+#define GEODE_LRULOCALDESTROYACTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRULOCALDESTROYACTION_HPP__
-#define __GEMFIRE_IMPL_LRULOCALDESTROYACTION_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "LRUAction.hpp"
@@ -51,4 +54,4 @@ class CPPCACHE_EXPORT LRULocalDestroyAction : public virtual LRUAction {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_IMPL_LRULOCALDESTROYACTION_HPP__
+#endif // GEODE_LRULOCALDESTROYACTION_H_

--- a/src/cppcache/src/LRUMapEntry.hpp
+++ b/src/cppcache/src/LRUMapEntry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LRUMAPENTRY_H_
+#define GEODE_LRUMAPENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_LRUMAPENTRY_H__
-#define __GEMFIRE_IMPL_LRUMAPENTRY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/CacheableKey.hpp>
@@ -121,4 +124,4 @@ class CPPCACHE_EXPORT LRUEntryFactory : public EntryFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_IMPL_LRUMAPENTRY_H__
+#endif // GEODE_LRUMAPENTRY_H_

--- a/src/cppcache/src/LocalRegion.hpp
+++ b/src/cppcache/src/LocalRegion.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_LOCALREGION_H__
-#define __GEMFIRE_LOCALREGION_H__
+#pragma once
+
+#ifndef GEODE_LOCALREGION_H_
+#define GEODE_LOCALREGION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -495,4 +497,4 @@ class CPPCACHE_EXPORT LocalRegion : public RegionInternal {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_LOCALREGION_H__
+#endif // GEODE_LOCALREGION_H_

--- a/src/cppcache/src/LocatorListRequest.hpp
+++ b/src/cppcache/src/LocatorListRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LOCATORLISTREQUEST_H_
+#define GEODE_LOCATORLISTREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __LOCATORLISTREQUEST__
-#define __LOCATORLISTREQUEST__
 #include <string>
 #include "ServerLocationRequest.hpp"
 #include "GeodeTypeIdsImpl.hpp"
@@ -39,4 +42,5 @@ class LocatorListRequest : public ServerLocationRequest {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_LOCATORLISTREQUEST_H_

--- a/src/cppcache/src/LocatorListResponse.hpp
+++ b/src/cppcache/src/LocatorListResponse.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_LOCATORLISTRESPONSE_H_
+#define GEODE_LOCATORLISTRESPONSE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _LOCATOR_LIST_RESPONSE_
-#define _LOCATOR_LIST_RESPONSE_
 #include <vector>
 #include "GeodeTypeIdsImpl.hpp"
 #include "ServerLocationResponse.hpp"
@@ -48,4 +51,5 @@ typedef SharedPtr<LocatorListResponse> LocatorListResponsePtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_LOCATORLISTRESPONSE_H_

--- a/src/cppcache/src/MapEntry.hpp
+++ b/src/cppcache/src/MapEntry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_MAPENTRY_H_
+#define GEODE_MAPENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_MAPENTRY_H__
-#define __GEMFIRE_IMPL_MAPENTRY_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cacheable.hpp>
@@ -285,4 +288,4 @@ class CPPCACHE_EXPORT EntryFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_MAPENTRY_H__
+#endif // GEODE_MAPENTRY_H_

--- a/src/cppcache/src/MapEntryT.hpp
+++ b/src/cppcache/src/MapEntryT.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_IMPL_MAPENTRY_T_HPP__
-#define __GEMFIRE_IMPL_MAPENTRY_T_HPP__
+#pragma once
+
+#ifndef GEODE_MAPENTRYT_H_
+#define GEODE_MAPENTRYT_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -290,4 +292,4 @@ inline int MapEntryST<TBase, 0, UPDATE_COUNT>::incUpdateCount(TBase* loc) {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_MAPENTRY_T_HPP__
+#endif // GEODE_MAPENTRYT_H_

--- a/src/cppcache/src/MapSegment.hpp
+++ b/src/cppcache/src/MapSegment.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_MAPSEGMENT_H_
+#define GEODE_MAPSEGMENT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_MAPSEGMENT_H__
-#define __GEMFIRE_IMPL_MAPSEGMENT_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 
@@ -307,4 +310,4 @@ class CPPCACHE_EXPORT MapSegment {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_MAPSEGMENT_H__
+#endif // GEODE_MAPSEGMENT_H_

--- a/src/cppcache/src/MapWithLock.hpp
+++ b/src/cppcache/src/MapWithLock.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_IMPL_MAP_WITHLOCK_H__
-#define __GEMFIRE_IMPL_MAP_WITHLOCK_H__
+#pragma once
+
+#ifndef GEODE_MAPWITHLOCK_H_
+#define GEODE_MAPWITHLOCK_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -79,4 +81,5 @@ typedef ACE_Guard<ACE_Recursive_Thread_Mutex> MapOfRegionGuard;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // define __GEMFIRE_IMPL_MAP_WITHLOCK_H__
+
+#endif // GEODE_MAPWITHLOCK_H_

--- a/src/cppcache/src/MemberListForVersionStamp.hpp
+++ b/src/cppcache/src/MemberListForVersionStamp.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_MEMBERLISTFORVERSIONSTAMP_H_
+#define GEODE_MEMBERLISTFORVERSIONSTAMP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __MemberListForVersionStamp_HPP__
-#define __MemberListForVersionStamp_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
@@ -59,4 +62,5 @@ typedef SharedPtr<MemberListForVersionStamp> MemberListForVersionStampPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __MemberListForVersionStamp_HPP__
+
+#endif // GEODE_MEMBERLISTFORVERSIONSTAMP_H_

--- a/src/cppcache/src/NanoTimer.hpp
+++ b/src/cppcache/src/NanoTimer.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_NANOTIMER_H_
+#define GEODE_NANOTIMER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,9 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GEMFIRE_IMPL_NANOTIMER_HPP_
-#define _GEMFIRE_IMPL_NANOTIMER_HPP_
-
 #include <gfcpp/gfcpp_globals.hpp>
 
 namespace apache {
@@ -34,4 +36,4 @@ class CPPCACHE_EXPORT NanoTimer {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_NANOTIMER_H_

--- a/src/cppcache/src/NoResult.hpp
+++ b/src/cppcache/src/NoResult.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_NORESULT_H_
+#define GEODE_NORESULT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_NO_RESULT_HPP__
-#define __GEMFIRE_NO_RESULT_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/gf_types.hpp>
@@ -63,4 +66,4 @@ class CPPCACHE_EXPORT NoResult : public ResultCollector {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_NO_RESULT_HPP__
+#endif // GEODE_NORESULT_H_

--- a/src/cppcache/src/NonCopyable.hpp
+++ b/src/cppcache/src/NonCopyable.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_NONCOPYABLE_H_
+#define GEODE_NONCOPYABLE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NON_COPYABLE_H_
-#define NON_COPYABLE_H_
 
 namespace apache {
 namespace geode {
@@ -40,4 +43,5 @@ class CPPCACHE_EXPORT NonAssignable {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // GEODE_NONCOPYABLE_H_

--- a/src/cppcache/src/PdxEnumInstantiator.hpp
+++ b/src/cppcache/src/PdxEnumInstantiator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXENUMINSTANTIATOR_H_
+#define GEODE_PDXENUMINSTANTIATOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,12 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* PdxEnumInstantiator.hpp
-*/
-
-#ifndef _GEMFIRE_PDXENUM_INSTANTIATOR_HPP_
-#define _GEMFIRE_PDXENUM_INSTANTIATOR_HPP_
 
 #include <gfcpp/Serializable.hpp>
 #include <gfcpp/CacheableEnum.hpp>
@@ -54,4 +53,5 @@ class PdxEnumInstantiator : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* _GEMFIRE_PDXENUM_INSTANTIATOR_HPP_ */
+
+#endif // GEODE_PDXENUMINSTANTIATOR_H_

--- a/src/cppcache/src/PdxFieldType.hpp
+++ b/src/cppcache/src/PdxFieldType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXFIELDTYPE_H_
+#define GEODE_PDXFIELDTYPE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxFieldType.hpp
- *
- *  Created on: Nov 3, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_IMPL_PDXFIELDTYPE_HPP_
-#define _GEMFIRE_IMPL_PDXFIELDTYPE_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Serializable.hpp>
@@ -111,4 +107,5 @@ class CPPCACHE_EXPORT PdxFieldType : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXFIELDTYPE_HPP_ */
+
+#endif // GEODE_PDXFIELDTYPE_H_

--- a/src/cppcache/src/PdxHelper.hpp
+++ b/src/cppcache/src/PdxHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXHELPER_H_
+#define GEODE_PDXHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef PDXHELPER_HPP_
-#define PDXHELPER_HPP_
 
 #include <gfcpp/DataOutput.hpp>
 #include "EnumInfo.hpp"
@@ -81,4 +84,5 @@ class PdxHelper {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXHELPER_HPP_ */
+
+#endif // GEODE_PDXHELPER_H_

--- a/src/cppcache/src/PdxInstanceFactoryImpl.hpp
+++ b/src/cppcache/src/PdxInstanceFactoryImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __PDXINSTANCE_FACTORY_IMPL_HPP_
-#define __PDXINSTANCE_FACTORY_IMPL_HPP_
+#pragma once
+
+#ifndef GEODE_PDXINSTANCEFACTORYIMPL_H_
+#define GEODE_PDXINSTANCEFACTORYIMPL_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -455,4 +458,5 @@ class CPPCACHE_EXPORT PdxInstanceFactoryImpl : public PdxInstanceFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __PDXINSTANCE_FACTORY_IMPL_HPP_ */
+
+#endif // GEODE_PDXINSTANCEFACTORYIMPL_H_

--- a/src/cppcache/src/PdxInstanceImpl.hpp
+++ b/src/cppcache/src/PdxInstanceImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __PDXINSTANCE_IMPL_HPP_
-#define __PDXINSTANCE_IMPL_HPP_
+#pragma once
+
+#ifndef GEODE_PDXINSTANCEIMPL_H_
+#define GEODE_PDXINSTANCEIMPL_H_
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1167,4 +1170,5 @@ typedef SharedPtr<PdxInstanceImpl> PdxInstanceImplPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __PDXINSTANCE_IMPL_HPP_*/
+
+#endif // GEODE_PDXINSTANCEIMPL_H_

--- a/src/cppcache/src/PdxInstantiator.hpp
+++ b/src/cppcache/src/PdxInstantiator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXINSTANTIATOR_H_
+#define GEODE_PDXINSTANTIATOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxInstantiator.hpp
- *
- *  Created on: Dec 28, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_PDXINSTANTIATOR_HPP_
-#define _GEMFIRE_PDXINSTANTIATOR_HPP_
 
 #include <gfcpp/Serializable.hpp>
 
@@ -54,4 +50,5 @@ class PdxInstantiator : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* _GEMFIRE_PDXINSTANTIATOR_HPP_ */
+
+#endif // GEODE_PDXINSTANTIATOR_H_

--- a/src/cppcache/src/PdxLocalReader.hpp
+++ b/src/cppcache/src/PdxLocalReader.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXLOCALREADER_H_
+#define GEODE_PDXLOCALREADER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,14 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* PdxLocalReader.hpp
-* Created on: Nov 3, 2011
-*      Author: npatel
-*/
-
-#ifndef _GEMFIRE_IMPL_PDXLOCALREADER_HPP_
-#define _GEMFIRE_IMPL_PDXLOCALREADER_HPP_
 
 #include <gfcpp/PdxReader.hpp>
 #include "PdxType.hpp"
@@ -221,4 +218,5 @@ typedef SharedPtr<PdxLocalReader> PdxLocalReaderPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXLOCALREADER_HPP_ */
+
+#endif // GEODE_PDXLOCALREADER_H_

--- a/src/cppcache/src/PdxLocalWriter.hpp
+++ b/src/cppcache/src/PdxLocalWriter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXLOCALWRITER_H_
+#define GEODE_PDXLOCALWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxLocalWriter.hpp
- *
- *  Created on: Nov 3, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_IMPL_PDXLOCALWRITER_HPP_
-#define _GEMFIRE_IMPL_PDXLOCALWRITER_HPP_
 
 #include <gfcpp/PdxWriter.hpp>
 #include "PdxType.hpp"
@@ -342,4 +338,5 @@ typedef SharedPtr<PdxLocalWriter> PdxLocalWriterPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXLOCALWRITER_HPP_ */
+
+#endif // GEODE_PDXLOCALWRITER_H_

--- a/src/cppcache/src/PdxReaderWithTypeCollector.hpp
+++ b/src/cppcache/src/PdxReaderWithTypeCollector.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXREADERWITHTYPECOLLECTOR_H_
+#define GEODE_PDXREADERWITHTYPECOLLECTOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* PdxReaderWithTypeCollector.hpp
-*
-*  Created on: Nov 3, 2011
-*      Author: npatel
-*/
-
-#ifndef _GEMFIRE_IMPL_PDXREADERWITHTYPECOLLECTOR_HPP_
-#define _GEMFIRE_IMPL_PDXREADERWITHTYPECOLLECTOR_HPP_
 
 #include "PdxLocalReader.hpp"
 
@@ -183,4 +179,4 @@ typedef SharedPtr<PdxReaderWithTypeCollector> PdxReaderWithTypeCollectorPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif /* PDXREADERWITHTYPECOLLECTOR_HPP_ */
+#endif // GEODE_PDXREADERWITHTYPECOLLECTOR_H_

--- a/src/cppcache/src/PdxRemotePreservedData.hpp
+++ b/src/cppcache/src/PdxRemotePreservedData.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXREMOTEPRESERVEDDATA_H_
+#define GEODE_PDXREMOTEPRESERVEDDATA_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxType.hpp
- *
- *  Created on: Dec 09, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_IMPL_PDXREMOTEPRESERVEDDATA_HPP_
-#define _GEMFIRE_IMPL_PDXREMOTEPRESERVEDDATA_HPP_
 
 #include <gfcpp/PdxUnreadFields.hpp>
 #include <vector>
@@ -117,4 +113,5 @@ class PdxRemotePreservedData : public PdxUnreadFields {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_PDXREMOTEPRESERVEDDATA_H_

--- a/src/cppcache/src/PdxRemoteReader.hpp
+++ b/src/cppcache/src/PdxRemoteReader.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXREMOTEREADER_H_
+#define GEODE_PDXREMOTEREADER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,14 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* PdxRemoteReader.hpp
-*
-*  Created on: Nov 3, 2011
-*      Author: npatel
-*/
-#ifndef _GEMFIRE_IMPL_PDXREMOTEREADER_HPP_
-#define _GEMFIRE_IMPL_PDXREMOTEREADER_HPP_
 
 #include "PdxLocalReader.hpp"
 
@@ -216,4 +213,5 @@ typedef SharedPtr<PdxRemoteReader> PdxRemoteReaderPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXREMOTEREADER_HPP_ */
+
+#endif // GEODE_PDXREMOTEREADER_H_

--- a/src/cppcache/src/PdxRemoteWriter.hpp
+++ b/src/cppcache/src/PdxRemoteWriter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXREMOTEWRITER_H_
+#define GEODE_PDXREMOTEWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef PDXREMOTEWRITER_HPP_
-#define PDXREMOTEWRITER_HPP_
 
 #include "PdxLocalWriter.hpp"
 
@@ -238,4 +241,5 @@ typedef SharedPtr<PdxRemoteWriter> PdxRemoteWriterPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXREMOTEWRITER_HPP_ */
+
+#endif // GEODE_PDXREMOTEWRITER_H_

--- a/src/cppcache/src/PdxType.hpp
+++ b/src/cppcache/src/PdxType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXTYPE_H_
+#define GEODE_PDXTYPE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-* PdxType.hpp
-*
-*  Created on: Nov 3, 2011
-*      Author: npatel
-*/
-
-#ifndef _GEMFIRE_IMPL_PDXTYPE_HPP_
-#define _GEMFIRE_IMPL_PDXTYPE_HPP_
 
 #include <gfcpp/Serializable.hpp>
 #include "PdxFieldType.hpp"
@@ -224,4 +220,5 @@ class PdxType : public Serializable,
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXTYPE_HPP_ */
+
+#endif // GEODE_PDXTYPE_H_

--- a/src/cppcache/src/PdxTypeRegistry.hpp
+++ b/src/cppcache/src/PdxTypeRegistry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXTYPEREGISTRY_H_
+#define GEODE_PDXTYPEREGISTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxTypeRegistry.hpp
- *
- *  Created on: Dec 9, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_IMPL_PDXTYPEREGISTRY_HPP_
-#define _GEMFIRE_IMPL_PDXTYPEREGISTRY_HPP_
 
 #include <gfcpp/PdxSerializable.hpp>
 #include "PdxRemotePreservedData.hpp"
@@ -143,4 +139,5 @@ class CPPCACHE_EXPORT PdxTypeRegistry {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXTYPEREGISTRY_HPP_ */
+
+#endif // GEODE_PDXTYPEREGISTRY_H_

--- a/src/cppcache/src/PdxTypes.hpp
+++ b/src/cppcache/src/PdxTypes.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PDXTYPES_H__
-#define __GEMFIRE_PDXTYPES_H__
+#pragma once
+
+#ifndef GEODE_PDXTYPES_H_
+#define GEODE_PDXTYPES_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,4 +43,4 @@ class PdxTypes {
   static const int8_t DATE_SIZE = 8;
 };
 
-#endif  // __GEMFIRE_PDXTYPES_H__
+#endif // GEODE_PDXTYPES_H_

--- a/src/cppcache/src/PdxWriterWithTypeCollector.hpp
+++ b/src/cppcache/src/PdxWriterWithTypeCollector.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PDXWRITERWITHTYPECOLLECTOR_H_
+#define GEODE_PDXWRITERWITHTYPECOLLECTOR_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,15 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxWriterWithTypeCollector.hpp
- *
- *  Created on: Nov 3, 2011
- *      Author: npatel
- */
-
-#ifndef _GEMFIRE_IMPL_PDXWRITERWITHTYPECOLLECTOR_HPP_
-#define _GEMFIRE_IMPL_PDXWRITERWITHTYPECOLLECTOR_HPP_
 
 #include "PdxLocalWriter.hpp"
 //#include <map>
@@ -231,4 +227,5 @@ typedef SharedPtr<PdxWriterWithTypeCollector> PdxWriterWithTypeCollectorPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* PDXWRITERWITHTYPECOLLECTOR_HPP_ */
+
+#endif // GEODE_PDXWRITERWITHTYPECOLLECTOR_H_

--- a/src/cppcache/src/PoolAttributes.hpp
+++ b/src/cppcache/src/PoolAttributes.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_POOL_ATTRIBUTES_HPP__
-#define __GEMFIRE_POOL_ATTRIBUTES_HPP__
+#pragma once
+
+#ifndef GEODE_POOLATTRIBUTES_H_
+#define GEODE_POOLATTRIBUTES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -160,4 +163,4 @@ class PoolAttributes : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_POOL_ATTRIBUTES_HPP__
+#endif // GEODE_POOLATTRIBUTES_H_

--- a/src/cppcache/src/PoolStatistics.hpp
+++ b/src/cppcache/src/PoolStatistics.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_POOLSTATISTICS_H_
+#define GEODE_POOLSTATISTICS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_POOLSTATS_H__
-#define __GEMFIRE_POOLSTATS_H__ 1
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
@@ -249,4 +251,4 @@ class PoolStatType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_POOLSTATS_H__
+#endif // GEODE_POOLSTATISTICS_H_

--- a/src/cppcache/src/PoolXmlCreation.hpp
+++ b/src/cppcache/src/PoolXmlCreation.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_POOLXMLCREATION_HPP_
-#define _GEMFIRE_POOLXMLCREATION_HPP_
+#pragma once
+
+#ifndef GEODE_POOLXMLCREATION_H_
+#define GEODE_POOLXMLCREATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -84,4 +87,5 @@ class CPPCACHE_EXPORT PoolXmlCreation {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // #ifndef  _GEMFIRE_POOLXMLCREATION_HPP_
+
+#endif // GEODE_POOLXMLCREATION_H_

--- a/src/cppcache/src/PooledBase.hpp
+++ b/src/cppcache/src/PooledBase.hpp
@@ -1,7 +1,7 @@
-#ifndef _GEMFIRE_PooledBase_HPP_
-#define _GEMFIRE_PooledBase_HPP_
+#pragma once
 
-// PooledBase.hpp     -*- mode: c++ -*-
+#ifndef GEODE_POOLEDBASE_H_
+#define GEODE_POOLEDBASE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -61,6 +61,4 @@ class CPPCACHE_EXPORT PooledBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
-
-// the end...
+#endif // GEODE_POOLEDBASE_H_

--- a/src/cppcache/src/PooledBasePool.hpp
+++ b/src/cppcache/src/PooledBasePool.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_POOLEDBASEPOOL_H_
+#define GEODE_POOLEDBASEPOOL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_IMPL_POOLEDBASEPOOL_HPP_
-#define _GEMFIRE_IMPL_POOLEDBASEPOOL_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
@@ -79,4 +82,4 @@ class CPPCACHE_EXPORT PooledBasePool {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_POOLEDBASEPOOL_H_

--- a/src/cppcache/src/PreservedDataExpiryHandler.hpp
+++ b/src/cppcache/src/PreservedDataExpiryHandler.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PRESERVEDDATAEXPIRYHANDLER_H_
+#define GEODE_PRESERVEDDATAEXPIRYHANDLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __PRESERVEDDATAEXPIRYHANDLER_HPP__
-#define __PRESERVEDDATAEXPIRYHANDLER_HPP__
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cache.hpp>
 #include <gfcpp/PdxSerializable.hpp>
@@ -72,4 +75,5 @@ class CPPCACHE_EXPORT PreservedDataExpiryHandler : public ACE_Event_Handler {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __PRESERVEDDATAEXPIRYHANDLER_HPP__*/
+
+#endif // GEODE_PRESERVEDDATAEXPIRYHANDLER_H_

--- a/src/cppcache/src/ProxyCache.hpp
+++ b/src/cppcache/src/ProxyCache.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_PROXYCACHE_H__
-#define __GEMFIRE_PROXYCACHE_H__
+#pragma once
+
+#ifndef GEODE_PROXYCACHE_H_
+#define GEODE_PROXYCACHE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -133,4 +136,5 @@ class CPPCACHE_EXPORT ProxyCache : public RegionService {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_PROXYCACHE_H__
+
+#endif // GEODE_PROXYCACHE_H_

--- a/src/cppcache/src/ProxyRegion.hpp
+++ b/src/cppcache/src/ProxyRegion.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_PROXYREGION_H__
-#define __GEMFIRE_PROXYREGION_H__
+#pragma once
+
+#ifndef GEODE_PROXYREGION_H_
+#define GEODE_PROXYREGION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1519,4 +1521,4 @@ typedef SharedPtr<ProxyRegion> ProxyRegionPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_PROXYREGION_H__
+#endif // GEODE_PROXYREGION_H_

--- a/src/cppcache/src/ProxyRemoteQueryService.hpp
+++ b/src/cppcache/src/ProxyRemoteQueryService.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_PROXYREMOTEQUERYSERVICE_H__
-#define __GEMFIRE_PROXYREMOTEQUERYSERVICE_H__
+#pragma once
+
+#ifndef GEODE_PROXYREMOTEQUERYSERVICE_H_
+#define GEODE_PROXYREMOTEQUERYSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -69,4 +72,5 @@ typedef SharedPtr<ProxyRemoteQueryService> ProxyRemoteQueryServicePtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_PROXYREMOTEQUERYSERVICE_H__
+
+#endif // GEODE_PROXYREMOTEQUERYSERVICE_H_

--- a/src/cppcache/src/PutAllPartialResult.hpp
+++ b/src/cppcache/src/PutAllPartialResult.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PUTALLPARTIALRESULT_H_
+#define GEODE_PUTALLPARTIALRESULT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef PUTALL_PARTIAL_RESULT
-#define PUTALL_PARTIAL_RESULT
 
 #include <gfcpp/Serializable.hpp>
 #include <gfcpp/CacheableString.hpp>
@@ -133,4 +136,5 @@ class PutAllPartialResult : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_PUTALLPARTIALRESULT_H_

--- a/src/cppcache/src/PutAllPartialResultServerException.hpp
+++ b/src/cppcache/src/PutAllPartialResultServerException.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_PUTALLPARTIALRESULTSERVEREXCEPTION_H_
+#define GEODE_PUTALLPARTIALRESULTSERVEREXCEPTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef PUTALL_PARTIALRESULT_SERVER_EXCEPTION
-#define PUTALL_PARTIALRESULT_SERVER_EXCEPTION
 
 #include <gfcpp/Serializable.hpp>
 #include <gfcpp/CacheableString.hpp>
@@ -141,4 +144,5 @@ class CPPCACHE_EXPORT PutAllPartialResultServerException : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_PUTALLPARTIALRESULTSERVEREXCEPTION_H_

--- a/src/cppcache/src/Queue.hpp
+++ b/src/cppcache/src/Queue.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_QUEUE_H_
+#define GEODE_QUEUE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_QUEUE_HPP_
-#define __GEMFIRE_QUEUE_HPP_
 
 #include <deque>
 #include <ace/Time_Value.h>
@@ -165,4 +168,4 @@ class CPPCACHE_EXPORT Queue {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_QUEUE_HPP_
+#endif // GEODE_QUEUE_H_

--- a/src/cppcache/src/QueueConnectionRequest.hpp
+++ b/src/cppcache/src/QueueConnectionRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_QUEUECONNECTIONREQUEST_H_
+#define GEODE_QUEUECONNECTIONREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __QUEUE_CONNECTION_REQUEST__
-#define __QUEUE_CONNECTION_REQUEST__
 #include "ServerLocationRequest.hpp"
 #include "ServerLocation.hpp"
 #include "ClientProxyMembershipID.hpp"
@@ -60,4 +63,5 @@ class QueueConnectionRequest : public ServerLocationRequest {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_QUEUECONNECTIONREQUEST_H_

--- a/src/cppcache/src/QueueConnectionResponse.hpp
+++ b/src/cppcache/src/QueueConnectionResponse.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_QUEUECONNECTIONRESPONSE_H_
+#define GEODE_QUEUECONNECTIONRESPONSE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __QUEUE_CONNECTION_RESPONSE__
-#define __QUEUE_CONNECTION_RESPONSE__
 #include <list>
 #include "ServerLocationResponse.hpp"
 #include <gfcpp/DataInput.hpp>
@@ -49,4 +52,5 @@ typedef SharedPtr<QueueConnectionResponse> QueueConnectionResponsePtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_QUEUECONNECTIONRESPONSE_H_

--- a/src/cppcache/src/ReadWriteLock.hpp
+++ b/src/cppcache/src/ReadWriteLock.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_READWRITELOCK_H_
+#define GEODE_READWRITELOCK_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_IMPL_READWRITELOCK_HPP_
-#define _GEMFIRE_IMPL_READWRITELOCK_HPP_
 
 #include <ace/RW_Thread_Mutex.h>
 #include "Condition.hpp"
@@ -89,4 +92,4 @@ class TryWriteGuard {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_READWRITELOCK_H_

--- a/src/cppcache/src/RegionCommit.hpp
+++ b/src/cppcache/src/RegionCommit.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_REGIONCOMMIT_H_
+#define GEODE_REGIONCOMMIT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef REGIONCOMMIT_HPP_
-#define REGIONCOMMIT_HPP_
 
 #include <gfcpp/gf_types.hpp>
 #include <gfcpp/SharedBase.hpp>
@@ -60,4 +63,5 @@ class RegionCommit : public apache::geode::client::SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* REGIONCOMMIT_HPP_ */
+
+#endif // GEODE_REGIONCOMMIT_H_

--- a/src/cppcache/src/RegionExpiryHandler.hpp
+++ b/src/cppcache/src/RegionExpiryHandler.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REGIONEXPIRYTASK_H__
-#define __GEMFIRE_REGIONEXPIRYTASK_H__
+#pragma once
+
+#ifndef GEODE_REGIONEXPIRYHANDLER_H_
+#define GEODE_REGIONEXPIRYHANDLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -69,4 +72,4 @@ class CPPCACHE_EXPORT RegionExpiryHandler : public ACE_Event_Handler {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONEXPIRYTASK_H__
+#endif // GEODE_REGIONEXPIRYHANDLER_H_

--- a/src/cppcache/src/RegionGlobalLocks.hpp
+++ b/src/cppcache/src/RegionGlobalLocks.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_REGIONGLOBAL_H__
-#define __GEMFIRE_REGIONGLOBAL_H__
+#pragma once
+
+#ifndef GEODE_REGIONGLOBALLOCKS_H_
+#define GEODE_REGIONGLOBALLOCKS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,4 +43,4 @@ class CPPCACHE_EXPORT RegionGlobalLocks {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONGLOBAL_H__
+#endif // GEODE_REGIONGLOBALLOCKS_H_

--- a/src/cppcache/src/RegionInternal.hpp
+++ b/src/cppcache/src/RegionInternal.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_REGIONINTERNAL_H__
-#define __GEMFIRE_REGIONINTERNAL_H__
+#pragma once
+
+#ifndef GEODE_REGIONINTERNAL_H_
+#define GEODE_REGIONINTERNAL_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -295,4 +297,4 @@ typedef SharedPtr<RegionInternal> RegionInternalPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REGIONINTERNAL_H__
+#endif // GEODE_REGIONINTERNAL_H_

--- a/src/cppcache/src/RegionStats.hpp
+++ b/src/cppcache/src/RegionStats.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_REGIONSTATS_H_
+#define GEODE_REGIONSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_REGIONSTATS_H__
-#define __GEMFIRE_REGIONSTATS_H__ 1
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
@@ -233,4 +235,4 @@ class RegionStatType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_REGIONSTATS_H__
+#endif // GEODE_REGIONSTATS_H_

--- a/src/cppcache/src/RegionXmlCreation.hpp
+++ b/src/cppcache/src/RegionXmlCreation.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_REGIONXMLCREATION_HPP_
-#define _GEMFIRE_REGIONXMLCREATION_HPP_
+#pragma once
+
+#ifndef GEODE_REGIONXMLCREATION_H_
+#define GEODE_REGIONXMLCREATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -127,4 +130,5 @@ class CPPCACHE_EXPORT RegionXmlCreation {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // #ifndef  _GEMFIRE_REGIONXMLCREATION_HPP_
+
+#endif // GEODE_REGIONXMLCREATION_H_

--- a/src/cppcache/src/RemoteQuery.hpp
+++ b/src/cppcache/src/RemoteQuery.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REMOTEQUERY_H__
-#define __GEMFIRE_REMOTEQUERY_H__
+#pragma once
+
+#ifndef GEODE_REMOTEQUERY_H_
+#define GEODE_REMOTEQUERY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -82,4 +85,4 @@ typedef SharedPtr<RemoteQuery> RemoteQueryPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_REMOTEQUERY_H__
+#endif // GEODE_REMOTEQUERY_H_

--- a/src/cppcache/src/RemoteQueryService.hpp
+++ b/src/cppcache/src/RemoteQueryService.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_REMOTEQUERYSERVICE_H__
-#define __GEMFIRE_REMOTEQUERYSERVICE_H__
+#pragma once
+
+#ifndef GEODE_REMOTEQUERYSERVICE_H_
+#define GEODE_REMOTEQUERYSERVICE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -86,4 +89,5 @@ typedef SharedPtr<RemoteQueryService> RemoteQueryServicePtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef __GEMFIRE_REMOTEQUERYSERVICE_H__
+
+#endif // GEODE_REMOTEQUERYSERVICE_H_

--- a/src/cppcache/src/ResultSetImpl.hpp
+++ b/src/cppcache/src/ResultSetImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_RESULTSETIMPL_H__
-#define __GEMFIRE_RESULTSETIMPL_H__
+#pragma once
+
+#ifndef GEODE_RESULTSETIMPL_H_
+#define GEODE_RESULTSETIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -61,4 +64,4 @@ class CPPCACHE_EXPORT ResultSetImpl : public ResultSet {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_RESULTSETIMPL_H__
+#endif // GEODE_RESULTSETIMPL_H_

--- a/src/cppcache/src/SerializationRegistry.hpp
+++ b/src/cppcache/src/SerializationRegistry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SERIALIZATIONREGISTRY_H_
+#define GEODE_SERIALIZATIONREGISTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_IMPL_SERIALIZATIONREGISTRY_HPP_
-#define _GEMFIRE_IMPL_SERIALIZATIONREGISTRY_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 
@@ -155,4 +157,4 @@ class CPPCACHE_EXPORT SerializationRegistry {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_SERIALIZATIONREGISTRY_H_

--- a/src/cppcache/src/ServerLocation.hpp
+++ b/src/cppcache/src/ServerLocation.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SERVERLOCATION_H_
+#define GEODE_SERVERLOCATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __SERVER_LOCATION__
-#define __SERVER_LOCATION__
 #include <gfcpp/Serializable.hpp>
 #include <string>
 #include <gfcpp/DataInput.hpp>
@@ -175,4 +178,5 @@ class CPPCACHE_EXPORT ServerLocation : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_SERVERLOCATION_H_

--- a/src/cppcache/src/ServerLocationRequest.hpp
+++ b/src/cppcache/src/ServerLocationRequest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SERVERLOCATIONREQUEST_H_
+#define GEODE_SERVERLOCATIONREQUEST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __SERVER_LOCATION_REQUEST__
-#define __SERVER_LOCATION_REQUEST__
 #include <gfcpp/Serializable.hpp>
 namespace apache {
 namespace geode {
@@ -34,4 +37,5 @@ class ServerLocationRequest : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_SERVERLOCATIONREQUEST_H_

--- a/src/cppcache/src/ServerLocationResponse.hpp
+++ b/src/cppcache/src/ServerLocationResponse.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SERVERLOCATIONRESPONSE_H_
+#define GEODE_SERVERLOCATIONRESPONSE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __SERVER_LOCATION__RESPONSE__
-#define __SERVER_LOCATION__RESPONSE__
 #include <gfcpp/Serializable.hpp>
 #include "GeodeTypeIdsImpl.hpp"
 namespace apache {
@@ -39,4 +42,5 @@ class ServerLocationResponse : public Serializable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_SERVERLOCATIONRESPONSE_H_

--- a/src/cppcache/src/Set.hpp
+++ b/src/cppcache/src/Set.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SET_H_
+#define GEODE_SET_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_SET_HPP_
-#define _GEMFIRE_SET_HPP_
 
 #include <unordered_set>
 #include <ace/Guard_T.h>
@@ -125,4 +128,4 @@ class CPPCACHE_EXPORT Set : private NonAssignable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // !defined _GEMFIRE_SET_HPP_
+#endif // GEODE_SET_H_

--- a/src/cppcache/src/SpinLock.hpp
+++ b/src/cppcache/src/SpinLock.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SPINLOCK_H_
+#define GEODE_SPINLOCK_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_UTIL_IMPL_SPINLOCK_HPP__
-#define __GEMFIRE_UTIL_IMPL_SPINLOCK_HPP__
 
 #include "HostAsm.hpp"
 
@@ -116,4 +119,4 @@ CPPCACHE_EXPORT void testSpinLockRelease(void* lock);
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_SPINLOCK_H_

--- a/src/cppcache/src/SslSockStream.hpp
+++ b/src/cppcache/src/SslSockStream.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SSLSOCKSTREAM_H_
+#define GEODE_SSLSOCKSTREAM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __SslSockStream_hpp__
-#define __SslSockStream_hpp__
 
 #include <ace/ACE.h>
 #include <ace/DLL.h>
@@ -90,4 +93,5 @@ class SslSockStream {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __SslSockStream_hpp__
+
+#endif // GEODE_SSLSOCKSTREAM_H_

--- a/src/cppcache/src/StackFrame.hpp
+++ b/src/cppcache/src/StackFrame.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_STACKFRAME_H_
+#define GEODE_STACKFRAME_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_STACKFRAME_HPP_
-#define _GEMFIRE_STACKFRAME_HPP_
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -142,4 +144,4 @@ class StackFrame {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* _GEMFIRE_STACKFRAME_HPP_ */
+#endif // GEODE_STACKFRAME_H_

--- a/src/cppcache/src/StackTrace.hpp
+++ b/src/cppcache/src/StackTrace.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_STACKTRACE_H_
+#define GEODE_STACKTRACE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_STACKTRACE_HPP_
-#define _GEMFIRE_STACKTRACE_HPP_
 
 #define GF_TRACE_LEN 25
 
@@ -64,4 +66,4 @@ class StackTrace : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_STACKTRACE_H_

--- a/src/cppcache/src/StructSetImpl.hpp
+++ b/src/cppcache/src/StructSetImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef __GEMFIRE_STRUCTSETIMPL_H__
-#define __GEMFIRE_STRUCTSETIMPL_H__
+#pragma once
+
+#ifndef GEODE_STRUCTSETIMPL_H_
+#define GEODE_STRUCTSETIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -73,4 +76,4 @@ class CPPCACHE_EXPORT StructSetImpl : public StructSet {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_STRUCTSETIMPL_H__
+#endif // GEODE_STRUCTSETIMPL_H_

--- a/src/cppcache/src/SuspendedTxExpiryHandler.hpp
+++ b/src/cppcache/src/SuspendedTxExpiryHandler.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_SUSPENDEDTXEXPIRYHANDLER_H_
+#define GEODE_SUSPENDEDTXEXPIRYHANDLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_SUSPENDEDTXEXPIRYTASK_H__
-#define _GEMFIRE_SUSPENDEDTXEXPIRYTASK_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Cache.hpp>
@@ -63,4 +66,5 @@ class CPPCACHE_EXPORT SuspendedTxExpiryHandler : public ACE_Event_Handler {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // ifndef _GEMFIRE_ENTRYEXPIRYTASK_H__
+
+#endif // GEODE_SUSPENDEDTXEXPIRYHANDLER_H_

--- a/src/cppcache/src/TSSTXStateWrapper.hpp
+++ b/src/cppcache/src/TSSTXStateWrapper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TSSTXSTATEWRAPPER_H_
+#define GEODE_TSSTXSTATEWRAPPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TSSTXSTATEWRAPPER_HPP_
-#define TSSTXSTATEWRAPPER_HPP_
 
 #include <ace/TSS_T.h>
 #include "TXId.hpp"
@@ -50,4 +53,5 @@ class TSSTXStateWrapper {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TSSTXSTATEWRAPPER_HPP_ */
+
+#endif // GEODE_TSSTXSTATEWRAPPER_H_

--- a/src/cppcache/src/TXCleaner.hpp
+++ b/src/cppcache/src/TXCleaner.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXCLEANER_H_
+#define GEODE_TXCLEANER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: sshcherbakov
  */
 
-#ifndef TXCLEANER_HPP_
-#define TXCLEANER_HPP_
 
 #include "CacheTransactionManagerImpl.hpp"
 #include "TSSTXStateWrapper.hpp"
@@ -52,4 +55,5 @@ class TXCleaner {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TXCLEANER_HPP_ */
+
+#endif // GEODE_TXCLEANER_H_

--- a/src/cppcache/src/TXCommitMessage.hpp
+++ b/src/cppcache/src/TXCommitMessage.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXCOMMITMESSAGE_H_
+#define GEODE_TXCOMMITMESSAGE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TXCOMMITMESSAGE_HPP_
-#define TXCOMMITMESSAGE_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/gf_types.hpp>
@@ -58,4 +61,5 @@ class TXCommitMessage : public apache::geode::client::Cacheable {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif /* TXCOMMITMESSAGE_HPP_ */
+
+#endif // GEODE_TXCOMMITMESSAGE_H_

--- a/src/cppcache/src/TXEntryState.hpp
+++ b/src/cppcache/src/TXEntryState.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXENTRYSTATE_H_
+#define GEODE_TXENTRYSTATE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TXENTRYSTATE_HPP_
-#define TXENTRYSTATE_HPP_
 
 #include <gfcpp/gf_types.hpp>
 
@@ -85,4 +88,5 @@ _GF_PTR_DEF_(TXEntryState, TXEntryStatePtr);
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TXENTRYSTATE_HPP_ */
+
+#endif // GEODE_TXENTRYSTATE_H_

--- a/src/cppcache/src/TXId.hpp
+++ b/src/cppcache/src/TXId.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXID_H_
+#define GEODE_TXID_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TXID_H_
-#define TXID_H_
 
 #include <gfcpp/gf_types.hpp>
 #include <gfcpp/TransactionId.hpp>
@@ -52,4 +55,5 @@ class TXId : public apache::geode::client::TransactionId {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TXID_H_ */
+
+#endif // GEODE_TXID_H_

--- a/src/cppcache/src/TXRegionState.hpp
+++ b/src/cppcache/src/TXRegionState.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXREGIONSTATE_H_
+#define GEODE_TXREGIONSTATE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TXREGIONSTATE_HPP_
-#define TXREGIONSTATE_HPP_
 
 #include <gfcpp/gf_types.hpp>
 #include <gfcpp/HashMapT.hpp>
@@ -48,4 +51,5 @@ _GF_PTR_DEF_(TXRegionState, TXRegionStatePtr);
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TXREGIONSTATE_HPP_ */
+
+#endif // GEODE_TXREGIONSTATE_H_

--- a/src/cppcache/src/TXState.hpp
+++ b/src/cppcache/src/TXState.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TXSTATE_H_
+#define GEODE_TXSTATE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TXSTATE_HPP_
-#define TXSTATE_HPP_
 
 #include "TXId.hpp"
 #include "TXRegionState.hpp"
@@ -100,4 +103,5 @@ class TXState {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TXSTATE_HPP_ */
+
+#endif // GEODE_TXSTATE_H_

--- a/src/cppcache/src/TableOfPrimes.hpp
+++ b/src/cppcache/src/TableOfPrimes.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TABLEOFPRIMES_H_
+#define GEODE_TABLEOFPRIMES_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_TABLEOFPRIMES_H__
-#define __GEMFIRE_IMPL_TABLEOFPRIMES_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <algorithm>
@@ -88,4 +91,4 @@ class CPPCACHE_EXPORT TableOfPrimes {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_TABLEOFPRIMES_H__
+#endif // GEODE_TABLEOFPRIMES_H_

--- a/src/cppcache/src/TcpConn.hpp
+++ b/src/cppcache/src/TcpConn.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCPCONN_H_
+#define GEODE_TCPCONN_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TcpConn_hpp__
-#define __TcpConn_hpp__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Log.hpp>
@@ -139,4 +142,5 @@ class CPPCACHE_EXPORT TcpConn : public Connector {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TcpConn_hpp__
+
+#endif // GEODE_TCPCONN_H_

--- a/src/cppcache/src/TcpSslConn.hpp
+++ b/src/cppcache/src/TcpSslConn.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCPSSLCONN_H_
+#define GEODE_TCPSSLCONN_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TcpSslConn_hpp__
-#define __TcpSslConn_hpp__
 
 #include "TcpConn.hpp"
 #include <ace/DLL.h>
@@ -85,4 +88,5 @@ class TcpSslConn : public TcpConn {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TcpSslConn_hpp__
+
+#endif // GEODE_TCPSSLCONN_H_

--- a/src/cppcache/src/TcrChunkedContext.hpp
+++ b/src/cppcache/src/TcrChunkedContext.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRCHUNKEDCONTEXT_H_
+#define GEODE_TCRCHUNKEDCONTEXT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,8 +25,6 @@
  *
  */
 
-#ifndef __TCR_CHUNKED_CONTEXT_HPP__
-#define __TCR_CHUNKED_CONTEXT_HPP__
 
 #include <memory>
 
@@ -184,4 +187,5 @@ class TcrChunkedContext {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TCR_CHUNKED_CONTEXT_HPP__
+
+#endif // GEODE_TCRCHUNKEDCONTEXT_H_

--- a/src/cppcache/src/TcrConnection.hpp
+++ b/src/cppcache/src/TcrConnection.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRCONNECTION_H_
+#define GEODE_TCRCONNECTION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_CONNECTION_HPP__
-#define __TCR_CONNECTION_HPP__
 
 #include <ace/Semaphore.h>
 #include <gfcpp/gfcpp_globals.hpp>
@@ -404,4 +407,5 @@ class CPPCACHE_EXPORT TcrConnection {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TCR_CONNECTION_HPP__
+
+#endif // GEODE_TCRCONNECTION_H_

--- a/src/cppcache/src/TcrConnectionManager.hpp
+++ b/src/cppcache/src/TcrConnectionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRCONNECTIONMANAGER_H_
+#define GEODE_TCRCONNECTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_CONNECTIONMANAGER_HPP__
-#define __TCR_CONNECTIONMANAGER_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "GF_TASK_T.hpp"
@@ -208,4 +211,5 @@ class DistManagersLockGuard {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TCR_CONNECTIONMANAGER_HPP__
+
+#endif // GEODE_TCRCONNECTIONMANAGER_H_

--- a/src/cppcache/src/TcrDistributionManager.hpp
+++ b/src/cppcache/src/TcrDistributionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRDISTRIBUTIONMANAGER_H_
+#define GEODE_TCRDISTRIBUTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_DISTRIBUTION_MANAGER_HPP__
-#define __TCR_DISTRIBUTION_MANAGER_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "ThinClientDistributionManager.hpp"
@@ -53,4 +56,5 @@ class CPPCACHE_EXPORT TcrDistributionManager
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __TCR_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_TCRDISTRIBUTIONMANAGER_H_

--- a/src/cppcache/src/TcrEndpoint.hpp
+++ b/src/cppcache/src/TcrEndpoint.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRENDPOINT_H_
+#define GEODE_TCRENDPOINT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_ENDPOINT_HPP__
-#define __TCR_ENDPOINT_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <string>
@@ -263,4 +266,5 @@ class CPPCACHE_EXPORT TcrEndpoint {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __TCR_ENDPOINT_HPP__
+
+#endif // GEODE_TCRENDPOINT_H_

--- a/src/cppcache/src/TcrHADistributionManager.hpp
+++ b/src/cppcache/src/TcrHADistributionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRHADISTRIBUTIONMANAGER_H_
+#define GEODE_TCRHADISTRIBUTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCRHA_DISTRIBUTION_MANAGER_HPP__
-#define __TCRHA_DISTRIBUTION_MANAGER_HPP__
 
 #include <gfcpp/gf_base.hpp>
 #include "ThinClientDistributionManager.hpp"
@@ -94,4 +97,5 @@ class CPPCACHE_EXPORT TcrHADistributionManager
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TCRHA_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_TCRHADISTRIBUTIONMANAGER_H_

--- a/src/cppcache/src/TcrMessage.hpp
+++ b/src/cppcache/src/TcrMessage.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRMESSAGE_H_
+#define GEODE_TCRMESSAGE_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_MESSAGE_HPP__
-#define __TCR_MESSAGE_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "AtomicInc.hpp"
@@ -1224,4 +1227,5 @@ class TcrMessageHelper {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TCR_MESSAGE_HPP__
+
+#endif // GEODE_TCRMESSAGE_H_

--- a/src/cppcache/src/TcrPoolEndPoint.hpp
+++ b/src/cppcache/src/TcrPoolEndPoint.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TCRPOOLENDPOINT_H_
+#define GEODE_TCRPOOLENDPOINT_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TCR_POOL_ENDPOINT__
-#define __TCR_POOL_ENDPOINT__
 #include "TcrEndpoint.hpp"
 #include "PoolStatistics.hpp"
 namespace apache {
@@ -60,4 +63,5 @@ class TcrPoolEndPoint : public TcrEndpoint {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_TCRPOOLENDPOINT_H_

--- a/src/cppcache/src/ThinClientBaseDM.hpp
+++ b/src/cppcache/src/ThinClientBaseDM.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTBASEDM_H_
+#define GEODE_THINCLIENTBASEDM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_BASE_DISTRIBUTION_MANAGER_HPP__
-#define __THINCLIENT_BASE_DISTRIBUTION_MANAGER_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include "TcrConnectionManager.hpp"
@@ -198,4 +201,5 @@ class ThinClientBaseDM {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __THINCLIENT_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_THINCLIENTBASEDM_H_

--- a/src/cppcache/src/ThinClientCacheDistributionManager.hpp
+++ b/src/cppcache/src/ThinClientCacheDistributionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTCACHEDISTRIBUTIONMANAGER_H_
+#define GEODE_THINCLIENTCACHEDISTRIBUTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_CACHE_DISTRIBUTION_MANAGER_HPP__
-#define __THINCLIENT_CACHE_DISTRIBUTION_MANAGER_HPP__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
@@ -62,4 +65,5 @@ typedef SharedPtr<ThinClientCacheDistributionManager>
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __THINCLIENT_CACHE_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_THINCLIENTCACHEDISTRIBUTIONMANAGER_H_

--- a/src/cppcache/src/ThinClientDistributionManager.hpp
+++ b/src/cppcache/src/ThinClientDistributionManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTDISTRIBUTIONMANAGER_H_
+#define GEODE_THINCLIENTDISTRIBUTIONMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_DISTRIBUTION_MANAGER_HPP__
-#define __THINCLIENT_DISTRIBUTION_MANAGER_HPP__
 
 #include "ThinClientBaseDM.hpp"
 
@@ -76,4 +79,5 @@ class ThinClientDistributionManager : public ThinClientBaseDM {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __THINCLIENT_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_THINCLIENTDISTRIBUTIONMANAGER_H_

--- a/src/cppcache/src/ThinClientHARegion.hpp
+++ b/src/cppcache/src/ThinClientHARegion.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_THINCLIENTHAREGION_H__
-#define __GEMFIRE_THINCLIENTHAREGION_H__
+#pragma once
+
+#ifndef GEODE_THINCLIENTHAREGION_H_
+#define GEODE_THINCLIENTHAREGION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -86,4 +88,4 @@ class CPPCACHE_EXPORT ThinClientHARegion : public ThinClientRegion {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_THINCLIENTHAREGION_H__
+#endif // GEODE_THINCLIENTHAREGION_H_

--- a/src/cppcache/src/ThinClientLocatorHelper.hpp
+++ b/src/cppcache/src/ThinClientLocatorHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTLOCATORHELPER_H_
+#define GEODE_THINCLIENTLOCATORHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __LOCATOR_HELPER_HPP_INCLUDED__
-#define __LOCATOR_HELPER_HPP_INCLUDED__
 
 #include <string>
 #include <gfcpp/gfcpp_globals.hpp>
@@ -67,4 +70,5 @@ class ThinClientLocatorHelper {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_THINCLIENTLOCATORHELPER_H_

--- a/src/cppcache/src/ThinClientPoolDM.hpp
+++ b/src/cppcache/src/ThinClientPoolDM.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTPOOLDM_H_
+#define GEODE_THINCLIENTPOOLDM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_POOL_DISTRIBUTION_MANAGER_HPP__
-#define __THINCLIENT_POOL_DISTRIBUTION_MANAGER_HPP__
 
 #include <string>
 #include "ThinClientBaseDM.hpp"
@@ -678,4 +681,5 @@ class OnRegionFunctionExecution : public PooledWork<GfErrType> {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __THINCLIENT_POOL_DISTRIBUTION_MANAGER_HPP__
+
+#endif // GEODE_THINCLIENTPOOLDM_H_

--- a/src/cppcache/src/ThinClientPoolHADM.hpp
+++ b/src/cppcache/src/ThinClientPoolHADM.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTPOOLHADM_H_
+#define GEODE_THINCLIENTPOOLHADM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THIN_CLIENT_POOL_HADM__
-#define __THIN_CLIENT_POOL_HADM__
 #include "ThinClientPoolDM.hpp"
 #include "PoolAttributes.hpp"
 #include "TcrConnectionManager.hpp"
@@ -145,4 +148,5 @@ typedef SharedPtr<ThinClientPoolHADM> ThinClientPoolHADMPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_THINCLIENTPOOLHADM_H_

--- a/src/cppcache/src/ThinClientPoolRegion.hpp
+++ b/src/cppcache/src/ThinClientPoolRegion.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTPOOLREGION_H_
+#define GEODE_THINCLIENTPOOLREGION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTPOOLREGION_HPP_
-#define THINCLIENTPOOLREGION_HPP_
 
 #include "ThinClientHARegion.hpp"
 
@@ -53,4 +56,5 @@ class ThinClientPoolRegion : public ThinClientRegion {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* THINCLIENTPOOLREGION_HPP_ */
+
+#endif // GEODE_THINCLIENTPOOLREGION_H_

--- a/src/cppcache/src/ThinClientPoolStickyDM.hpp
+++ b/src/cppcache/src/ThinClientPoolStickyDM.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTPOOLSTICKYDM_H_
+#define GEODE_THINCLIENTPOOLSTICKYDM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_POOL_STICKY_DM__
-#define __THINCLIENT_POOL_STICKY_DM__
 #include "ThinClientPoolDM.hpp"
 #include "ThinClientStickyManager.hpp"
 namespace apache {
@@ -53,4 +56,5 @@ typedef SharedPtr<ThinClientPoolStickyDM> ThinClientPoolStickyDMPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_THINCLIENTPOOLSTICKYDM_H_

--- a/src/cppcache/src/ThinClientPoolStickyHADM.hpp
+++ b/src/cppcache/src/ThinClientPoolStickyHADM.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTPOOLSTICKYHADM_H_
+#define GEODE_THINCLIENTPOOLSTICKYHADM_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_POOL_STICKY_HA_DM__
-#define __THINCLIENT_POOL_STICKY_HA_DM__
 #include "ThinClientPoolHADM.hpp"
 
 namespace apache {
@@ -54,4 +57,5 @@ typedef SharedPtr<ThinClientPoolStickyHADM> ThinClientPoolStickyHADMPtr;
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_THINCLIENTPOOLSTICKYHADM_H_

--- a/src/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/src/cppcache/src/ThinClientRedundancyManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTREDUNDANCYMANAGER_H_
+#define GEODE_THINCLIENTREDUNDANCYMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef THINCLIENTREDUNDANCYMANAGER_HPP_
-#define THINCLIENTREDUNDANCYMANAGER_HPP_
 
 #include "TcrMessage.hpp"
 #include "TcrEndpoint.hpp"
@@ -145,4 +148,5 @@ class ThinClientRedundancyManager {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* THINCLIENTREDUNDANCYMANAGER_HPP_ */
+
+#endif // GEODE_THINCLIENTREDUNDANCYMANAGER_H_

--- a/src/cppcache/src/ThinClientRegion.hpp
+++ b/src/cppcache/src/ThinClientRegion.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_THINCLIENTREGION_H__
-#define __GEMFIRE_THINCLIENTREGION_H__
+#pragma once
+
+#ifndef GEODE_THINCLIENTREGION_H_
+#define GEODE_THINCLIENTREGION_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -620,4 +622,4 @@ typedef SharedPtr<ChunkedDurableCQListResponse> ChunkedDurableCQListResponsePtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_THINCLIENTREGION_H__
+#endif // GEODE_THINCLIENTREGION_H_

--- a/src/cppcache/src/ThinClientStickyManager.hpp
+++ b/src/cppcache/src/ThinClientStickyManager.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THINCLIENTSTICKYMANAGER_H_
+#define GEODE_THINCLIENTSTICKYMANAGER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __THINCLIENT_POOL_STICKY_MANAGER__
-#define __THINCLIENT_POOL_STICKY_MANAGER__
 
 #include "TssConnectionWrapper.hpp"
 #include <algorithm>
@@ -56,4 +59,5 @@ class ThinClientStickyManager {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_THINCLIENTSTICKYMANAGER_H_

--- a/src/cppcache/src/ThreadPool.hpp
+++ b/src/cppcache/src/ThreadPool.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_THREADPOOL_H_
+#define GEODE_THREADPOOL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef THREADPOOL_HPP_
-#define THREADPOOL_HPP_
 
 #include <ace/Task.h>
 #include <ace/Method_Request.h>
@@ -158,4 +161,5 @@ typedef ACE_Singleton<ThreadPool, ACE_Recursive_Thread_Mutex> TPSingleton;
 }  // namespace geode
 }  // namespace apache
 
-#endif /* THREADPOOL_HPP_ */
+
+#endif // GEODE_THREADPOOL_H_

--- a/src/cppcache/src/TimeoutTimer.hpp
+++ b/src/cppcache/src/TimeoutTimer.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TIMEOUTTIMER_H_
+#define GEODE_TIMEOUTTIMER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_TIMEOUT_HPP_
-#define _GEMFIRE_TIMEOUT_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 
@@ -67,4 +70,4 @@ class CPPCACHE_EXPORT TimeoutTimer {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+#endif // GEODE_TIMEOUTTIMER_H_

--- a/src/cppcache/src/TombstoneExpiryHandler.hpp
+++ b/src/cppcache/src/TombstoneExpiryHandler.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TOMBSTONEEXPIRYHANDLER_H_
+#define GEODE_TOMBSTONEEXPIRYHANDLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_TOMBSTONEEXPIRYTASK_H__
-#define __GEMFIRE_TOMBSTONEEXPIRYTASK_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Region.hpp>
@@ -71,4 +74,4 @@ class CPPCACHE_EXPORT TombstoneExpiryHandler : public ACE_Event_Handler {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_TOMBSTONEEXPIRYTASK_H__
+#endif // GEODE_TOMBSTONEEXPIRYHANDLER_H_

--- a/src/cppcache/src/TombstoneList.hpp
+++ b/src/cppcache/src/TombstoneList.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TOMBSTONELIST_H_
+#define GEODE_TOMBSTONELIST_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_IMPL_TOMBSTONELIST_H__
-#define __GEMFIRE_IMPL_TOMBSTONELIST_H__
 
 #include <list>
 #include <ace/Recursive_Thread_Mutex.h>
@@ -98,4 +100,4 @@ typedef SharedPtr<TombstoneList> TombstoneListPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // !defined (__GEMFIRE_IMPL_TOMBSTONELIST_H__)
+#endif // GEODE_TOMBSTONELIST_H_

--- a/src/cppcache/src/TrackedMapEntry.hpp
+++ b/src/cppcache/src/TrackedMapEntry.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TRACKEDMAPENTRY_H_
+#define GEODE_TRACKEDMAPENTRY_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef __GEMFIRE_IMPL_TRACKEDMAPENTRY_HPP__
-#define __GEMFIRE_IMPL_TRACKEDMAPENTRY_HPP__
 
 #include "MapEntry.hpp"
 
@@ -79,4 +81,4 @@ class TrackedMapEntry : public MapEntry {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* __GEMFIRE_IMPL_TRACKEDMAPENTRY_HPP__ */
+#endif // GEODE_TRACKEDMAPENTRY_H_

--- a/src/cppcache/src/TransactionSuspender.hpp
+++ b/src/cppcache/src/TransactionSuspender.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TRANSACTIONSUSPENDER_H_
+#define GEODE_TRANSACTIONSUSPENDER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TRANSACTIONSUSPENDER_HPP_
-#define TRANSACTIONSUSPENDER_HPP_
 
 #include "TXState.hpp"
 
@@ -42,4 +45,5 @@ class TransactionSuspender {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TRANSACTIONSUSPENDER_HPP_ */
+
+#endif // GEODE_TRANSACTIONSUSPENDER_H_

--- a/src/cppcache/src/TransactionalOperation.hpp
+++ b/src/cppcache/src/TransactionalOperation.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TRANSACTIONALOPERATION_H_
+#define GEODE_TRANSACTIONALOPERATION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef TRANSACTIONALOPERATION_HPP_
-#define TRANSACTIONALOPERATION_HPP_
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/gf_types.hpp>
@@ -70,4 +73,5 @@ class TransactionalOperation : public apache::geode::client::SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /* TRANSACTIONALOPERATION_HPP_ */
+
+#endif // GEODE_TRANSACTIONALOPERATION_H_

--- a/src/cppcache/src/TssConnectionWrapper.hpp
+++ b/src/cppcache/src/TssConnectionWrapper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_TSSCONNECTIONWRAPPER_H_
+#define GEODE_TSSCONNECTIONWRAPPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _TSS_CONNECTION_WRAPPER_HPP_
-#define _TSS_CONNECTION_WRAPPER_HPP_
 #include <ace/TSS_T.h>
 #include <gfcpp/Pool.hpp>
 #include <map>
@@ -72,4 +75,5 @@ class TssConnectionWrapper {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_TSSCONNECTIONWRAPPER_H_

--- a/src/cppcache/src/UserAttributes.hpp
+++ b/src/cppcache/src/UserAttributes.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_USERATTRIBUTES_H__
-#define __GEMFIRE_USERATTRIBUTES_H__
+#pragma once
+
+#ifndef GEODE_USERATTRIBUTES_H_
+#define GEODE_USERATTRIBUTES_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -17,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/Properties.hpp>
 #include "TcrEndpoint.hpp"
@@ -152,4 +155,4 @@ class GuardUserAttribures {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_USERATTRIBUTES_H__
+#endif // GEODE_USERATTRIBUTES_H_

--- a/src/cppcache/src/Utils.hpp
+++ b/src/cppcache/src/Utils.hpp
@@ -1,5 +1,7 @@
-#ifndef __GEMFIRE_IMPL_UTILS_H__
-#define __GEMFIRE_IMPL_UTILS_H__
+#pragma once
+
+#ifndef GEODE_UTILS_H_
+#define GEODE_UTILS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -224,4 +226,4 @@ class RandGen {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef __GEMFIRE_IMPL_UTILS_H__
+#endif // GEODE_UTILS_H_

--- a/src/cppcache/src/Version.hpp
+++ b/src/cppcache/src/Version.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_VERSION_H_
+#define GEODE_VERSION_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_VERSION_HPP__
-#define __GEMFIRE_VERSION_HPP__
+
 #include "CacheImpl.hpp"
 
 namespace apache {
@@ -36,4 +40,4 @@ class Version {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //__GEMFIRE_VERSION_HPP__s
+#endif // GEODE_VERSION_H_

--- a/src/cppcache/src/VersionStamp.hpp
+++ b/src/cppcache/src/VersionStamp.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_VERSIONSTAMP_H_
+#define GEODE_VERSIONSTAMP_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __GEMFIRE_IMPL_VERSIONSTAMP_H__
-#define __GEMFIRE_IMPL_VERSIONSTAMP_H__
 
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/SharedPtr.hpp>
@@ -80,4 +83,4 @@ typedef SharedPtr<VersionStamp> VersionStampPtr;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __GEMFIRE_IMPL_VERSIONSTAMP_H__
+#endif // GEODE_VERSIONSTAMP_H_

--- a/src/cppcache/src/VersionTag.hpp
+++ b/src/cppcache/src/VersionTag.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_VERSIONTAG_H_
+#define GEODE_VERSIONTAG_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __VERSIONTAG_HPP__
-#define __VERSIONTAG_HPP__
 
 #include <gfcpp/Cacheable.hpp>
 #include "GeodeTypeIdsImpl.hpp"
@@ -86,4 +89,5 @@ class VersionTag : public Cacheable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __VERSIONTAG_HPP__
+
+#endif // GEODE_VERSIONTAG_H_

--- a/src/cppcache/src/VersionedCacheableObjectPartList.hpp
+++ b/src/cppcache/src/VersionedCacheableObjectPartList.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_VERSIONEDCACHEABLEOBJECTPARTLIST_HPP_
-#define _GEMFIRE_VERSIONEDCACHEABLEOBJECTPARTLIST_HPP_
+#pragma once
+
+#ifndef GEODE_VERSIONEDCACHEABLEOBJECTPARTLIST_H_
+#define GEODE_VERSIONEDCACHEABLEOBJECTPARTLIST_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -283,4 +285,4 @@ class VersionedCacheableObjectPartList : public CacheableObjectPartList {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_VERSIONEDCACHEABLEOBJECTPARTLIST_HPP_
+#endif // GEODE_VERSIONEDCACHEABLEOBJECTPARTLIST_H_

--- a/src/cppcache/src/gfcppBanner.hpp
+++ b/src/cppcache/src/gfcppBanner.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_GFCPPBANNER_H_
+#define GEODE_GFCPPBANNER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -26,3 +31,5 @@ class gfcppBanner {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
+
+#endif // GEODE_GFCPPBANNER_H_

--- a/src/cppcache/src/statistics/AtomicStatisticsImpl.hpp
+++ b/src/cppcache/src/statistics/AtomicStatisticsImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_ATOMICSTATISTICSIMPL_HPP_
-#define _GEMFIRE_STATISTICS_ATOMICSTATISTICSIMPL_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
+#define GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -246,4 +249,4 @@ class AtomicStatisticsImpl : public Statistics, private NonCopyable {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //  _GEMFIRE_STATISTICS_ATOMICSTATISTICSIMPL_HPP_
+#endif // GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_

--- a/src/cppcache/src/statistics/GeodeStatisticsFactory.hpp
+++ b/src/cppcache/src/statistics/GeodeStatisticsFactory.hpp
@@ -1,7 +1,8 @@
+#pragma once
 
+#ifndef GEODE_STATISTICS_GEODESTATISTICSFACTORY_H_
+#define GEODE_STATISTICS_GEODESTATISTICSFACTORY_H_
 
-#ifndef _GEMFIRE_STATISTICS_GEMFIRESTATISTICSFACTORY_HPP_
-#define _GEMFIRE_STATISTICS_GEMFIRESTATISTICSFACTORY_HPP_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 
 #include <sys/types.h>
@@ -150,4 +152,4 @@ class GeodeStatisticsFactory : public StatisticsFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //  _GEMFIRE_STATISTICS_GEMFIRESTATISTICSFACTORY_HPP_
+#endif // GEODE_STATISTICS_GEODESTATISTICSFACTORY_H_

--- a/src/cppcache/src/statistics/HostStatHelper.hpp
+++ b/src/cppcache/src/statistics/HostStatHelper.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATHELPER_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATHELPER_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATHELPER_H_
+#define GEODE_STATISTICS_HOSTSTATHELPER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 #include <string>
 #include "StatisticDescriptorImpl.hpp"
@@ -77,4 +81,5 @@ class CPPCACHE_EXPORT HostStatHelper {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //_GEMFIRE_STATISTICS_HOSTSTATHELPER_HPP_
+
+#endif // GEODE_STATISTICS_HOSTSTATHELPER_H_

--- a/src/cppcache/src/statistics/HostStatHelperLinux.hpp
+++ b/src/cppcache/src/statistics/HostStatHelperLinux.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATHELPERLINUX_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATHELPERLINUX_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATHELPERLINUX_H_
+#define GEODE_STATISTICS_HOSTSTATHELPERLINUX_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -49,4 +52,4 @@ class HostStatHelperLinux {
 
 #endif  // if def(_LINUX)
 
-#endif  // _GEMFIRE_STATISTICS_HOSTSTATHELPERLINUX_HPP_
+#endif // GEODE_STATISTICS_HOSTSTATHELPERLINUX_H_

--- a/src/cppcache/src/statistics/HostStatHelperNull.hpp
+++ b/src/cppcache/src/statistics/HostStatHelperNull.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATHELPERNULL_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATHELPERNULL_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATHELPERNULL_H_
+#define GEODE_STATISTICS_HOSTSTATHELPERNULL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -34,4 +37,4 @@ class HostStatHelperNull {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_HOSTSTATHELPERLINUX_HPP_
+#endif // GEODE_STATISTICS_HOSTSTATHELPERNULL_H_

--- a/src/cppcache/src/statistics/HostStatHelperSolaris.hpp
+++ b/src/cppcache/src/statistics/HostStatHelperSolaris.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATHELPERSOLARIS_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATHELPERSOLARIS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATHELPERSOLARIS_H_
+#define GEODE_STATISTICS_HOSTSTATHELPERSOLARIS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -65,4 +68,4 @@ class HostStatHelperSolaris {
 
 #endif  // if def(_SOLARIS)
 
-#endif  // _GEMFIRE_STATISTICS_HOSTSTATHELPERSOLARIS_HPP_
+#endif // GEODE_STATISTICS_HOSTSTATHELPERSOLARIS_H_

--- a/src/cppcache/src/statistics/HostStatHelperWin.hpp
+++ b/src/cppcache/src/statistics/HostStatHelperWin.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATHELPERWIN_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATHELPERWIN_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATHELPERWIN_H_
+#define GEODE_STATISTICS_HOSTSTATHELPERWIN_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -300,4 +303,4 @@ class HostStatHelperWin {
 
 #endif  // (_WIN32)
 
-#endif  // _GEMFIRE_STATISTICS_HOSTSTATHELPERWIN_HPP_
+#endif // GEODE_STATISTICS_HOSTSTATHELPERWIN_H_

--- a/src/cppcache/src/statistics/HostStatSampler.hpp
+++ b/src/cppcache/src/statistics/HostStatSampler.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_STATISTICS_HOSTSTATSAMPLER_HPP_
-#define _GEMFIRE_STATISTICS_HOSTSTATSAMPLER_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_HOSTSTATSAMPLER_H_
+#define GEODE_STATISTICS_HOSTSTATSAMPLER_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -251,4 +253,4 @@ class CPPCACHE_EXPORT HostStatSampler : public ACE_Task_Base,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_HOSTSTATSAMPLER_HPP_
+#endif // GEODE_STATISTICS_HOSTSTATSAMPLER_H_

--- a/src/cppcache/src/statistics/LinuxProcessStats.hpp
+++ b/src/cppcache/src/statistics/LinuxProcessStats.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_LINUXPROCESSSTATS_HPP_
-#define _GEMFIRE_STATISTICS_LINUXPROCESSSTATS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_LINUXPROCESSSTATS_H_
+#define GEODE_STATISTICS_LINUXPROCESSSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
 #include <gfcpp/statistics/StatisticsType.hpp>
@@ -79,4 +83,4 @@ class CPPCACHE_EXPORT LinuxProcessStats : public ProcessStats {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE_STATISTICS_LINUXPROCESSSTATS_HPP_
+#endif // GEODE_STATISTICS_LINUXPROCESSSTATS_H_

--- a/src/cppcache/src/statistics/NullProcessStats.hpp
+++ b/src/cppcache/src/statistics/NullProcessStats.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_NULLPROCESSSTATS_HPP_
-#define _GEMFIRE_STATISTICS_NULLPROCESSSTATS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_NULLPROCESSSTATS_H_
+#define GEODE_STATISTICS_NULLPROCESSSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 #include <gfcpp/statistics/Statistics.hpp>
 #include <gfcpp/statistics/StatisticsType.hpp>
@@ -53,4 +57,4 @@ class CPPCACHE_EXPORT NullProcessStats : public ProcessStats {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE_STATISTICS_NULLPROCESSSTATS_HPP_
+#endif // GEODE_STATISTICS_NULLPROCESSSTATS_H_

--- a/src/cppcache/src/statistics/OsStatisticsImpl.hpp
+++ b/src/cppcache/src/statistics/OsStatisticsImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_OSSTATISTICSIMPL_HPP_
-#define _GEMFIRE_STATISTICS_OSSTATISTICSIMPL_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_OSSTATISTICSIMPL_H_
+#define GEODE_STATISTICS_OSSTATISTICSIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -257,4 +260,4 @@ class OsStatisticsImpl : public Statistics,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_OSSTATISTICSIMPL_HPP_
+#endif // GEODE_STATISTICS_OSSTATISTICSIMPL_H_

--- a/src/cppcache/src/statistics/PoolStatsSampler.hpp
+++ b/src/cppcache/src/statistics/PoolStatsSampler.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_STATISTICS_POOLSTATSSAMPLER_H_
+#define GEODE_STATISTICS_POOLSTATSSAMPLER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __POOLSTATSSAMPLER__
-#define __POOLSTATSSAMPLER__
 #include <ace/Task.h>
 #include <gfcpp/gfcpp_globals.hpp>
 namespace apache {
@@ -59,4 +62,5 @@ class CPPCACHE_EXPORT PoolStatsSampler : public ACE_Task_Base {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif
+
+#endif // GEODE_STATISTICS_POOLSTATSSAMPLER_H_

--- a/src/cppcache/src/statistics/ProcessStats.hpp
+++ b/src/cppcache/src/statistics/ProcessStats.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_STATISTICS_PROCESSSTATS_HPP_
-#define _GEMFIRE_STATISTICS_PROCESSSTATS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_PROCESSSTATS_H_
+#define GEODE_STATISTICS_PROCESSSTATS_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -77,4 +79,5 @@ class CPPCACHE_EXPORT ProcessStats {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // _GEMFIRE_STATISTICS_PROCESSSTATS_HPP_
+
+#endif // GEODE_STATISTICS_PROCESSSTATS_H_

--- a/src/cppcache/src/statistics/SolarisProcessStats.hpp
+++ b/src/cppcache/src/statistics/SolarisProcessStats.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_SOLARISPROCESSSTATS_HPP_
-#define _GEMFIRE_STATISTICS_SOLARISPROCESSSTATS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_SOLARISPROCESSSTATS_H_
+#define GEODE_STATISTICS_SOLARISPROCESSSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -81,4 +84,4 @@ class CPPCACHE_EXPORT SolarisProcessStats : public ProcessStats {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE_STATISTICS_SOLARISPROCESSSTATS_HPP_
+#endif // GEODE_STATISTICS_SOLARISPROCESSSTATS_H_

--- a/src/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/src/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_STATISTICS_STATARCHIVEWRITER_H_
+#define GEODE_STATISTICS_STATARCHIVEWRITER_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_STATISTICS_STATARCHIVERITER_HPP_
-#define _GEMFIRE_STATISTICS_STATARCHIVERITER_HPP_
 
 #include <map>
 #include <list>
@@ -266,4 +268,4 @@ class CPPCACHE_EXPORT StatArchiveWriter {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GEMFIRE_STATISTICS_STATARCHIVERITER_HPP_
+#endif // GEODE_STATISTICS_STATARCHIVEWRITER_H_

--- a/src/cppcache/src/statistics/StatSamplerStats.hpp
+++ b/src/cppcache/src/statistics/StatSamplerStats.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICSSAMPLERSTATISTICS_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICSSAMPLERSTATISTICS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_STATSAMPLERSTATS_H_
+#define GEODE_STATISTICS_STATSAMPLERSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -54,4 +57,5 @@ class CPPCACHE_EXPORT StatSamplerStats {
 }  // namespace statistics
 }  // namespace geode
 }  // namespace apache
-#endif  //_GEMFIRE_STATISTICS_STATISTICSSAMPLERSTATISTICS_HPP_
+
+#endif // GEODE_STATISTICS_STATSAMPLERSTATS_H_

--- a/src/cppcache/src/statistics/StatisticDescriptorImpl.hpp
+++ b/src/cppcache/src/statistics/StatisticDescriptorImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_STATISTICS_STATISTICDESCRIPTORIMPL_H_
+#define GEODE_STATISTICS_STATISTICDESCRIPTORIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,9 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef _GEMFIRE_STATISTICS_STATISTICDESCRIPTORIMPL_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICDESCRIPTORIMPL_HPP_
 
 #include <string>
 #include <gfcpp/ExceptionTypes.hpp>
@@ -248,4 +250,4 @@ s
 }  // namespace geode
 }  // namespace apache
 
-#endif  //  _GEMFIRE_STATISTICS_STATISTICDESCRIPTORIMPL_HPP_
+#endif // GEODE_STATISTICS_STATISTICDESCRIPTORIMPL_H_

--- a/src/cppcache/src/statistics/StatisticsManager.hpp
+++ b/src/cppcache/src/statistics/StatisticsManager.hpp
@@ -1,7 +1,8 @@
+#pragma once
 
+#ifndef GEODE_STATISTICS_STATISTICSMANAGER_H_
+#define GEODE_STATISTICS_STATISTICSMANAGER_H_
 
-#ifndef _GEMFIRE_STATISTICS_STATISTICSAPPMANAGER_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICSAPPMANAGER_HPP_
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +19,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gfcpp/gfcpp_globals.hpp>
 
 #include <sys/types.h>
@@ -129,4 +131,4 @@ class StatisticsManager {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //  _GEMFIRE_STATISTICS_STATISTICSAPPMANAGER_HPP_
+#endif // GEODE_STATISTICS_STATISTICSMANAGER_H_

--- a/src/cppcache/src/statistics/StatisticsTypeImpl.hpp
+++ b/src/cppcache/src/statistics/StatisticsTypeImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_STATISTICSTYPEIMPL_HPP_
-#define _GEMFIRE_STATISTICS_STATISTICSTYPEIMPL_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_STATISTICSTYPEIMPL_H_
+#define GEODE_STATISTICS_STATISTICSTYPEIMPL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -99,4 +102,4 @@ class StatisticsTypeImpl : public StatisticsType {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // ifndef _GEMFIRE_STATISTICS_STATISTICSTYPEIMPL_HPP_
+#endif // GEODE_STATISTICS_STATISTICSTYPEIMPL_H_

--- a/src/cppcache/src/statistics/StatsDef.hpp
+++ b/src/cppcache/src/statistics/StatsDef.hpp
@@ -1,5 +1,7 @@
-#ifndef _GEMFIRE_STATISTICS_STATSDEF_HPP_
-#define _GEMFIRE_STATISTICS_STATSDEF_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_STATSDEF_H_
+#define GEODE_STATISTICS_STATSDEF_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -51,4 +53,5 @@ typedef enum {
 }  // namespace statistics
 }  // namespace geode
 }  // namespace apache
-#endif  // _GEMFIRE_STATISTICS_STATSDEF_HPP_
+
+#endif // GEODE_STATISTICS_STATSDEF_H_

--- a/src/cppcache/src/statistics/WindowsProcessStats.hpp
+++ b/src/cppcache/src/statistics/WindowsProcessStats.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE_STATISTICS_WINDOWSPROCESSSTATS_HPP_
-#define _GEMFIRE_STATISTICS_WINDOWSPROCESSSTATS_HPP_
+#pragma once
+
+#ifndef GEODE_STATISTICS_WINDOWSPROCESSSTATS_H_
+#define GEODE_STATISTICS_WINDOWSPROCESSSTATS_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -84,4 +87,4 @@ class CPPCACHE_EXPORT WindowsProcessStats : public ProcessStats {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE_STATISTICS_WINDOWSPROCESSSTATS_HPP_
+#endif // GEODE_STATISTICS_WINDOWSPROCESSSTATS_H_

--- a/src/cryptoimpl/DHImpl.hpp
+++ b/src/cryptoimpl/DHImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _DHEIMPL_HPP_INCLUDED_
-#define _DHEIMPL_HPP_INCLUDED_
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_051947d883001c8686df187fe716cbd0
+#define APACHE_GEODE_GUARD_051947d883001c8686df187fe716cbd0
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -94,4 +97,5 @@ class DHImpl {
 
 bool DHImpl::m_init = false;
 
-#endif  // _DHEIMPL_HPP_INCLUDED_
+
+#endif // APACHE_GEODE_GUARD_051947d883001c8686df187fe716cbd0

--- a/src/cryptoimpl/GFSsl.hpp
+++ b/src/cryptoimpl/GFSsl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_66e094f2e630a8aefdce2e4d93340f13
+#define APACHE_GEODE_GUARD_66e094f2e630a8aefdce2e4d93340f13
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: ankurs
  */
 
-#ifndef GFSSL_HPP_
-#define GFSSL_HPP_
 
 #include <ace/INET_Addr.h>
 #include <ace/OS.h>
@@ -39,4 +42,5 @@ class GFSsl {
   virtual void close() = 0;
 };
 
-#endif /* GFSSL_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_66e094f2e630a8aefdce2e4d93340f13

--- a/src/cryptoimpl/SSLImpl.hpp
+++ b/src/cryptoimpl/SSLImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_d7c8a71cb25b1a2fdc896009aee7509f
+#define APACHE_GEODE_GUARD_d7c8a71cb25b1a2fdc896009aee7509f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _SSLIMPL_HPP_INCLUDED_
-#define _SSLIMPL_HPP_INCLUDED_
 
 #include <gfcpp/gf_base.hpp>
 #include "ace/ACE.h"
@@ -56,4 +59,5 @@ CPPCACHE_EXPORT void* gf_create_SslImpl(ACE_SOCKET sock, const char* pubkeyfile,
 CPPCACHE_EXPORT void gf_destroy_SslImpl(void* impl);
 }
 
-#endif  // _SSLIMPL_HPP_INCLUDED_
+
+#endif // APACHE_GEODE_GUARD_d7c8a71cb25b1a2fdc896009aee7509f

--- a/src/dhimpl/DHImpl.hpp
+++ b/src/dhimpl/DHImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _DHEIMPL_HPP_INCLUDED_
-#define _DHEIMPL_HPP_INCLUDED_
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_0b4f257a1a4de03f53b0299148e95656
+#define APACHE_GEODE_GUARD_0b4f257a1a4de03f53b0299148e95656
+
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -64,4 +67,5 @@ CPPCACHE_EXPORT bool gf_verifyDH(const char* subject,
                                  int* reason);
 }
 
-#endif  // _DHEIMPL_HPP_INCLUDED_
+
+#endif // APACHE_GEODE_GUARD_0b4f257a1a4de03f53b0299148e95656

--- a/src/pdxautoserializer/ASBuiltins.hpp
+++ b/src/pdxautoserializer/ASBuiltins.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_eb7690d50321df9f22960c0ceecdeea5
+#define APACHE_GEODE_GUARD_eb7690d50321df9f22960c0ceecdeea5
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_ASBUILTINS_HPP_
-#define _GFAS_ASBUILTINS_HPP_
 
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -120,4 +123,5 @@ inline void readObject(apache::geode::client::DataInput& input,
 }
 }
 
-#endif  // _GFAS_ASBUILTINS_HPP_
+
+#endif // APACHE_GEODE_GUARD_eb7690d50321df9f22960c0ceecdeea5

--- a/src/pdxautoserializer/ASCLIBuiltins.hpp
+++ b/src/pdxautoserializer/ASCLIBuiltins.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_435faaccc293c5822dd1ce9185411ec7
+#define APACHE_GEODE_GUARD_435faaccc293c5822dd1ce9185411ec7
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_ASCLIBUILTINS_HPP_
-#define _GFAS_ASCLIBUILTINS_HPP_
 
 #ifdef GEMFIRE_CLR
 
@@ -457,4 +460,5 @@ inline void ReadObject(apache::geode::client::DataInput& input,
 
 #endif  // GEMFIRE_CLR
 
-#endif  // _GFAS_ASCLIBUILTINS_HPP_
+
+#endif // APACHE_GEODE_GUARD_435faaccc293c5822dd1ce9185411ec7

--- a/src/pdxautoserializer/ASCPPInclude.hpp
+++ b/src/pdxautoserializer/ASCPPInclude.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ce84784877faf1099879ab9252de0187
+#define APACHE_GEODE_GUARD_ce84784877faf1099879ab9252de0187
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_ASCPPINCLUDE_HPP_
-#define _GFAS_ASCPPINCLUDE_HPP_
 
 #define GFINCLUDE
 #define GFEXCLUDE
@@ -33,4 +36,5 @@
  #define __builtin_va_list int
  */
 
-#endif  // _GFAS_ASCPPINCLUDE_HPP_
+
+#endif // APACHE_GEODE_GUARD_ce84784877faf1099879ab9252de0187

--- a/src/pdxautoserializer/CodeGenerator.hpp
+++ b/src/pdxautoserializer/CodeGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_fb876ec7655e479e35df4a1cc2653f47
+#define APACHE_GEODE_GUARD_fb876ec7655e479e35df4a1cc2653f47
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_CODEGENERATOR_HPP_
-#define _GFAS_CODEGENERATOR_HPP_
 
 #include "base_types.hpp"
 
@@ -172,4 +175,5 @@ class CodeGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_CODEGENERATOR_HPP_
+
+#endif // APACHE_GEODE_GUARD_fb876ec7655e479e35df4a1cc2653f47

--- a/src/pdxautoserializer/CodeGeneratorFactory.hpp
+++ b/src/pdxautoserializer/CodeGeneratorFactory.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_736109a2751770a130d751c8754e234c
+#define APACHE_GEODE_GUARD_736109a2751770a130d751c8754e234c
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_CODEGENERATORFACTORY_HPP_
-#define _GFAS_CODEGENERATORFACTORY_HPP_
 
 #include "CodeGenerator.hpp"
 
@@ -69,4 +72,5 @@ class CodeGeneratorFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_CODEGENERATORFACTORY_HPP_
+
+#endif // APACHE_GEODE_GUARD_736109a2751770a130d751c8754e234c

--- a/src/pdxautoserializer/InputParser.hpp
+++ b/src/pdxautoserializer/InputParser.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_906466ac6028b9eac9226aa77077245f
+#define APACHE_GEODE_GUARD_906466ac6028b9eac9226aa77077245f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_INPUTPARSER_HPP_
-#define _GFAS_INPUTPARSER_HPP_
 
 #include "base_types.hpp"
 #include "CodeGenerator.hpp"
@@ -179,4 +182,5 @@ class InputParser {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_INPUTPARSER_HPP_
+
+#endif // APACHE_GEODE_GUARD_906466ac6028b9eac9226aa77077245f

--- a/src/pdxautoserializer/InputParserFactory.hpp
+++ b/src/pdxautoserializer/InputParserFactory.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_6c288c7ce306f6376599e765eb252f29
+#define APACHE_GEODE_GUARD_6c288c7ce306f6376599e765eb252f29
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_INPUTPARSERFACTORY_HPP_
-#define _GFAS_INPUTPARSERFACTORY_HPP_
 
 #include "InputParser.hpp"
 #include <utility>
@@ -71,4 +74,5 @@ class InputParserFactory {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_INPUTPARSERFACTORY_HPP_
+
+#endif // APACHE_GEODE_GUARD_6c288c7ce306f6376599e765eb252f29

--- a/src/pdxautoserializer/OutputFormatter.hpp
+++ b/src/pdxautoserializer/OutputFormatter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_8157a8a77b151f9beadc02d24c462c34
+#define APACHE_GEODE_GUARD_8157a8a77b151f9beadc02d24c462c34
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_OUTPUTFORMATTER_HPP_
-#define _GFAS_OUTPUTFORMATTER_HPP_
 
 #include <ostream>
 #include <streambuf>
@@ -225,4 +228,5 @@ class OutputFormatter : public std::ostream {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_OUTPUTFORMATTER_HPP_
+
+#endif // APACHE_GEODE_GUARD_8157a8a77b151f9beadc02d24c462c34

--- a/src/pdxautoserializer/base_types.hpp
+++ b/src/pdxautoserializer/base_types.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_dbef31dd4224e58666543cc33c286150
+#define APACHE_GEODE_GUARD_dbef31dd4224e58666543cc33c286150
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_BASETYPES_HPP_
-#define _GFAS_BASETYPES_HPP_
 
 #include <string>
 #include <vector>
@@ -251,4 +254,5 @@ typedef std::vector<VariableInfo>::const_iterator VariableVectorIterator;
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_BASETYPES_HPP_
+
+#endif // APACHE_GEODE_GUARD_dbef31dd4224e58666543cc33c286150

--- a/src/pdxautoserializer/impl/CPPCodeGenerator.hpp
+++ b/src/pdxautoserializer/impl/CPPCodeGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_571a5e03438f4ddbf05bf82f4b838736
+#define APACHE_GEODE_GUARD_571a5e03438f4ddbf05bf82f4b838736
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_CPPCODEGENERATOR_HPP_
-#define _GFAS_CPPCODEGENERATOR_HPP_
 
 #include "../CodeGenerator.hpp"
 #include "../OutputFormatter.hpp"
@@ -234,4 +237,5 @@ class CPPCodeGenerator : public CodeGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_CPPCODEGENERATOR_HPP_
+
+#endif // APACHE_GEODE_GUARD_571a5e03438f4ddbf05bf82f4b838736

--- a/src/pdxautoserializer/impl/Helper.hpp
+++ b/src/pdxautoserializer/impl/Helper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_debdc61f2b91c81fc06a894ab962375d
+#define APACHE_GEODE_GUARD_debdc61f2b91c81fc06a894ab962375d
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_HELPER_HPP_
-#define _GFAS_HELPER_HPP_
 
 #include "../InputParser.hpp"
 #include <algorithm>
@@ -186,4 +189,5 @@ class Helper {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_HELPER_HPP_
+
+#endif // APACHE_GEODE_GUARD_debdc61f2b91c81fc06a894ab962375d

--- a/src/pdxautoserializer/impl/Log.hpp
+++ b/src/pdxautoserializer/impl/Log.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ede048400be44f9dde5948f28b51fc23
+#define APACHE_GEODE_GUARD_ede048400be44f9dde5948f28b51fc23
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef _GFAS_LOG_HPP_
-#define _GFAS_LOG_HPP_
 
 #include <string>
 #include <iosfwd>
@@ -88,4 +91,5 @@ class Log {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // _GFAS_LOG_HPP_
+
+#endif // APACHE_GEODE_GUARD_ede048400be44f9dde5948f28b51fc23

--- a/src/sqliteimpl/SqLiteHelper.hpp
+++ b/src/sqliteimpl/SqLiteHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_447d8a867ee02dec66fc5d71c2102d35
+#define APACHE_GEODE_GUARD_447d8a867ee02dec66fc5d71c2102d35
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -53,3 +58,5 @@ class SqLiteHelper {
   int createTable();
   int executePragma(const char* pragmaName, int pragmaValue);
 };
+
+#endif // APACHE_GEODE_GUARD_447d8a867ee02dec66fc5d71c2102d35

--- a/src/sqliteimpl/SqLiteImpl.hpp
+++ b/src/sqliteimpl/SqLiteImpl.hpp
@@ -1,5 +1,8 @@
-#ifndef _SqLiteIMPL_HPP__
-#define _SqLiteIMPL_HPP__
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_da3f13342a1583210e9ae3d60d356b5f
+#define APACHE_GEODE_GUARD_da3f13342a1583210e9ae3d60d356b5f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -137,4 +140,5 @@ class SqLiteImpl : public PersistenceManager {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //_SqLiteIMPL_HPP__
+
+#endif // APACHE_GEODE_GUARD_da3f13342a1583210e9ae3d60d356b5f

--- a/src/tests/cpp/fwk/UdpIpc.hpp
+++ b/src/tests/cpp/fwk/UdpIpc.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ebe55397742f4c3cb6d6e6eaf7338769
+#define APACHE_GEODE_GUARD_ebe55397742f4c3cb6d6e6eaf7338769
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __UDPIPC_HPP__
-#define __UDPIPC_HPP__
 
 // ----------------------------------------------------------------------------
 #include <gfcpp/GeodeCppCache.hpp>
@@ -88,4 +91,5 @@ class TestProcessor : public ServiceTask {
 }  // namespace apache
 // ----------------------------------------------------------------------------
 
-#endif  // __UDPIPC_HPP__
+
+#endif // APACHE_GEODE_GUARD_ebe55397742f4c3cb6d6e6eaf7338769

--- a/src/tests/cpp/fwklib/ClientTask.hpp
+++ b/src/tests/cpp/fwklib/ClientTask.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_27b17454dd8037d9589090f2615d5988
+#define APACHE_GEODE_GUARD_27b17454dd8037d9589090f2615d5988
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __ClientTask_hpp__
-#define __ClientTask_hpp__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <AtomicInc.hpp>
@@ -158,4 +161,5 @@ class ThreadedTask : public ClientTask {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __ClientTask_hpp__
+
+#endif // APACHE_GEODE_GUARD_27b17454dd8037d9589090f2615d5988

--- a/src/tests/cpp/fwklib/FrameworkTest.hpp
+++ b/src/tests/cpp/fwklib/FrameworkTest.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_785ebc022f46abcb7ea497df264a48ae
+#define APACHE_GEODE_GUARD_785ebc022f46abcb7ea497df264a48ae
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __FrameworkTest_hpp__
-#define __FrameworkTest_hpp__
 
 #include "fwklib/TimeSync.hpp"
 #include "fwklib/ClientTask.hpp"
@@ -278,4 +281,5 @@ class FrameworkTest  // Base class all test classes written for xml testing
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __FrameworkTest_hpp__
+
+#endif // APACHE_GEODE_GUARD_785ebc022f46abcb7ea497df264a48ae

--- a/src/tests/cpp/fwklib/FwkBB.hpp
+++ b/src/tests/cpp/fwklib/FwkBB.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_e4048febbad0240d5090fde0a083a7ac
+#define APACHE_GEODE_GUARD_e4048febbad0240d5090fde0a083a7ac
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,8 +27,6 @@
   * @see
   */
 
-#ifndef __FWK_BB_HPP__
-#define __FWK_BB_HPP__
 
 #include <gfcpp/gf_base.hpp>
 #include "fwklib/FwkLog.hpp"
@@ -230,4 +233,5 @@ class FwkBBMessage {
 
 // ----------------------------------------------------------------------------
 
-#endif  // __FWK_BB_HPP__
+
+#endif // APACHE_GEODE_GUARD_e4048febbad0240d5090fde0a083a7ac

--- a/src/tests/cpp/fwklib/FwkBBClient.hpp
+++ b/src/tests/cpp/fwklib/FwkBBClient.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_8443d3966c0b05a9e05eafa7ca28e4c7
+#define APACHE_GEODE_GUARD_8443d3966c0b05a9e05eafa7ca28e4c7
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,8 +27,6 @@
   * @see
   */
 
-#ifndef __FWK_BB_CLIENT_HPP__
-#define __FWK_BB_CLIENT_HPP__
 
 #include "FwkBB.hpp"
 #include "UDPIpc.hpp"
@@ -187,4 +190,5 @@ class FwkBBClient {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWK_BB_CLIENT_HPP__
+
+#endif // APACHE_GEODE_GUARD_8443d3966c0b05a9e05eafa7ca28e4c7

--- a/src/tests/cpp/fwklib/FwkBBServer.hpp
+++ b/src/tests/cpp/fwklib/FwkBBServer.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_bb6131bfb60de61fcfc2f40301c3f02c
+#define APACHE_GEODE_GUARD_bb6131bfb60de61fcfc2f40301c3f02c
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,8 +27,6 @@
   * @see
   */
 
-#ifndef __FWK_BB_SERVER_HPP__
-#define __FWK_BB_SERVER_HPP__
 
 #include "FwkBB.hpp"
 #include "UDPIpc.hpp"
@@ -222,4 +225,5 @@ class BBProcessor : public ServiceTask {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWK_BB_SERVER_HPP__
+
+#endif // APACHE_GEODE_GUARD_bb6131bfb60de61fcfc2f40301c3f02c

--- a/src/tests/cpp/fwklib/FwkException.hpp
+++ b/src/tests/cpp/fwklib/FwkException.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_43257b24105ffca3ff3bd16dc0cd17d2
+#define APACHE_GEODE_GUARD_43257b24105ffca3ff3bd16dc0cd17d2
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __FWKEXCEPTION_HPP__
-#define __FWKEXCEPTION_HPP__
 
 #include <string>
 
@@ -66,4 +69,5 @@ class FwkException {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWKEXCEPTION_HPP__
+
+#endif // APACHE_GEODE_GUARD_43257b24105ffca3ff3bd16dc0cd17d2

--- a/src/tests/cpp/fwklib/FwkExport.hpp
+++ b/src/tests/cpp/fwklib/FwkExport.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_dd058cd17302e55845b453e0c42c27c9
+#define APACHE_GEODE_GUARD_dd058cd17302e55845b453e0c42c27c9
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -29,3 +34,5 @@
 #define TESTTASK extern "C" int32_t
 #define TEST_EXPORT extern "C"
 #endif
+
+#endif // APACHE_GEODE_GUARD_dd058cd17302e55845b453e0c42c27c9

--- a/src/tests/cpp/fwklib/FwkLog.hpp
+++ b/src/tests/cpp/fwklib/FwkLog.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_09e162ef70ce6628f1f097a2c0333b34
+#define APACHE_GEODE_GUARD_09e162ef70ce6628f1f097a2c0333b34
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __FWK_LOG_HPP__
-#define __FWK_LOG_HPP__
 
 #include <gfcpp/gf_base.hpp>
 
@@ -123,4 +126,5 @@ const char* getNodeName();
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWK_LOG_HPP__
+
+#endif // APACHE_GEODE_GUARD_09e162ef70ce6628f1f097a2c0333b34

--- a/src/tests/cpp/fwklib/FwkObjects.hpp
+++ b/src/tests/cpp/fwklib/FwkObjects.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_e9a3be6b0d737dd314e3ec4bc3a93eba
+#define APACHE_GEODE_GUARD_e9a3be6b0d737dd314e3ec4bc3a93eba
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,8 +29,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __FWK_OBJECTS_HPP__
-#define __FWK_OBJECTS_HPP__
 
 #include <gfcpp/Properties.hpp>
 #include <gfcpp/ExpirationAction.hpp>
@@ -1617,4 +1620,5 @@ class TestDriver {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWK_OBJECTS_HPP__
+
+#endif // APACHE_GEODE_GUARD_e9a3be6b0d737dd314e3ec4bc3a93eba

--- a/src/tests/cpp/fwklib/FwkStrCvt.hpp
+++ b/src/tests/cpp/fwklib/FwkStrCvt.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_596076185d7a905f2040a9113cab41f2
+#define APACHE_GEODE_GUARD_596076185d7a905f2040a9113cab41f2
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __FWK_STR_CVT_HPP__
-#define __FWK_STR_CVT_HPP__
 
 #include "config.h"
 #include <gfcpp/gfcpp_globals.hpp>
@@ -348,4 +351,5 @@ class FwkStrCvt {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __FWK_STR_CVT_HPP__
+
+#endif // APACHE_GEODE_GUARD_596076185d7a905f2040a9113cab41f2

--- a/src/tests/cpp/fwklib/GsRandom.hpp
+++ b/src/tests/cpp/fwklib/GsRandom.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_07015f9e9a2d1cdc790e5e202a3742fe
+#define APACHE_GEODE_GUARD_07015f9e9a2d1cdc790e5e202a3742fe
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __GS_RANDOM_HPP__
-#define __GS_RANDOM_HPP__
 
 #include <gfcpp/gf_base.hpp>
 
@@ -234,4 +237,5 @@ class GsRandom {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __GS_RANDOM_HPP__
+
+#endif // APACHE_GEODE_GUARD_07015f9e9a2d1cdc790e5e202a3742fe

--- a/src/tests/cpp/fwklib/IpcHandler.hpp
+++ b/src/tests/cpp/fwklib/IpcHandler.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_450b17d5d954d8270b6906f1510c355c
+#define APACHE_GEODE_GUARD_450b17d5d954d8270b6906f1510c355c
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __IpcHandler_hpp__
-#define __IpcHandler_hpp__
 
 #include <ace/SOCK_Stream.h>
 #include <ace/OS.h>
@@ -85,4 +88,5 @@ class IpcHandler {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __IpcHandler_hpp__
+
+#endif // APACHE_GEODE_GUARD_450b17d5d954d8270b6906f1510c355c

--- a/src/tests/cpp/fwklib/MersenneTwister.hpp
+++ b/src/tests/cpp/fwklib/MersenneTwister.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_2cbb06e4c156792558ba80dbf0fbc5e9
+#define APACHE_GEODE_GUARD_2cbb06e4c156792558ba80dbf0fbc5e9
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -71,8 +76,6 @@
 // It would be nice to CC: rjwagner@writeme.com and Cokus@math.washington.edu
 // when you write.
 
-#ifndef MERSENNETWISTER_H
-#define MERSENNETWISTER_H
 
 // Not thread safe (unless auto-initialization is avoided and each thread has
 // its own MTRand object)
@@ -158,8 +161,6 @@ class MTRand {
   static uint32_t hash(time_t t, clock_t c);
 };
 
-#endif  // MERSENNETWISTER_H
-
 // Change log:
 //
 // v0.1 - First release on 15 May 2000
@@ -199,3 +200,5 @@ class MTRand {
 //      - Fixed out-of-range number generation on 64-bit machines
 //      - Improved portability by substituting literal constants for long enum's
 //      - Changed license from GNU LGPL to BSD
+
+#endif // APACHE_GEODE_GUARD_2cbb06e4c156792558ba80dbf0fbc5e9

--- a/src/tests/cpp/fwklib/PaceMeter.hpp
+++ b/src/tests/cpp/fwklib/PaceMeter.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_0b9b6fa2558c2b1a9cd9f073630e90aa
+#define APACHE_GEODE_GUARD_0b9b6fa2558c2b1a9cd9f073630e90aa
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __PaceMeter_hpp__
-#define __PaceMeter_hpp__
 
 #include "fwklib/FwkLog.hpp"
 #include <ace/Time_Value.h>
@@ -129,4 +132,5 @@ class PaceMeter {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __PaceMeter_hpp__
+
+#endif // APACHE_GEODE_GUARD_0b9b6fa2558c2b1a9cd9f073630e90aa

--- a/src/tests/cpp/fwklib/PerfFwk.hpp
+++ b/src/tests/cpp/fwklib/PerfFwk.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_72e4dc209ca3876b269e52c8a14f412b
+#define APACHE_GEODE_GUARD_72e4dc209ca3876b269e52c8a14f412b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __PerfFwk_hpp__
-#define __PerfFwk_hpp__
 
 #include <gfcpp/gf_base.hpp>
 
@@ -333,4 +336,5 @@ class Counter {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __PerfFwk_hpp__
+
+#endif // APACHE_GEODE_GUARD_72e4dc209ca3876b269e52c8a14f412b

--- a/src/tests/cpp/fwklib/PoolHelper.hpp
+++ b/src/tests/cpp/fwklib/PoolHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_b2a51368e1c04b7833061e32a761f2df
+#define APACHE_GEODE_GUARD_b2a51368e1c04b7833061e32a761f2df
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __POOL_HELPER_HPP__
-#define __POOL_HELPER_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <AtomicInc.hpp>
@@ -147,4 +150,5 @@ class PoolHelper {
 
 // ----------------------------------------------------------------------------
 
-#endif  // __POOL_HELPER_HPP__
+
+#endif // APACHE_GEODE_GUARD_b2a51368e1c04b7833061e32a761f2df

--- a/src/tests/cpp/fwklib/QueryHelper.hpp
+++ b/src/tests/cpp/fwklib/QueryHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_f57a1f9a1b1286d041f077ee231e8637
+#define APACHE_GEODE_GUARD_f57a1f9a1b1286d041f077ee231e8637
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef TEST_QUERYHELPER_HPP
-#define TEST_QUERYHELPER_HPP
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <stdlib.h>
@@ -1148,4 +1151,5 @@ bool QueryHelper::verifySS(SelectResultsPtr& structSet, int expectedRows,
   return false;
 }
 
-#endif  // TEST_QUERYHELPER_HPP
+
+#endif // APACHE_GEODE_GUARD_f57a1f9a1b1286d041f077ee231e8637

--- a/src/tests/cpp/fwklib/RegionHelper.hpp
+++ b/src/tests/cpp/fwklib/RegionHelper.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ecbb34b204212c99ce0936eb50297d23
+#define APACHE_GEODE_GUARD_ecbb34b204212c99ce0936eb50297d23
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __REGION_HELPER_HPP__
-#define __REGION_HELPER_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <AtomicInc.hpp>
@@ -258,4 +261,5 @@ class RegionHelper {
 
 // ----------------------------------------------------------------------------
 
-#endif  // __REGION_HELPER_HPP__
+
+#endif // APACHE_GEODE_GUARD_ecbb34b204212c99ce0936eb50297d23

--- a/src/tests/cpp/fwklib/Service.hpp
+++ b/src/tests/cpp/fwklib/Service.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_6024bf86dd8d0d4aad8f988f5ba1655a
+#define APACHE_GEODE_GUARD_6024bf86dd8d0d4aad8f988f5ba1655a
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __Service_hpp__
-#define __Service_hpp__
 
 #include <gfcpp/gf_base.hpp>
 #include <AtomicInc.hpp>
@@ -163,4 +166,5 @@ class IPCMessage {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __Service_hpp__
+
+#endif // APACHE_GEODE_GUARD_6024bf86dd8d0d4aad8f988f5ba1655a

--- a/src/tests/cpp/fwklib/TaskClient.hpp
+++ b/src/tests/cpp/fwklib/TaskClient.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_a7058f04d2a065ec8cd9179a5349a649
+#define APACHE_GEODE_GUARD_a7058f04d2a065ec8cd9179a5349a649
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TaskClient_hpp__
-#define __TaskClient_hpp__
 
 #include "PerfFwk.hpp"
 #include "FwkLog.hpp"
@@ -182,4 +185,5 @@ class TaskClient : public ACE_Task_Base {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TaskClient_hpp__
+
+#endif // APACHE_GEODE_GUARD_a7058f04d2a065ec8cd9179a5349a649

--- a/src/tests/cpp/fwklib/TcpIpc.hpp
+++ b/src/tests/cpp/fwklib/TcpIpc.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_7dbd8fa103bfe69138e0b0571a737c9c
+#define APACHE_GEODE_GUARD_7dbd8fa103bfe69138e0b0571a737c9c
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TcpIpc_hpp__
-#define __TcpIpc_hpp__
 
 #include <gfcpp/gf_base.hpp>
 #include <ace/SOCK_Stream.h>
@@ -73,4 +76,5 @@ class TcpIpc {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __TcpIpc_hpp__
+
+#endif // APACHE_GEODE_GUARD_7dbd8fa103bfe69138e0b0571a737c9c

--- a/src/tests/cpp/fwklib/TestClient.hpp
+++ b/src/tests/cpp/fwklib/TestClient.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_b1ca2169435caedbb3e0ccb04094fb46
+#define APACHE_GEODE_GUARD_b1ca2169435caedbb3e0ccb04094fb46
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TestClient_hpp__
-#define __TestClient_hpp__
 
 #include "fwklib/PerfFwk.hpp"
 #include "fwklib/ClientTask.hpp"
@@ -117,4 +120,5 @@ class TestClient : public ACE_Task_Base {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __TestClient_hpp__
+
+#endif // APACHE_GEODE_GUARD_b1ca2169435caedbb3e0ccb04094fb46

--- a/src/tests/cpp/fwklib/TimeBomb.hpp
+++ b/src/tests/cpp/fwklib/TimeBomb.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_79d494cc4b256bbd77fabec6e825390a
+#define APACHE_GEODE_GUARD_79d494cc4b256bbd77fabec6e825390a
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TimeBomb_hpp__
-#define __TimeBomb_hpp__
 
 #include "fwklib/PerfFwk.hpp"
 #include "fwklib/FwkLog.hpp"
@@ -81,4 +84,5 @@ class TimeBomb : public ACE_Task_Base {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __TimeBomb_hpp__
+
+#endif // APACHE_GEODE_GUARD_79d494cc4b256bbd77fabec6e825390a

--- a/src/tests/cpp/fwklib/TimeLimit.hpp
+++ b/src/tests/cpp/fwklib/TimeLimit.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_1628cb6366f926a3cac7309d67d1a4d7
+#define APACHE_GEODE_GUARD_1628cb6366f926a3cac7309d67d1a4d7
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TimeLimit_hpp__
-#define __TimeLimit_hpp__
 
 #include "fwklib/FwkLog.hpp"
 #include <ace/Time_Value.h>
@@ -49,4 +52,5 @@ class TimeLimit {
 }
 }
 
-#endif  // __TimeLimit_hpp__
+
+#endif // APACHE_GEODE_GUARD_1628cb6366f926a3cac7309d67d1a4d7

--- a/src/tests/cpp/fwklib/TimeSync.hpp
+++ b/src/tests/cpp/fwklib/TimeSync.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_b6cf051f15f6d158175a22b44bbe4b98
+#define APACHE_GEODE_GUARD_b6cf051f15f6d158175a22b44bbe4b98
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __TimeSync_hpp__
-#define __TimeSync_hpp__
 
 #include "fwklib/PerfFwk.hpp"
 
@@ -90,4 +93,5 @@ class TimeSync : public ACE_Task_Base {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  // __TimeSync_hpp__
+
+#endif // APACHE_GEODE_GUARD_b6cf051f15f6d158175a22b44bbe4b98

--- a/src/tests/cpp/fwklib/Timer.hpp
+++ b/src/tests/cpp/fwklib/Timer.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_8d07450f18b766edac2c13c91b9680d4
+#define APACHE_GEODE_GUARD_8d07450f18b766edac2c13c91b9680d4
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __Timer_hpp__
-#define __Timer_hpp__
 
 #include <gfcpp/gf_base.hpp>
 #include "fwklib/FwkLog.hpp"
@@ -177,4 +180,5 @@ class HRTimer {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __Timer_hpp__
+
+#endif // APACHE_GEODE_GUARD_8d07450f18b766edac2c13c91b9680d4

--- a/src/tests/cpp/fwklib/UDPIpc.hpp
+++ b/src/tests/cpp/fwklib/UDPIpc.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_31f0c15c526e6fca1c0825a818e204d4
+#define APACHE_GEODE_GUARD_31f0c15c526e6fca1c0825a818e204d4
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __UDPIpc_hpp__
-#define __UDPIpc_hpp__
 
 #include "Service.hpp"
 #include "PerfFwk.hpp"
@@ -295,4 +298,5 @@ class Responder : public ServiceTask {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // __UDPIpc_hpp__
+
+#endif // APACHE_GEODE_GUARD_31f0c15c526e6fca1c0825a818e204d4

--- a/src/tests/cpp/pdxautoserializerclass/AutoPdxVersioned1.hpp
+++ b/src/tests/cpp/pdxautoserializerclass/AutoPdxVersioned1.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_9b6d34ac32115700916ecb8e4bf0d825
+#define APACHE_GEODE_GUARD_9b6d34ac32115700916ecb8e4bf0d825
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __AUTOPDXVERSIONED1OBJECT_HPP__
-#define __AUTOPDXVERSIONED1OBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -371,4 +374,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) NestedPdx : public PdxSerializable {
 };
 typedef SharedPtr<NestedPdx> NestedPdxPtr;
 }  // namespace AutoPdxTests
-#endif /* __AUTOPDXVERSIONED1OBJECT_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_9b6d34ac32115700916ecb8e4bf0d825

--- a/src/tests/cpp/pdxautoserializerclass/AutoPdxVersioned2.hpp
+++ b/src/tests/cpp/pdxautoserializerclass/AutoPdxVersioned2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_6e3336d3474c5bad468aecf72316fc4b
+#define APACHE_GEODE_GUARD_6e3336d3474c5bad468aecf72316fc4b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,8 +20,6 @@
  * limitations under the License.
  */
 
-#ifndef __AUTOPDXVERSIONED2OBJECT_HPP__
-#define __AUTOPDXVERSIONED2OBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -269,4 +272,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) AutoPdxVersioned2 : public PdxSerializable {
 };
 typedef SharedPtr<AutoPdxTests::AutoPdxVersioned2> AutoPdxVersioned2Ptr;
 }  // namespace AutoPdxTests
-#endif /* __AUTOPDXVERSIONED2OBJECT_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_6e3336d3474c5bad468aecf72316fc4b

--- a/src/tests/cpp/pdxautoserializerclass/PortfolioPdx.hpp
+++ b/src/tests/cpp/pdxautoserializerclass/PortfolioPdx.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_115ad9fa08f9b8368045cfda498ff99b
+#define APACHE_GEODE_GUARD_115ad9fa08f9b8368045cfda498ff99b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __AutoPORTFOLIOPDX_HPP__
-#define __AutoPORTFOLIOPDX_HPP__
 
 #include "PositionPdx.hpp"
 #define GFIGNORE(X) X
@@ -110,4 +113,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) PortfolioPdx : public PdxSerializable {
 
 typedef SharedPtr<PortfolioPdx> PortfolioPdxPtr;
 }  // namespace AutoPdxTests
-#endif
+
+#endif // APACHE_GEODE_GUARD_115ad9fa08f9b8368045cfda498ff99b

--- a/src/tests/cpp/pdxautoserializerclass/PositionPdx.hpp
+++ b/src/tests/cpp/pdxautoserializerclass/PositionPdx.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_fc0317ed5799f03f58df423db009e0b5
+#define APACHE_GEODE_GUARD_fc0317ed5799f03f58df423db009e0b5
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __AutoPOSITIONPDX_HPP__
-#define __AutoPOSITIONPDX_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <gfcpp/PdxSerializable.hpp>
@@ -104,4 +107,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) PositionPdx
 
 typedef apache::geode::client::SharedPtr<PositionPdx> PositionPdxPtr;
 }  // namespace AutoPdxTests
-#endif
+
+#endif // APACHE_GEODE_GUARD_fc0317ed5799f03f58df423db009e0b5

--- a/src/tests/cpp/security/CredentialGenerator.hpp
+++ b/src/tests/cpp/security/CredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_602c04192305d5a8fa539c0c989ef65f
+#define APACHE_GEODE_GUARD_602c04192305d5a8fa539c0c989ef65f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef _GEMFIRE_CREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_CREDENTIALGENERATOR_HPP_
 
 // ----------------------------------------------------------------------------
 
@@ -272,4 +275,5 @@ class CredentialGenerator : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_602c04192305d5a8fa539c0c989ef65f

--- a/src/tests/cpp/security/DummyCredentialGenerator.hpp
+++ b/src/tests/cpp/security/DummyCredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_329d127281ca21e68d7ebee13db94333
+#define APACHE_GEODE_GUARD_329d127281ca21e68d7ebee13db94333
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_DUMMYCREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_DUMMYCREDENTIALGENERATOR_HPP_
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -102,4 +105,5 @@ class DummyCredentialGenerator : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_329d127281ca21e68d7ebee13db94333

--- a/src/tests/cpp/security/DummyCredentialGenerator2.hpp
+++ b/src/tests/cpp/security/DummyCredentialGenerator2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_0da927e22048b213714a43e14dd590ec
+#define APACHE_GEODE_GUARD_0da927e22048b213714a43e14dd590ec
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_DUMMYCREDENTIALGENERATOR2_HPP_
-#define _GEMFIRE_DUMMYCREDENTIALGENERATOR2_HPP_
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -101,4 +104,5 @@ class DummyCredentialGenerator2 : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_0da927e22048b213714a43e14dd590ec

--- a/src/tests/cpp/security/DummyCredentialGenerator3.hpp
+++ b/src/tests/cpp/security/DummyCredentialGenerator3.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_51f14f2d7ae4ce792fd44841b21b89dd
+#define APACHE_GEODE_GUARD_51f14f2d7ae4ce792fd44841b21b89dd
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_DUMMYCREDENTIALGENERATOR3_HPP_
-#define _GEMFIRE_DUMMYCREDENTIALGENERATOR3_HPP_
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -101,4 +104,5 @@ class DummyCredentialGenerator3 : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_51f14f2d7ae4ce792fd44841b21b89dd

--- a/src/tests/cpp/security/LdapUserCredentialGenerator.hpp
+++ b/src/tests/cpp/security/LdapUserCredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_13e33c8479a332a850fc4a6ded808476
+#define APACHE_GEODE_GUARD_13e33c8479a332a850fc4a6ded808476
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_LDAPUSERCREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_LDAPUSERCREDENTIALGENERATOR_HPP_
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -114,4 +117,5 @@ class LdapUserCredentialGenerator : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif /*_GEMFIRE_LDAPUSERCREDENTIALGENERATOR_HPP_*/
+
+#endif // APACHE_GEODE_GUARD_13e33c8479a332a850fc4a6ded808476

--- a/src/tests/cpp/security/NoopCredentialGenerator.hpp
+++ b/src/tests/cpp/security/NoopCredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_1f7c1dec923abb55cf489a3ad8997066
+#define APACHE_GEODE_GUARD_1f7c1dec923abb55cf489a3ad8997066
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_NOOPCREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_NOOPCREDENTIALGENERATOR_HPP_
 
 #include "CredentialGenerator.hpp"
 
@@ -60,4 +63,5 @@ class NoopCredentialGenerator : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_1f7c1dec923abb55cf489a3ad8997066

--- a/src/tests/cpp/security/PkcsAuthInit.hpp
+++ b/src/tests/cpp/security/PkcsAuthInit.hpp
@@ -1,5 +1,8 @@
-#ifndef _GEMFIRE__PKCSAUTHINIT__HPP
-#define _GEMFIRE__PKCSAUTHINIT__HPP
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_b6aee18fde62b9f395d7603d1d57c641
+#define APACHE_GEODE_GUARD_b6aee18fde62b9f395d7603d1d57c641
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -104,4 +107,5 @@ class PKCSAuthInitInternal : public AuthInitialize {
 }  // namespace geode
 }  // namespace apache
 
-#endif  //_GEMFIRE__PKCSAUTHINIT__HPP
+
+#endif // APACHE_GEODE_GUARD_b6aee18fde62b9f395d7603d1d57c641

--- a/src/tests/cpp/security/PkcsCredentialGenerator.hpp
+++ b/src/tests/cpp/security/PkcsCredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_7531b050ea22f83a394ce20e9ea4949d
+#define APACHE_GEODE_GUARD_7531b050ea22f83a394ce20e9ea4949d
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_PKCSCREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_PKCSCREDENTIALGENERATOR_HPP_
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -142,4 +145,5 @@ class PKCSCredentialGenerator : public CredentialGenerator {
 }  // namespace geode
 }  // namespace apache
 
-#endif /*_GEMFIRE_PKCSCREDENTIALGENERATOR_HPP_*/
+
+#endif // APACHE_GEODE_GUARD_7531b050ea22f83a394ce20e9ea4949d

--- a/src/tests/cpp/security/Security.hpp
+++ b/src/tests/cpp/security/Security.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_d8d76480867ce6629add87fe227d225f
+#define APACHE_GEODE_GUARD_d8d76480867ce6629add87fe227d225f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,8 +30,6 @@
 
 // ----------------------------------------------------------------------------
 
-#ifndef __SECURITY_HPP__
-#define __SECURITY_HPP__
 
 // ----------------------------------------------------------------------------
 
@@ -119,4 +122,5 @@ class Security : public FrameworkTest {
 }  // namespace apache
 // ----------------------------------------------------------------------------
 
-#endif  // __SECURITY_HPP__
+
+#endif // APACHE_GEODE_GUARD_d8d76480867ce6629add87fe227d225f

--- a/src/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
+++ b/src/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_a14b9dccb3fd9b3b05214dc60326e629
+#define APACHE_GEODE_GUARD_a14b9dccb3fd9b3b05214dc60326e629
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _GEMFIRE_XMLAUTHZCREDENTIALGENERATOR_HPP_
-#define _GEMFIRE_XMLAUTHZCREDENTIALGENERATOR_HPP_
 
 #include <gfcpp/SharedBase.hpp>
 #include <gfcpp/Properties.hpp>
@@ -311,4 +314,5 @@ class XmlAuthzCredentialGenerator : public SharedBase {
 }  // namespace geode
 }  // namespace apache
 
-#endif /*_GEMFIRE_AUTHZCREDENTIALGENERATOR_HPP_*/
+
+#endif // APACHE_GEODE_GUARD_a14b9dccb3fd9b3b05214dc60326e629

--- a/src/tests/cpp/security/typedefs.hpp
+++ b/src/tests/cpp/security/typedefs.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_8a35926faf964b72538dc78519ee0e9b
+#define APACHE_GEODE_GUARD_8a35926faf964b72538dc78519ee0e9b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TYPEDEFS_HPP_
-#define __TYPEDEFS_HPP_
 
 #ifdef _LINUX
 _Pragma("GCC system_header")
@@ -129,4 +132,5 @@ _Pragma("GCC system_header")
   }  // namespace geode
 }  // namespace apache
 
-#endif /*__TYPEDEFS_HPP_*/
+
+#endif // APACHE_GEODE_GUARD_8a35926faf964b72538dc78519ee0e9b

--- a/src/tests/cpp/testobject/ArrayOfByte.hpp
+++ b/src/tests/cpp/testobject/ArrayOfByte.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ec3211e9438cbef839aaab90eac09a4b
+#define APACHE_GEODE_GUARD_ec3211e9438cbef839aaab90eac09a4b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __ArrayOfByte_HPP__
-#define __ArrayOfByte_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -122,4 +125,5 @@ class TESTOBJECT_EXPORT ArrayOfByte {
 };
 }  // namespace testobject
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_ec3211e9438cbef839aaab90eac09a4b

--- a/src/tests/cpp/testobject/BatchObject.hpp
+++ b/src/tests/cpp/testobject/BatchObject.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_018c280d1ad9e881b092dcb9f3304d88
+#define APACHE_GEODE_GUARD_018c280d1ad9e881b092dcb9f3304d88
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the cq functionality.
  */
 
-#ifndef __BATCHOBJECT_HPP__
-#define __BATCHOBJECT_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -88,4 +91,5 @@ class TESTOBJECT_EXPORT BatchObject : public TimestampedObject {
 
 typedef apache::geode::client::SharedPtr<BatchObject> BatchObjectPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_018c280d1ad9e881b092dcb9f3304d88

--- a/src/tests/cpp/testobject/DeltaFastAssetAccount.hpp
+++ b/src/tests/cpp/testobject/DeltaFastAssetAccount.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_4419550c0ee1c11f3f7580e8ae97f3e4
+#define APACHE_GEODE_GUARD_4419550c0ee1c11f3f7580e8ae97f3e4
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the query functionality.
  */
 
-#ifndef __DELTAFASTASSETACT__HPP__
-#define __DELTAFASTASSETACT__HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -148,4 +151,5 @@ class TESTOBJECT_EXPORT DeltaFastAssetAccount : public Cacheable, public Delta {
   }
 };
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_4419550c0ee1c11f3f7580e8ae97f3e4

--- a/src/tests/cpp/testobject/DeltaPSTObject.hpp
+++ b/src/tests/cpp/testobject/DeltaPSTObject.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_71203be2b9e093a3e3b66356ee334b67
+#define APACHE_GEODE_GUARD_71203be2b9e093a3e3b66356ee334b67
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __DELTAPSTOBJECT_HPP__
-#define __DELTAPSTOBJECT_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -92,4 +95,5 @@ class TESTOBJECT_EXPORT DeltaPSTObject : public Cacheable, public Delta {
 };
 typedef apache::geode::client::SharedPtr<DeltaPSTObject> DeltaPSTObjectPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_71203be2b9e093a3e3b66356ee334b67

--- a/src/tests/cpp/testobject/DeltaTestImpl.hpp
+++ b/src/tests/cpp/testobject/DeltaTestImpl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_f0dde88a60c43a402c317bb0bafa6c73
+#define APACHE_GEODE_GUARD_f0dde88a60c43a402c317bb0bafa6c73
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef DELTATESTIMPL_HPP_
-#define DELTATESTIMPL_HPP_
 
 #include <ace/ACE.h>
 #include <ace/OS.h>
@@ -120,4 +123,5 @@ class TESTOBJECT_EXPORT DeltaTestImpl : public Cacheable, public Delta {
   CacheableStringPtr toString() const;
 };
 }  // namespace testobject
-#endif /* DELTATESTIMPL_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_f0dde88a60c43a402c317bb0bafa6c73

--- a/src/tests/cpp/testobject/DeltaTestObj.hpp
+++ b/src/tests/cpp/testobject/DeltaTestObj.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_ae1a70d692bfcc850903bc09f7fe0b96
+#define APACHE_GEODE_GUARD_ae1a70d692bfcc850903bc09f7fe0b96
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __DeltaTestObj_HPP__
-#define __DeltaTestObj_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include "DeltaTestImpl.hpp"
@@ -94,4 +97,5 @@ class TESTOBJECT_EXPORT DeltaTestObj : public DeltaTestImpl {
 
 typedef apache::geode::client::SharedPtr<DeltaTestObj> DeltaTestObjPtr;
 }
-#endif
+
+#endif // APACHE_GEODE_GUARD_ae1a70d692bfcc850903bc09f7fe0b96

--- a/src/tests/cpp/testobject/EqStruct.hpp
+++ b/src/tests/cpp/testobject/EqStruct.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_01922391216844a010651b52b4fa268b
+#define APACHE_GEODE_GUARD_01922391216844a010651b52b4fa268b
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __EQSTRUCT_HPP__
-#define __EQSTRUCT_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -149,4 +152,5 @@ class TESTOBJECT_EXPORT EqStruct : public TimestampedObject {
 
 typedef apache::geode::client::SharedPtr<EqStruct> EqStructPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_01922391216844a010651b52b4fa268b

--- a/src/tests/cpp/testobject/FastAsset.hpp
+++ b/src/tests/cpp/testobject/FastAsset.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_d8ed0294ced849b84153696edefc4a35
+#define APACHE_GEODE_GUARD_d8ed0294ced849b84153696edefc4a35
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the query functionality.
  */
 
-#ifndef __FASTASSET__HPP__
-#define __FASTASSET__HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -113,4 +116,5 @@ class TESTOBJECT_EXPORT FastAsset : public TimestampedObject {
 
 // typedef apache::geode::client::SharedPtr<FastAsset> FastAssetPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_d8ed0294ced849b84153696edefc4a35

--- a/src/tests/cpp/testobject/FastAssetAccount.hpp
+++ b/src/tests/cpp/testobject/FastAssetAccount.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_4bb699f806bb1f49d020175dd0840394
+#define APACHE_GEODE_GUARD_4bb699f806bb1f49d020175dd0840394
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the query functionality.
  */
 
-#ifndef __FASTASSETACT__HPP__
-#define __FASTASSETACT__HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -120,4 +123,5 @@ class TESTOBJECT_EXPORT FastAssetAccount : public TimestampedObject {
 
 typedef apache::geode::client::SharedPtr<FastAssetAccount> FastAssetAccountPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_4bb699f806bb1f49d020175dd0840394

--- a/src/tests/cpp/testobject/InvalidPdxUsage.hpp
+++ b/src/tests/cpp/testobject/InvalidPdxUsage.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_a4f4888599d6fc0d8dc148908db41bfb
+#define APACHE_GEODE_GUARD_a4f4888599d6fc0d8dc148908db41bfb
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __INVALIDPDXUSAGE_HPP__
-#define __INVALIDPDXUSAGE_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -690,4 +693,5 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 };
 typedef SharedPtr<PdxTests::InvalidPdxUsage> InvalidPdxUsagePtr;
 }  // namespace PdxTests
-#endif /* PDXOBJECT_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_a4f4888599d6fc0d8dc148908db41bfb

--- a/src/tests/cpp/testobject/NestedPdxObject.hpp
+++ b/src/tests/cpp/testobject/NestedPdxObject.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_28158ffb5a5f70ed511fa8baa47de6a8
+#define APACHE_GEODE_GUARD_28158ffb5a5f70ed511fa8baa47de6a8
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
 *
 */
 
-#ifndef __NESTEDPDXOBJECT_HPP__
-#define __NESTEDPDXOBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -335,4 +338,5 @@ class TESTOBJECT_EXPORT SerializePdx : public PdxSerializable {
 };
 typedef SharedPtr<SerializePdx> SerializePdxPtr;
 }  // namespace testobject
-#endif /* __NESTEDPDXOBJECT_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_28158ffb5a5f70ed511fa8baa47de6a8

--- a/src/tests/cpp/testobject/NonPdxType.hpp
+++ b/src/tests/cpp/testobject/NonPdxType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_07889e0b6ef2b0613a9cd1037e4e3eb5
+#define APACHE_GEODE_GUARD_07889e0b6ef2b0613a9cd1037e4e3eb5
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: vrao
  */
 
-#ifndef __NONPDXTYPE_HPP__
-#define __NONPDXTYPE_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 
@@ -483,4 +486,5 @@ class TESTOBJECT_EXPORT NonPdxType {
                         int* arrLengths) const;
 };
 }  // namespace PdxTests
-#endif /* __NONPDXTYPE_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_07889e0b6ef2b0613a9cd1037e4e3eb5

--- a/src/tests/cpp/testobject/NoopAuthInit.hpp
+++ b/src/tests/cpp/testobject/NoopAuthInit.hpp
@@ -1,5 +1,8 @@
-#ifndef __NOOPAUTHINIT__
-#define __NOOPAUTHINIT__
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_c4d769074b0c6edf12cc639d50a34284
+#define APACHE_GEODE_GUARD_c4d769074b0c6edf12cc639d50a34284
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -82,4 +85,5 @@ class NoopAuthInit : public AuthInitialize {
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-#endif  //__NOOPAUTHINIT__
+
+#endif // APACHE_GEODE_GUARD_c4d769074b0c6edf12cc639d50a34284

--- a/src/tests/cpp/testobject/PSTObject.hpp
+++ b/src/tests/cpp/testobject/PSTObject.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_3063688f9fda2bf5152f1eec97ed4928
+#define APACHE_GEODE_GUARD_3063688f9fda2bf5152f1eec97ed4928
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __PSTOBJECT_HPP__
-#define __PSTOBJECT_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -87,4 +90,5 @@ class TESTOBJECT_EXPORT PSTObject : public TimestampedObject {
 
 typedef apache::geode::client::SharedPtr<PSTObject> PSTObjectPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_3063688f9fda2bf5152f1eec97ed4928

--- a/src/tests/cpp/testobject/PdxAutoMegaType.hpp
+++ b/src/tests/cpp/testobject/PdxAutoMegaType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_08829dc10f69fd501e8ecbf245428569
+#define APACHE_GEODE_GUARD_08829dc10f69fd501e8ecbf245428569
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef PDX_AUTO_MEGA_TYPE_HPP_
-#define PDX_AUTO_MEGA_TYPE_HPP_
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -123,4 +126,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) PdxAutoMegaType : public PdxSerializable {
 typedef SharedPtr<PdxAutoMegaType> PdxAutoMegaTypePtr;
 }  // namespace PdxAutoTests
 
-#endif
+
+#endif // APACHE_GEODE_GUARD_08829dc10f69fd501e8ecbf245428569

--- a/src/tests/cpp/testobject/PdxClassV1.hpp
+++ b/src/tests/cpp/testobject/PdxClassV1.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_77cdb69379ae1ddf0404bd7ed757eeb8
+#define APACHE_GEODE_GUARD_77cdb69379ae1ddf0404bd7ed757eeb8
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,8 +25,6 @@
  *  Created on: Feb 3, 2012
  *      Author: npatel
  */
-#ifndef __PDXCLASSV1_HPP__
-#define __PDXCLASSV1_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -529,4 +532,5 @@ class TESTOBJECT_EXPORT TestEqualsV1 : public PdxSerializable {
 };
 
 } /* namespace PdxTests */
-#endif /* PDXCLASSV1_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_77cdb69379ae1ddf0404bd7ed757eeb8

--- a/src/tests/cpp/testobject/PdxClassV1WithAuto.hpp
+++ b/src/tests/cpp/testobject/PdxClassV1WithAuto.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_d211265b7b7a98aa276892bb897cf15f
+#define APACHE_GEODE_GUARD_d211265b7b7a98aa276892bb897cf15f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __PDX_CLASSV1_WITH_AUTO_HPP__
-#define __PDX_CLASSV1_WITH_AUTO_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -565,4 +568,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) TestEqualsV1 : public PdxSerializable {
 };
 
 } /* namespace PdxTestsAuto */
-#endif /* PDXCLASSV1_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_d211265b7b7a98aa276892bb897cf15f

--- a/src/tests/cpp/testobject/PdxClassV2.hpp
+++ b/src/tests/cpp/testobject/PdxClassV2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_468cbc833956797cfd132b131985f50c
+#define APACHE_GEODE_GUARD_468cbc833956797cfd132b131985f50c
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,8 +25,6 @@
  *  Created on: Feb 3, 2012
  *      Author: npatel
  */
-#ifndef __PDXCLASSV2_HPP__
-#define __PDXCLASSV2_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -570,4 +573,5 @@ public:
 */
 
 } /* namespace PdxTests */
-#endif /* PDXCLASSV1_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_468cbc833956797cfd132b131985f50c

--- a/src/tests/cpp/testobject/PdxClassV2WithAuto.hpp
+++ b/src/tests/cpp/testobject/PdxClassV2WithAuto.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_e5b77d2dd656c240f07a78ec6f670100
+#define APACHE_GEODE_GUARD_e5b77d2dd656c240f07a78ec6f670100
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __PDX_CLASSV2_WITH_AUTO_HPP__
-#define __PDX_CLASSV2_WITH_AUTO_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -602,4 +605,5 @@ public:
 */
 
 } /* namespace PdxTestsAuto */
-#endif /* PDXCLASSV1_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_e5b77d2dd656c240f07a78ec6f670100

--- a/src/tests/cpp/testobject/PdxType.hpp
+++ b/src/tests/cpp/testobject/PdxType.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_1072d2981f0f5cd29b6a6a69e0abf84f
+#define APACHE_GEODE_GUARD_1072d2981f0f5cd29b6a6a69e0abf84f
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __PDXOBJECT_HPP__
-#define __PDXOBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -799,4 +802,5 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 };
 typedef SharedPtr<PdxTests::PdxType> PdxTypePtr;
 }  // namespace PdxTests
-#endif /* PDXOBJECT_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_1072d2981f0f5cd29b6a6a69e0abf84f

--- a/src/tests/cpp/testobject/PdxTypeWithAuto.hpp
+++ b/src/tests/cpp/testobject/PdxTypeWithAuto.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_6db2d9020b4eb2dea09007c460e08e85
+#define APACHE_GEODE_GUARD_6db2d9020b4eb2dea09007c460e08e85
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __PDX_OBJECT_WITH_AUTO_HPP__
-#define __PDX_OBJECT_WITH_AUTO_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -752,4 +755,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) PdxType : public PdxSerializable {
 };
 typedef SharedPtr<PdxTestsAuto::PdxType> PdxTypePtr;
 }  // namespace PdxTestsAuto
-#endif /* PDXOBJECT_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_6db2d9020b4eb2dea09007c460e08e85

--- a/src/tests/cpp/testobject/PdxVersioned1.hpp
+++ b/src/tests/cpp/testobject/PdxVersioned1.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_471ba700244b02138198b644dcea79d5
+#define APACHE_GEODE_GUARD_471ba700244b02138198b644dcea79d5
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __PDXVERSIONED1OBJECT_HPP__
-#define __PDXVERSIONED1OBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -252,4 +255,5 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
 };
 typedef SharedPtr<PdxTests::PdxVersioned1> PdxVersioned1Ptr;
 }  // namespace PdxTests
-#endif /* __PDXVERSIONED1OBJECT_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_471ba700244b02138198b644dcea79d5

--- a/src/tests/cpp/testobject/PdxVersioned2.hpp
+++ b/src/tests/cpp/testobject/PdxVersioned2.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_63ab68609b8ab024ce65b860ce4c14dd
+#define APACHE_GEODE_GUARD_63ab68609b8ab024ce65b860ce4c14dd
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __PDXVERSIONED2OBJECT_HPP__
-#define __PDXVERSIONED2OBJECT_HPP__
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -255,4 +258,5 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
 };
 typedef SharedPtr<PdxTests::PdxVersioned2> PdxVersioned2Ptr;
 }  // namespace PdxTests
-#endif /* __PDXVERSIONED2OBJECT_HPP__ */
+
+#endif // APACHE_GEODE_GUARD_63ab68609b8ab024ce65b860ce4c14dd

--- a/src/tests/cpp/testobject/Portfolio.hpp
+++ b/src/tests/cpp/testobject/Portfolio.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_5dd561945b3f1843d3e6d0d1e94a9a0d
+#define APACHE_GEODE_GUARD_5dd561945b3f1843d3e6d0d1e94a9a0d
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __PORTFOLIO_HPP__
-#define __PORTFOLIO_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include "Position.hpp"
@@ -128,4 +131,5 @@ class TESTOBJECT_EXPORT Portfolio : public Serializable {
 
 typedef SharedPtr<Portfolio> PortfolioPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_5dd561945b3f1843d3e6d0d1e94a9a0d

--- a/src/tests/cpp/testobject/PortfolioPdx.hpp
+++ b/src/tests/cpp/testobject/PortfolioPdx.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_c671317d09616c448db78f20e3208e41
+#define APACHE_GEODE_GUARD_c671317d09616c448db78f20e3208e41
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __PORTFOLIOPDX_HPP__
-#define __PORTFOLIOPDX_HPP__
 
 #include "PositionPdx.hpp"
 
@@ -105,4 +108,5 @@ class TESTOBJECT_EXPORT PortfolioPdx : public PdxSerializable {
 
 typedef SharedPtr<PortfolioPdx> PortfolioPdxPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_c671317d09616c448db78f20e3208e41

--- a/src/tests/cpp/testobject/Position.hpp
+++ b/src/tests/cpp/testobject/Position.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_6b0a46d8e03f0ffb9c53c7c14ef5eed4
+#define APACHE_GEODE_GUARD_6b0a46d8e03f0ffb9c53c7c14ef5eed4
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __POSITION_HPP__
-#define __POSITION_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string.h>
@@ -105,4 +108,5 @@ class TESTOBJECT_EXPORT Position : public apache::geode::client::Serializable {
 
 typedef apache::geode::client::SharedPtr<Position> PositionPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_6b0a46d8e03f0ffb9c53c7c14ef5eed4

--- a/src/tests/cpp/testobject/PositionPdx.hpp
+++ b/src/tests/cpp/testobject/PositionPdx.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_16153fc06e90eeaa167430a34632e57d
+#define APACHE_GEODE_GUARD_16153fc06e90eeaa167430a34632e57d
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,8 +24,6 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#ifndef __POSITIONPDX_HPP__
-#define __POSITIONPDX_HPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <gfcpp/PdxSerializable.hpp>
@@ -101,4 +104,5 @@ class TESTOBJECT_EXPORT PositionPdx
 
 typedef apache::geode::client::SharedPtr<PositionPdx> PositionPdxPtr;
 }  // namespace testobject
-#endif
+
+#endif // APACHE_GEODE_GUARD_16153fc06e90eeaa167430a34632e57d

--- a/src/tests/cpp/testobject/TestObject1.hpp
+++ b/src/tests/cpp/testobject/TestObject1.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_e0125e37a3eca017a80d206a8d22c2e8
+#define APACHE_GEODE_GUARD_e0125e37a3eca017a80d206a8d22c2e8
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: abhaware
  */
 
-#ifndef TESTOBJECT1_HPP_
-#define TESTOBJECT1_HPP_
 
 #include <gfcpp/GeodeCppCache.hpp>
 #include <string>
@@ -65,4 +68,5 @@ class TESTOBJECT_EXPORT TestObject1 : public Cacheable {
 
 typedef SharedPtr<TestObject1> TestObject1Ptr;
 }  // namespace testobject
-#endif /* TESTOBJECT1_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_e0125e37a3eca017a80d206a8d22c2e8

--- a/src/tests/cpp/testobject/TimestampedObject.hpp
+++ b/src/tests/cpp/testobject/TimestampedObject.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_f3340c9b2d447c884bfa8bef6b826bb9
+#define APACHE_GEODE_GUARD_f3340c9b2d447c884bfa8bef6b826bb9
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __TimestampedObjectHPP__
-#define __TimestampedObjectHPP__
 
 #include <gfcpp/GeodeCppCache.hpp>
 
@@ -50,4 +53,5 @@ class TESTOBJECT_EXPORT TimestampedObject
 typedef apache::geode::client::SharedPtr<TimestampedObject>
     TimestampedObjectPtr;
 }  // namespace testobject
-#endif  // __TimestampedObjectHPP__
+
+#endif // APACHE_GEODE_GUARD_f3340c9b2d447c884bfa8bef6b826bb9

--- a/src/tests/cpp/testobject/VariousPdxTypes.hpp
+++ b/src/tests/cpp/testobject/VariousPdxTypes.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_e8d4e6f6728b309933eb81791b61fc90
+#define APACHE_GEODE_GUARD_e8d4e6f6728b309933eb81791b61fc90
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +26,6 @@
  *      Author: npatel
  */
 
-#ifndef __VARIOUSPDXTYPES_HPP_
-#define __VARIOUSPDXTYPES_HPP_
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -535,4 +538,5 @@ class TESTOBJECT_EXPORT PdxInsideIGFSerializable : public Serializable {
 typedef SharedPtr<PdxInsideIGFSerializable> PdxInsideIGFSerializablePtr;
 
 } /* namespace PdxTests */
-#endif /* __VARIOUSPDXTYPES_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_e8d4e6f6728b309933eb81791b61fc90

--- a/src/tests/cpp/testobject/VariousPdxTypesWithAuto.hpp
+++ b/src/tests/cpp/testobject/VariousPdxTypesWithAuto.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef APACHE_GEODE_GUARD_99a40c6ce49041acf9d03a72cd57e1c2
+#define APACHE_GEODE_GUARD_99a40c6ce49041acf9d03a72cd57e1c2
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +19,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __VARIOUS_PDX_TYPES_WITH_AUTO_HPP_
-#define __VARIOUS_PDX_TYPES_WITH_AUTO_HPP_
 
 #include <gfcpp/PdxSerializable.hpp>
 #include <gfcpp/GeodeCppCache.hpp>
@@ -542,4 +545,5 @@ class GFIGNORE(TESTOBJECT_EXPORT) PdxInsideIGFSerializable
 typedef SharedPtr<PdxInsideIGFSerializable> PdxInsideIGFSerializablePtr;
 
 } /* namespace PdxTestsAuto */
-#endif /* __VARIOUSPDXTYPES_HPP_ */
+
+#endif // APACHE_GEODE_GUARD_99a40c6ce49041acf9d03a72cd57e1c2


### PR DESCRIPTION
In the process of replacing references to Gemfire with references to Apache Geode in the include guards, standardize the include guards and use #pragma once where applicable.