### PR TITLE
Add geode-redis to assembly.

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -341,6 +341,9 @@ distributions {
         from project(":geode-rebalancer").configurations.runtime
         from project(":geode-rebalancer").configurations.archives.allArtifacts.files
 
+        from project(":geode-redis").configurations.runtime
+        from project(":geode-redis").configurations.archives.allArtifacts.files
+
         from configurations.bundled
         from configurations.gfshDependencies
 


### PR DESCRIPTION
This makes starting a server with Redis actually work, at least on my machine.