### PR TITLE
GEODE-2589, GEODE-2590 lucene index region attributes should be based…

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
@@ -158,6 +158,8 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
     attributesFactory.setTotalNumBuckets(dataRegionAttributes.getTotalNumBuckets());
     attributesFactory.setRedundantCopies(dataRegionAttributes.getRedundantCopies());
     attributesFactory.setPartitionResolver(getPartitionResolver(dataRegionAttributes));
+    attributesFactory.setRecoveryDelay(dataRegionAttributes.getRecoveryDelay());
+    attributesFactory.setStartupRecoveryDelay(dataRegionAttributes.getStartupRecoveryDelay());
     return attributesFactory;
   }
 
@@ -185,7 +187,9 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
     RegionAttributes baseAttributes = this.cache.getRegionAttributes(regionShortCut.toString());
     AttributesFactory factory = new AttributesFactory(baseAttributes);
     factory.setPartitionAttributes(partitionAttributesFactory.create());
-    factory.setDiskStoreName(regionAttributes.getDiskStoreName());
+    if (regionAttributes.getDataPolicy().withPersistence()) {
+      factory.setDiskStoreName(regionAttributes.getDiskStoreName());
+    }
     RegionAttributes<K, V> attributes = factory.create();
 
     return createRegion(regionName, attributes);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
@@ -290,6 +290,7 @@ public class LuceneIndexForPartitionedRegionTest {
     String regionPath = "regionName";
     GemFireCacheImpl cache = Fakes.cache();
     RegionAttributes regionAttributes = mock(RegionAttributes.class);
+    when(regionAttributes.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
     PartitionAttributes partitionAttributes = initializeAttributes(cache);
     LuceneIndexForPartitionedRegion index =
         new LuceneIndexForPartitionedRegion(name, regionPath, cache);
@@ -310,6 +311,7 @@ public class LuceneIndexForPartitionedRegionTest {
     GemFireCacheImpl cache = Fakes.cache();
     PartitionAttributes partitionAttributes = initializeAttributes(cache);
     RegionAttributes regionAttributes = mock(RegionAttributes.class);
+    when(regionAttributes.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
     LuceneIndexForPartitionedRegion index =
         new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     LuceneIndexForPartitionedRegion indexSpy = spy(index);


### PR DESCRIPTION
lucene index region attributes should reflect those on data region

- lucene index region now inherits recoveryDelay and startupRecoveryDelay from data region
- lucene index region now only sets diskStoreName (in RegionAttributes) when data region has persistence.

@upthewaterspout @nabarunnag  - Could you please review these changes?