### PR TITLE
GEODE-1793 LocatorDUnitTest.testStartTwoLocatorsOneWithSSLAndTheOther…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
@@ -25,6 +25,7 @@ import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
 import org.apache.logging.log4j.Logger;
@@ -264,8 +265,8 @@ public class TcpClient {
     try {
       sock = socketCreator.connect(ipAddr.getAddress(), ipAddr.getPort(), timeout, null, false);
       sock.setSoTimeout(timeout);
-    } catch (SSLHandshakeException e) {
-      throw new LocatorCancelException("Unrecognisable response received", e);
+    } catch (SSLException e) {
+      throw new LocatorCancelException("Unable to form SSL connection", e);
     }
 
     try {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -77,9 +77,9 @@ public class TcpServer {
    * <p>
    * This should be incremented if the gossip message structures change
    * <p>
-   * 1000 - gemfire 5.5 - using java serialization 1001 - 5.7 - using DataSerializable and
-   * supporting server locator messages. 1002 - 7.1 - sending GemFire version along with
-   * GOSSIP_VERSION in each request.
+   * 1000 - gemfire 5.5 - using java serialization<br>
+   * 1001 - 5.7 - using DataSerializable and supporting server locator messages.<br>
+   * 1002 - 7.1 - sending GemFire version along with GOSSIP_VERSION in each request.
    * <p>
    * with the addition of support for all old versions of clients you can no longer change this
    * version number
@@ -89,7 +89,7 @@ public class TcpServer {
   // This GOSSIPVERSION is used in _getVersionForAddress request for getting GemFire version of a
   // GossipServer.
   public final static int OLDGOSSIPVERSION = 1001;
-
+  
   private static/* GemStoneAddition */ final Map GOSSIP_TO_GEMFIRE_VERSION_MAP = new HashMap();
 
   // For test purpose only
@@ -360,6 +360,13 @@ public class TcpServer {
           versionOrdinal = (short) GOSSIP_TO_GEMFIRE_VERSION_MAP.get(gossipVersion);
         } else {
           // Close the socket. We can not accept requests from a newer version
+          try {
+            sock.getOutputStream().write("unknown protocol version".getBytes());
+            sock.getOutputStream().flush();
+          } catch (IOException e) {
+            log.debug("exception in sending reply to process using unknown protocol "
+                + gossipVersion, e);
+          }
           sock.close();
           return;
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -89,7 +89,7 @@ public class TcpServer {
   // This GOSSIPVERSION is used in _getVersionForAddress request for getting GemFire version of a
   // GossipServer.
   public final static int OLDGOSSIPVERSION = 1001;
-  
+
   private static/* GemStoneAddition */ final Map GOSSIP_TO_GEMFIRE_VERSION_MAP = new HashMap();
 
   // For test purpose only
@@ -364,8 +364,8 @@ public class TcpServer {
             sock.getOutputStream().write("unknown protocol version".getBytes());
             sock.getOutputStream().flush();
           } catch (IOException e) {
-            log.debug("exception in sending reply to process using unknown protocol "
-                + gossipVersion, e);
+            log.debug(
+                "exception in sending reply to process using unknown protocol " + gossipVersion, e);
           }
           sock.close();
           return;

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -308,14 +308,11 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
   private Boolean startLocatorWithPortAndProperties(final int port, final Properties properties)
       throws IOException {
     try {
-//      System.setProperty("p2p.joinTimeout", "5000"); // set a short join timeout. default is 17000ms
       Locator.startLocatorAndDS(port, new File(""), properties);
     } catch (SystemConnectException e) {
       return Boolean.FALSE;
     } catch (GemFireConfigException e) {
       return Boolean.FALSE;
-    } finally {
-//      System.getProperties().remove("p2p.joinTimeout");
     }
     return Boolean.TRUE;
   }
@@ -635,12 +632,7 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
   private Locator startLocatorInternal(final int port, final Properties properties)
       throws IOException {
     Locator locator;
-    try {
-//      System.setProperty("p2p.joinTimeout", "5000"); // set a short join timeout. default is 17000ms
-      locator = Locator.startLocatorAndDS(port, new File(""), properties);
-    } finally {
-//      System.getProperties().remove("p2p.joinTimeout");
-    }
+    locator = Locator.startLocatorAndDS(port, new File(""), properties);
     return locator;
   }
 
@@ -1305,7 +1297,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
     bgexecLogger.info(addExpected);
 
     boolean exceptionOccurred = true;
-//    String oldValue = (String) System.getProperties().put("p2p.joinTimeout", "15000");
     try {
       DistributedSystem.connect(props);
       exceptionOccurred = false;
@@ -1322,11 +1313,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
       // if expected then add in a catch block for it above this catch
       org.apache.geode.test.dunit.Assert.fail("Failed with unexpected exception", ex);
     } finally {
-//      if (oldValue == null) {
-//        System.getProperties().remove("p2p.joinTimeout");
-//      } else {
-//        System.getProperties().put("p2p.joinTimeout", oldValue);
-//      }
       bgexecLogger.info(removeExpected);
     }
 
@@ -1360,7 +1346,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
 
       SerializableRunnable connect = new SerializableRunnable("Connect to " + locators) {
         public void run() {
-          // System.setProperty("p2p.joinTimeout", "5000");
           Properties props = new Properties();
           props.setProperty(MCAST_PORT, "0");
           props.setProperty(LOCATORS, locators);
@@ -1962,7 +1947,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
     File logFile = new File("");
     try {
       System.setProperty(InternalLocator.LOCATORS_PREFERRED_AS_COORDINATORS, "true");
-//      System.setProperty("p2p.joinTimeout", "1000");
       Properties locProps = new Properties();
       locProps.put(MCAST_PORT, "0");
       locProps.put(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
@@ -1972,7 +1956,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
       org.apache.geode.test.dunit.Assert.fail("While starting locator on port " + port, ex);
     } finally {
       System.getProperties().remove(InternalLocator.LOCATORS_PREFERRED_AS_COORDINATORS);
-//      System.getProperties().remove("p2p.joinTimeout");
     }
   }
 


### PR DESCRIPTION
This was a product issue.  When the locator using plain-text sockets is
contacted by a TcpClient using SSL the locator often just closes the socket.
On some platforms this causes a SSLHandshakeException but on others it
just causes a "SocketException: connection reset".  Writing some text to
the socket forces the TcpClient to get a SSLException (which is the superclass
of SSLHandshakeException).

The test class is still marked as Flaky due to GEODE-2542.

I deleted one of the tests in LocatorDUnitTest as it wasn't doing any useful validation and really served no purpose.

I also increased the joinTimeout in this test.  The original 1-second timeout was intended to make the tests run faster but I think it's probably the source of some of the flaky-ness in this set of tests.  Some of them were also overriding the joinTimeout established by the DUnit framework, so that was actually a bad thing to be doing.  The tests all run in a few seconds with the default joinTimeout setting anyway.
