### PR TITLE
GEODE-2596: Lucene metrics moved to public API

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneIndexStatsMonitor.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneIndexStatsMonitor.java
@@ -16,7 +16,7 @@ package org.apache.geode.cache.lucene.internal.management;
 
 import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
-import org.apache.geode.management.internal.ManagementStrings;
+import org.apache.geode.cache.lucene.management.LuceneIndexMetrics;
 import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor;
 import org.apache.geode.management.internal.beans.stats.StatType;
 import org.apache.geode.management.internal.beans.stats.StatsAverageLatency;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneServiceBridge.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneServiceBridge.java
@@ -18,7 +18,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.LuceneService;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
-import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
+import org.apache.geode.cache.lucene.management.LuceneIndexMetrics;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneServiceMBean.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneServiceMBean.java
@@ -16,6 +16,8 @@ package org.apache.geode.cache.lucene.internal.management;
 
 import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.LuceneService;
+import org.apache.geode.cache.lucene.management.LuceneIndexMetrics;
+import org.apache.geode.cache.lucene.management.LuceneServiceMXBean;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 
 import javax.management.NotificationBroadcasterSupport;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneIndexMetrics.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneIndexMetrics.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.cache.lucene.internal.management;
+package org.apache.geode.cache.lucene.management;
 
 import java.beans.ConstructorProperties;
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneServiceMXBean.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneServiceMXBean.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.cache.lucene.internal.management;
+package org.apache.geode.cache.lucene.management;
 
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission.Operation;

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/management/LuceneManagementDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/management/LuceneManagementDUnitTest.java
@@ -19,6 +19,8 @@ import org.apache.geode.cache.lucene.LuceneQuery;
 import org.apache.geode.cache.lucene.LuceneQueryException;
 import org.apache.geode.cache.lucene.LuceneService;
 import org.apache.geode.cache.lucene.LuceneServiceProvider;
+import org.apache.geode.cache.lucene.management.LuceneIndexMetrics;
+import org.apache.geode.cache.lucene.management.LuceneServiceMXBean;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.management.ManagementTestBase;


### PR DESCRIPTION
	* LuceneIndexMetrics and LuceneServiceMXBean were moved to org.apache.geode.cache.lucene.management
	

-- Lucene precheckin passed

@upthewaterspout @jhuynh1 @ladyVader @gesterzhou @boglesby 