### PR TITLE
GEODE-2618: PrimaryBucketExceptions handled in LuceneQueryFunction.ex…

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
@@ -23,6 +23,7 @@ import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
+import org.apache.geode.internal.cache.PrimaryBucketException;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.Query;
@@ -112,7 +113,8 @@ public class LuceneQueryFunction implements Function, InternalEntity {
       }
       stats.incNumberOfQueryExecuted();
       resultSender.lastResult(mergedResult);
-    } catch (IOException | BucketNotFoundException | CacheClosedException e) {
+    } catch (IOException | BucketNotFoundException | CacheClosedException
+        | PrimaryBucketException e) {
       logger.debug("Exception during lucene query function", e);
       throw new InternalFunctionInvocationTargetException(e);
     }


### PR DESCRIPTION
…ecute

	* PrimaryBucketException while executing a LuceneQuery will now be caught and wrapped as a InternalFunctionInvocationTargetException
	* This will trigger a re-execution of the LuceneQuery on the member which will have the primary bucket.

@jhuynh1 @upthewaterspout @boglesby @gesterzhou @ladyVader 