### PR TITLE
GEODE-2620: Rate stats removed from LuceneIndexMetrics

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneIndexStatsMonitor.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/management/LuceneIndexStatsMonitor.java
@@ -24,15 +24,9 @@ import org.apache.geode.management.internal.beans.stats.StatsRate;
 
 public class LuceneIndexStatsMonitor extends MBeanStatsMonitor {
 
-  private StatsRate updateRate;
-
   private StatsAverageLatency updateRateAverageLatency;
 
-  private StatsRate commitRate;
-
   private StatsAverageLatency commitRateAverageLatency;
-
-  private StatsRate queryRate;
 
   private StatsAverageLatency queryRateAverageLatency;
 
@@ -45,11 +39,6 @@ public class LuceneIndexStatsMonitor extends MBeanStatsMonitor {
   }
 
   private void configureMetrics() {
-    this.queryRate = new StatsRate(StatsKey.QUERIES, StatType.INT_TYPE, this);
-
-    this.updateRate = new StatsRate(StatsKey.UPDATES, StatType.INT_TYPE, this);
-
-    this.commitRate = new StatsRate(StatsKey.COMMITS, StatType.INT_TYPE, this);
 
     this.queryRateAverageLatency =
         new StatsAverageLatency(StatsKey.QUERIES, StatType.INT_TYPE, StatsKey.QUERY_TIME, this);
@@ -64,29 +53,26 @@ public class LuceneIndexStatsMonitor extends MBeanStatsMonitor {
   protected LuceneIndexMetrics getIndexMetrics(LuceneIndex index) {
     int queryExecutions = getStatistic(StatsKey.QUERIES).intValue();
     long queryExecutionTime = getStatistic(StatsKey.QUERY_TIME).longValue();
-    float queryRateValue = this.queryRate.getRate();
     long queryRateAverageLatencyValue = this.queryRateAverageLatency.getAverageLatency();
     int queryExecutionsInProgress = getStatistic(StatsKey.QUERIES_IN_PROGRESS).intValue();
     long queryExecutionTotalHits = getStatistic(StatsKey.QUERIES_TOTAL_HITS).longValue();
 
     int updates = getStatistic(StatsKey.UPDATES).intValue();
     long updateTime = getStatistic(StatsKey.UPDATE_TIME).longValue();
-    float updateRateValue = this.updateRate.getRate();
     long updateRateAverageLatencyValue = this.updateRateAverageLatency.getAverageLatency();
     int updatesInProgress = getStatistic(StatsKey.UPDATES_IN_PROGRESS).intValue();
 
     int commits = getStatistic(StatsKey.COMMITS).intValue();
     long commitTime = getStatistic(StatsKey.COMMIT_TIME).longValue();
-    float commitRateValue = this.commitRate.getRate();
     long commitRateAverageLatencyValue = this.commitRateAverageLatency.getAverageLatency();
     int commitsInProgress = getStatistic(StatsKey.COMMITS_IN_PROGRESS).intValue();
 
     int documents = getStatistic(StatsKey.DOCUMENTS).intValue();
 
     return new LuceneIndexMetrics(index.getRegionPath(), index.getName(), queryExecutions,
-        queryExecutionTime, queryRateValue, queryRateAverageLatencyValue, queryExecutionsInProgress,
-        queryExecutionTotalHits, updates, updateTime, updateRateValue,
-        updateRateAverageLatencyValue, updatesInProgress, commits, commitTime, commitRateValue,
-        commitRateAverageLatencyValue, commitsInProgress, documents);
+        queryExecutionTime, queryRateAverageLatencyValue, queryExecutionsInProgress,
+        queryExecutionTotalHits, updates, updateTime, updateRateAverageLatencyValue,
+        updatesInProgress, commits, commitTime, commitRateAverageLatencyValue, commitsInProgress,
+        documents);
   }
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneIndexMetrics.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/LuceneIndexMetrics.java
@@ -28,8 +28,6 @@ public class LuceneIndexMetrics {
 
   private final long queryExecutionTime;
 
-  private final float queryRate;
-
   private final long queryRateAverageLatency;
 
   private final int queryExecutionsInProgress;
@@ -40,8 +38,6 @@ public class LuceneIndexMetrics {
 
   private final long updateTime;
 
-  private final float updateRate;
-
   private final long updateRateAverageLatency;
 
   private final int updatesInProgress;
@@ -49,8 +45,6 @@ public class LuceneIndexMetrics {
   private final int commits;
 
   private final long commitTime;
-
-  private final float commitRate;
 
   private final long commitRateAverageLatency;
 
@@ -63,32 +57,27 @@ public class LuceneIndexMetrics {
    * an instance of this class.
    */
   @ConstructorProperties({"regionPath", "indexName", "queryExecutions", "queryExecutionTime",
-      "queryRate", "queryRateAverageLatency", "queryExecutionsInProgress",
-      "queryExecutionTotalHits", "updates", "updateTime", "updateRate", "updateRateAverageLatency",
-      "updatesInProgress", "commits", "commitTime", "commitRate", "commitRateAverageLatency",
-      "commitsInProgress", "documents"})
+      "queryRateAverageLatency", "queryExecutionsInProgress", "queryExecutionTotalHits", "updates",
+      "updateTime", "updateRateAverageLatency", "updatesInProgress", "commits", "commitTime",
+      "commitRateAverageLatency", "commitsInProgress", "documents"})
   public LuceneIndexMetrics(String regionPath, String indexName, int queryExecutions,
-      long queryExecutionTime, float queryRate, long queryRateAverageLatency,
-      int queryExecutionsInProgress, long queryExecutionTotalHits, int updates, long updateTime,
-      float updateRate, long updateRateAverageLatency, int updatesInProgress, int commits,
-      long commitTime, float commitRate, long commitRateAverageLatency, int commitsInProgress,
-      int documents) {
+      long queryExecutionTime, long queryRateAverageLatency, int queryExecutionsInProgress,
+      long queryExecutionTotalHits, int updates, long updateTime, long updateRateAverageLatency,
+      int updatesInProgress, int commits, long commitTime, long commitRateAverageLatency,
+      int commitsInProgress, int documents) {
     this.regionPath = regionPath;
     this.indexName = indexName;
     this.queryExecutions = queryExecutions;
     this.queryExecutionTime = queryExecutionTime;
-    this.queryRate = queryRate;
     this.queryRateAverageLatency = queryRateAverageLatency;
     this.queryExecutionsInProgress = queryExecutionsInProgress;
     this.queryExecutionTotalHits = queryExecutionTotalHits;
     this.updates = updates;
     this.updateTime = updateTime;
-    this.updateRate = updateRate;
     this.updateRateAverageLatency = updateRateAverageLatency;
     this.updatesInProgress = updatesInProgress;
     this.commits = commits;
     this.commitTime = commitTime;
-    this.commitRate = commitRate;
     this.commitRateAverageLatency = commitRateAverageLatency;
     this.commitsInProgress = commitsInProgress;
     this.documents = documents;
@@ -129,15 +118,6 @@ public class LuceneIndexMetrics {
    */
   public long getQueryExecutionTime() {
     return this.queryExecutionTime;
-  }
-
-  /**
-   * Returns the rate of query execution using the {@link LuceneIndex}
-   *
-   * @return the rate of query execution using the Lucene Index
-   */
-  public float getQueryRate() {
-    return this.queryRate;
   }
 
   /**
@@ -186,15 +166,6 @@ public class LuceneIndexMetrics {
   }
 
   /**
-   * Returns the rate at which update operations are executed on the {@link LuceneIndex}
-   *
-   * @return rate at which update operations are executed on the {@link LuceneIndex}
-   */
-  public float getUpdateRate() {
-    return this.updateRate;
-  }
-
-  /**
    * Returns the average latency for the update operations on the {@link LuceneIndex}
    *
    * @return the average latency for the update operations in nanoseconds on the Lucene Index
@@ -228,15 +199,6 @@ public class LuceneIndexMetrics {
    */
   public long getCommitTime() {
     return this.commitTime;
-  }
-
-  /**
-   * Returns the rate of commit operations on the {@link LuceneIndex}
-   *
-   * @return the rate of commit operations on the Lucene Index
-   */
-  public float getCommitRate() {
-    return this.commitRate;
   }
 
   /**
@@ -277,16 +239,14 @@ public class LuceneIndexMetrics {
     return new StringBuilder().append(getClass().getSimpleName()).append("[").append("regionPath=")
         .append(this.regionPath).append("; indexName=").append(this.indexName)
         .append("; queryExecutions=").append(this.queryExecutions).append("; queryExecutionTime=")
-        .append(this.queryExecutionTime).append("; queryRate=").append(this.queryRate)
-        .append("; queryRateAverageLatency=").append(this.queryRateAverageLatency)
-        .append("; queryExecutionsInProgress=").append(this.queryExecutionsInProgress)
-        .append("; queryExecutionTotalHits=").append(this.queryExecutionTotalHits)
-        .append("; updates=").append(this.updates).append("; updateTime=").append(this.updateTime)
-        .append("; updateRate=").append(this.updateRate).append("; updateRateAverageLatency=")
+        .append(this.queryExecutionTime).append("; queryRateAverageLatency=")
+        .append(this.queryRateAverageLatency).append("; queryExecutionsInProgress=")
+        .append(this.queryExecutionsInProgress).append("; queryExecutionTotalHits=")
+        .append(this.queryExecutionTotalHits).append("; updates=").append(this.updates)
+        .append("; updateTime=").append(this.updateTime).append("; updateRateAverageLatency=")
         .append(this.updateRateAverageLatency).append("; updatesInProgress=")
         .append(this.updatesInProgress).append("; commits=").append(this.commits)
-        .append("; commitTime=").append(this.commitTime).append("; commitRate=")
-        .append(this.commitRate).append("; commitRateAverageLatency=")
+        .append("; commitTime=").append(this.commitTime).append("; commitRateAverageLatency=")
         .append(this.commitRateAverageLatency).append("; commitsInProgress=")
         .append(this.commitsInProgress).append("; documents=").append(this.documents).append("]")
         .toString();


### PR DESCRIPTION
	* Commit Rate, update rate and query rate removed from LuceneIndexMetrics
	* They can be added back again when the getRate method in StatsRate.java is fixed

@upthewaterspout @jhuynh1 @ladyVader @gesterzhou @boglesby 

-- Lucene precheckin and spotlessApply passed