### PR TITLE
GEODE-2592 Document Lucene-related gfsh commands

### DIFF
--- a/geode-book/master_middleman/source/subnavs/geode-subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode-subnav.erb
@@ -1766,6 +1766,9 @@ gfsh</a>
                                         <a href="/docs/guide/11/tools_modules/gfsh/quick_ref_commands_by_area.html#topic_1C82E6F1B2AF4A65A8DA6B3C846BAC13">Locator Commands</a>
                                     </li>
                                     <li>
+                                        <a href="/docs/guide/11/tools_modules/gfsh/quick_ref_commands_by_area.html#topic_lucene_commands">Lucene Commands</a>
+                                    </li>
+                                    <li>
                                         <a href="/docs/guide/11/tools_modules/gfsh/quick_ref_commands_by_area.html#topic_cvg_bls_5q">PDX Commands</a>
                                     </li>
                                     <li>
@@ -1852,6 +1855,9 @@ gfsh</a>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/create.html#topic_960A5B6FD3D84E1881EE118E299DD12D">create index</a>
                                             </li>
                                             <li>
+                                                <a href="/docs/guide/11/tools_modules/gfsh/command-pages/create.html#create_lucene_index">create lucene index</a>
+                                            </li>
+                                            <li>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/create.html#topic_54B0985FEC5241CA9D26B0CE0A5EA863">create region</a>
                                             </li>
                                         </ul>
@@ -1882,6 +1888,9 @@ gfsh</a>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/describe.html#topic_C635B500BE6A4F1D9572D0BC98A224F2">describe disk-store</a>
                                             </li>
                                             <li>
+                                                <a href="/docs/guide/11/tools_modules/gfsh/command-pages/describe.html#describe_lucene_index">describe lucene index</a>
+                                            </li>
+                                            <li>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/describe.html#topic_D62F3D42B1D84CF68F03D54D5122806A">describe member</a>
                                             </li>
                                             <li>
@@ -1904,6 +1913,9 @@ gfsh</a>
                                             </li>
                                             <li>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/destroy.html#topic_D00219CCD6F64C1582A0802AC5CDF3F3">destroy index</a>
+                                            </li>
+                                            <li>
+                                                <a href="/docs/guide/11/tools_modules/gfsh/command-pages/destroy.html#destroy_lucene_index">destroy lucene index</a>
                                             </li>
                                             <li>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/destroy.html#topic_BEDACECF4599407794ACBC0E56B30F65">destroy region</a>
@@ -2004,6 +2016,9 @@ gfsh</a>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/list.html#topic_B3B51B6DEA484EE086C4F657EC9831F2">list indexes</a>
                                             </li>
                                             <li>
+                                                <a href="/docs/guide/11/tools_modules/gfsh/command-pages/list.html#list_lucene_indexes">list lucene indexes</a>
+                                            </li>
+                                            <li>
                                                 <a href="/docs/guide/11/tools_modules/gfsh/command-pages/list.html#topic_5B5BFB2E5F314210858641BE3A689637">list members</a>
                                             </li>
                                             <li>
@@ -2046,6 +2061,9 @@ gfsh</a>
                                     </li>
                                     <li>
                                         <a href="/docs/guide/11/tools_modules/gfsh/command-pages/run.html">run</a>
+                                    </li>
+                                    <li>
+                                        <a href="/docs/guide/11/tools_modules/gfsh/command-pages/search.html">search lucene</a>
                                     </li>
                                     <li>
                                         <a href="/docs/guide/11/tools_modules/gfsh/command-pages/set.html">set variable</a>

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -18,36 +18,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<a id="topic_9663C9448D2745B387FC08F84818DDEC"></a>
-
 
 Create async-event-queues, disk-stores, gateway receivers, gateway senders, indexes, and regions.
 
--   **[create async-event-queue](../../../tools_modules/gfsh/command-pages/create.html#topic_ryz_pb1_dk)**
+-   **[create async-event-queue](#topic_ryz_pb1_dk)**
 
     Creates an asynchronous event queue for batching events before they are delivered by a gateway sender.
 
--   **[create defined indexes](../../../tools_modules/gfsh/command-pages/create.html#topic_w2t_l3m_qq)**
+-   **[create defined indexes](#topic_w2t_l3m_qq)**
 
     Creates all the defined indexes.
 
--   **[create disk-store](../../../tools_modules/gfsh/command-pages/create.html#topic_bkn_zty_ck)**
+-   **[create disk-store](#topic_bkn_zty_ck)**
 
     Defines a pool of one or more disk stores, which can be used by regions and client subscription queues, and gateway sender queues for WAN distribution.
 
--   **[create gateway-receiver](../../../tools_modules/gfsh/command-pages/create.html#topic_a4x_pb1_dk)**
+-   **[create gateway-receiver](#topic_a4x_pb1_dk)**
 
     Creates a gateway receiver. You can only have one gateway receiver on each member, and unlike a gateway sender, you do not need to specify an identifier for the gateway receiver .
 
--   **[create gateway-sender](../../../tools_modules/gfsh/command-pages/create.html#topic_hg2_bjz_ck)**
+-   **[create gateway-sender](#topic_hg2_bjz_ck)**
 
     Creates a gateway sender on one or more members of a distributed system.
 
--   **[create index](../../../tools_modules/gfsh/command-pages/create.html#topic_960A5B6FD3D84E1881EE118E299DD12D)**
+-   **[create index](#topic_960A5B6FD3D84E1881EE118E299DD12D)**
 
     Create an index that can be used when executing queries.
 
--   **[create region](../../../tools_modules/gfsh/command-pages/create.html#topic_54B0985FEC5241CA9D26B0CE0A5EA863)**
+-   **[create lucene index](#create_lucene_index)**
+
+    Create a region with given path and configuration.
+
+-   **[create region](#topic_54B0985FEC5241CA9D26B0CE0A5EA863)**
 
     Create a region with given path and configuration.
 
@@ -72,10 +74,8 @@ create async-event-queue --id=value --listener=value [--group=value(nullvalue)*]
     [--listener-param=value(,value)*]
 ```
 
-<a id="topic_ryz_pb1_dk__table_jzz_pb1_dk"></a>
-
+**Parameters, create async-event-queue:**
 <table>
-<caption><span class="tablecap">Table 1. Create Async-Event-Queue Parameters</span></caption>
 <colgroup>
 <col width="33%" />
 <col width="34%" />
@@ -179,8 +179,6 @@ create async-event-queue --id=value --listener=value [--group=value(nullvalue)*]
 </tbody>
 </table>
 
-<span class="tablecap">Table 1. Create Async-Event-Queue Parameters</span>
-
 **Example Commands:**
 
 ``` pre
@@ -201,14 +199,13 @@ See also [define index](define.html) and [clear defined indexes](clear.html).
 create defined indexes [--member=value] [--group=value]
 ```
 
-<a id="topic_w2t_l3m_qq__table_cgy_3jm_qq"></a>
+**Parameters, create defined indexes:**
 
 | Name                                           | Description                                                        | Default |
 |------------------------------------------------|--------------------------------------------------------------------|---------|
 | <span class="keyword parmname">\\-\\-member</span> | Name/Id of the member on which index will be created.              |         |
 | <span class="keyword parmname">\\-\\-group</span>  | The index will be created on all the members in this member group. |         |
 
-<span class="tablecap">Table 2. Create Defined Indexes Parameters</span>
 
 **Example Commands:**
 
@@ -250,10 +247,10 @@ create disk-store --name=value --dir=value(,value)* [--allow-force-compaction(=v
 [--disk-usage-warning-percentage=value] [--disk-usage-critical-percentage=value]
 ```
 
-<a id="topic_bkn_zty_ck__table_lkn_zty_ck"></a>
+
+**Parameters, create disk-store:**
 
 <table>
-<caption><span class="tablecap">Table 3. Create Disk-Store Parameters</span></caption>
 <colgroup>
 <col width="25%" />
 <col width="50%" />
@@ -335,8 +332,6 @@ If the specified directory does not exist, the command will create the directory
 </tbody>
 </table>
 
-<span class="tablecap">Table 3. Create Disk-Store Parameters</span>
-
 **Example Commands:**
 
 ``` pre
@@ -369,10 +364,9 @@ create gateway-receiver [--group=value(,value)*] [--member=value(,value)*]
   [--gateway-transport-filter=value(,value)*]
 ```
 
-<a id="topic_a4x_pb1_dk__table_v4x_pb1_dk"></a>
+**Parameters, create gateway-receiver:**
 
 <table>
-<caption><span class="tablecap">Table 4. Create Gateway-Receiver Parameters</span></caption>
 <colgroup>
 <col width="33%" />
 <col width="33%" />
@@ -436,12 +430,10 @@ create gateway-receiver [--group=value(,value)*] [--member=value(,value)*]
 </tbody>
 </table>
 
-<span class="tablecap">Table 4. Create Gateway-Receiver Parameters</span>
-
 **Example Commands:**
 
 ``` pre
-gfsh>create gatweway-receiver --member=server1
+gfsh>create gateway-receiver --member=server1
 ```
 
 **Sample Output:**
@@ -477,10 +469,9 @@ create gateway-sender --id=value --remote-distributed-system-id=value
    [--gateway-transport-filter=value(,value)*]
 ```
 
-<a id="topic_hg2_bjz_ck__table_ah2_bjz_ck"></a>
+**Parameters, create gateway-sender:**
 
 <table>
-<caption><span class="tablecap">Table 5. Create Gateway-Sender Parameters</span></caption>
 <colgroup>
 <col width="30%" />
 <col width="50%" />
@@ -606,8 +597,6 @@ create gateway-sender --id=value --remote-distributed-system-id=value
 </tbody>
 </table>
 
-<span class="tablecap">Table 5. Create Gateway-Sender Parameters</span>
-
 **Example Commands:**
 
 ``` pre
@@ -638,18 +627,17 @@ create index --name=value --expression=value --region=value
 [--member=value] [--type=value] [--group=value]
 ```
 
-<a id="topic_960A5B6FD3D84E1881EE118E299DD12D__table_9E1C010276AC45A59446A767A517D39F"></a>
+**Parameters: create index:**
 
 | Name                                               | Description                                                                            | Default |
 |----------------------------------------------------|----------------------------------------------------------------------------------------|---------|
 | <span class="keyword parmname">\\-\\-name</span>       | *Required.* Name of the index to create.                                               |         |
-| <span class="keyword parmname">\\-\\-expression</span> | *Required.* Field of the region values that are referenced by the index.               |         |
+| <span class="keyword parmname">&#8209;&#8209;expression</span> | *Required.* Field of the region values that are referenced by the index.               |         |
 | <span class="keyword parmname">\\-\\-region</span>     | *Required.* Name/Path of the region which corresponds to the "from" clause in a query. |         |
 | <span class="keyword parmname">\\-\\-member</span>     | Name/Id of the member on which index will be created.                                  |         |
 | <span class="keyword parmname">\\-\\-type</span>       | Type of the index. Valid values are: `range`, `key` and `hash`.                        | `range` |
 | <span class="keyword parmname">\\-\\-group</span>      | The index will be created on all the members in this member group.                     |         |
 
-<span class="tablecap">Table 6. Create Index Parameters</span>
 
 **Example Commands:**
 
@@ -673,6 +661,48 @@ Failed to create index "myIndex2" due to following reasons
 Index "myIndex2" already exists.  Create failed due to duplicate name.
 Occurred on following members
 1. ubuntu(server1:17682)<v1>:27574
+```
+
+## <a id="create_lucene_index" class="no-quick-link"></a>create lucene index
+
+Create a Lucene index.
+
+See also [describe lucene index](describe.html#describe_lucene_index), [destroy lucene index](destroy.html#destroy_lucene_index), [list lucene indexes](list.html#list_lucene_indexes) and [search lucene](search.html#search_lucene).
+
+**Availability:** Online. You must be connected in <span class="keyword parmname">gfsh</span> to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+create lucene index --name=value --region=value --field=value(,value)* [--analyzer=value(,value)*] [--group=value(,value)*]
+```
+
+**Parameters, create lucene index:**
+
+| Name                                               | Description                                                                            | Default |
+|----------------------------------------------------|----------------------------------------------------------------------------------------|---------|
+| <span class="keyword parmname">\\-\\-name</span>       | *Required.* Name of the index to create.                                               |         |
+| <span class="keyword parmname">\\-\\-region</span>     | *Required.* Name/Path of the region which corresponds to the "from" clause in a query. |         |
+| <span class="keyword parmname">\\-\\-field</span>      | *Required.* Field of the region values that are referenced by the index.               |         |
+| <span class="keyword parmname">&#8209;&#8209;analyzer</span>   | Analyzer to extract terms from text                                  |         |
+| <span class="keyword parmname">\\-\\-group</span>      | The index will be created on all the members in the specified member groups.                     |         |
+
+
+**Example Commands:**
+
+``` pre
+create region --name=Person --type=PARTITION_REDUNDANT_PERSISTENT
+create lucene index --name=customerIndex --region=/Customer --field=symbol,revenue,SSN,name,email,address,__REGION_VALUE_FIELD
+create lucene index --name=analyzerIndex --region=/Person --field=name,email,address,revenue --analyzer=null,org.apache.lucene.analysis.core.KeywordAnalyzer,examples.MyCharacterAnalyzer,null
+```
+
+**Sample Output:**
+
+``` pre
+gfsh>create lucene index --name=testIndex --region=testRegion --field=__REGION_VALUE_FIELD
+                 Member                  | Status
+---------------------------------------- | ---------------------------------
+192.168.1.23(server50505:17200)<v1>:1025 | Successfully created lucene index
 ```
 
 ## <a id="topic_54B0985FEC5241CA9D26B0CE0A5EA863" class="no-quick-link"></a>create region
@@ -711,10 +741,9 @@ See [Region Data Storage and Distribution](../../../developing/region_options/ch
     [--total-num-buckets=value] [--compressor=value] [--off-heap(=value)]
 ```
 
-<a id="topic_54B0985FEC5241CA9D26B0CE0A5EA863__table_4CDCDC115DD043D5B8ACAA8D4CCFB145"></a>
+**Parameters, create region:**
 
 <table>
-<caption><span class="tablecap">Table 7. Create Region Parameters</span></caption>
 <colgroup>
 <col width="20%" />
 <col width="50%" />
@@ -916,8 +945,6 @@ See [Region Data Storage and Distribution](../../../developing/region_options/ch
 </tr>
 </tbody>
 </table>
-
-<span class="tablecap">Table 7. Create Region Parameters</span>
 
 **Example Commands:**
 

--- a/geode-docs/tools_modules/gfsh/command-pages/describe.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/describe.html.md.erb
@@ -18,36 +18,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<a id="concept_B8A3E21674294C65AE9F9A60F37A284E"></a>
-
 
 Display details of a member's configuration, shell connection, disk-stores, members, or regions.
 
--   **[describe client](../../../tools_modules/gfsh/command-pages/describe.html#topic_gyr_jgz_ck)**
+-   **[describe client](#topic_gyr_jgz_ck)**
 
     Displays details about a specified client.
 
--   **[describe config](../../../tools_modules/gfsh/command-pages/describe.html#topic_3C2C817D999C4E40AF788808B7B6AF99)**
+-   **[describe config](#topic_3C2C817D999C4E40AF788808B7B6AF99)**
 
     Display the configuration of a member.
 
--   **[describe connection](../../../tools_modules/gfsh/command-pages/describe.html#topic_591DC6B781B641168E6173E69AC6D201)**
+-   **[describe connection](#topic_591DC6B781B641168E6173E69AC6D201)**
 
     Display connection information details.
 
--   **[describe disk-store](../../../tools_modules/gfsh/command-pages/describe.html#topic_C635B500BE6A4F1D9572D0BC98A224F2)**
+-   **[describe disk-store](#topic_C635B500BE6A4F1D9572D0BC98A224F2)**
 
     Display information about a member's disk store.
 
--   **[describe member](../../../tools_modules/gfsh/command-pages/describe.html#topic_D62F3D42B1D84CF68F03D54D5122806A)**
+-   **[describe lucene index](#describe_lucene_index)**
+
+    Display information about a Lucene index.
+
+-   **[describe member](#topic_D62F3D42B1D84CF68F03D54D5122806A)**
 
     Display details of a member with given name/id.
 
--   **[describe offline-disk-store](../../../tools_modules/gfsh/command-pages/describe.html#topic_kys_yvk_2l)**
+-   **[describe offline-disk-store](#topic_kys_yvk_2l)**
 
     Display information about an offline member's disk store.
 
--   **[describe region](../../../tools_modules/gfsh/command-pages/describe.html#topic_DECF7D3D33F54071B6B8AD4EA7E3F90B)**
+-   **[describe region](#topic_DECF7D3D33F54071B6B8AD4EA7E3F90B)**
 
     Display the attributes and key information of a region.
 
@@ -63,13 +65,12 @@ Displays details about a specified client.
 describe client --clientID=value
 ```
 
-<a id="topic_gyr_jgz_ck__table_pzd_qdh_2w"></a>
+**Parameters, describe client:**
 
 | Name                                             | Description                                                                                                                                     |
 |--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">&#8209;&#8209;clientID</span> | *Required.* ID of the client. To find a client ID, you can use the `list clients` command to display a list of connected clients and their IDs. |
 
-<span class="tablecap">Table 1. Describe Client Parameters</span>
 
 **Example Commands:**
 
@@ -108,14 +109,13 @@ Display the configuration of a member.
 describe config --member=value [--hide-defaults(=value)?]
 ```
 
-<a id="topic_3C2C817D999C4E40AF788808B7B6AF99__table_ohx_tdh_2w"></a>
+**Parameters, describe config:**
 
 | Name                                                  | Description                                                                      | Default Value |
 |-------------------------------------------------------|----------------------------------------------------------------------------------|---------------|
 | <span class="keyword parmname">\\-\\-member </span>       | Name or ID of a member whose configuration is to be shown.                       |               |
 | <span class="keyword parmname">\\-\\-hide-defaults</span> | Whether to hide configuration information for properties with the default value. | true          |
 
-<span class="tablecap">Table 2. Describe Config Parameters</span>
 
 **Example Commands:**
 
@@ -192,14 +192,13 @@ Display information about a member's disk store.
 describe disk-store --member=value --name=value
 ```
 
-<a id="topic_C635B500BE6A4F1D9572D0BC98A224F2__table_xs1_12h_2w"></a>
+**Parameters, describe disk-store:**
 
 | Name                                           | Description                                                            |
 |------------------------------------------------|------------------------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-member</span> | *Required.* Name/ID of the member with the disk store to be described. |
 | <span class="keyword parmname">\\-\\-name </span>  | *Required*. Name of the disk store to be described.                    |
 
-<span class="tablecap">Table 3. Describe Disk-Store Parameters</span>
 
 **Example Commands:**
 
@@ -233,6 +232,49 @@ PDX Serialization Meta-Data Stored : No
 
 ```
 
+## <a id="describe_lucene_index" class="no-quick-link"></a>describe lucene index
+
+Describe a Lucene index.
+
+See also [create lucene index](create.html#create_lucene_index), [destroy lucene index](destroy.html#destroy_lucene_index), [list lucene indexes](list.html#list_lucene_indexes) and [search lucene](search.html#search_lucene).
+
+**Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+describe lucene index --name=value --region=value
+```
+
+**Parameters, describe lucene index:**
+
+| Name                                               | Description                                                                  |
+|----------------------------------------------------|------------------------------------------------------------------------------|
+| <span class="keyword parmname">\\-\\-name</span>       | *Required.* Name of the Lucene index to describe                          |
+| <span class="keyword parmname">\\-\\-region</span>     | *Required.* Name and path of the region in which the Lucene index exists               |
+
+
+
+**Example Commands:**
+
+``` pre
+gfsh>describe lucene index --name=personIndex --region=/Person
+```
+
+**Sample Output:**
+
+``` pre
+gfsh>describe lucene index --name=personIndex --region=/Person
+Index Name  | Region Path |                 Indexed Fields                 | Field Analyzer |   Status    | Query Executions | Updates | Commits | Documents
+----------- | ----------- | ---------------------------------------------- | -------------- | ----------- | ---------------- | ------- | ------- | ---------
+personIndex | /Person     | [name, email, address, streetAddress, revenue] | {}             | Initialized | 339              | 1008    | 962     | 1004
+
+gfsh>describe lucene index --name=analyzerIndex --region=/Person
+ Index Name   | Region Path |     Indexed Fields     |            Field Analyzer             |   Status    | Query Executions | Updates | Commits | Documents
+------------- | ----------- | ---------------------- | ------------------------------------- | ----------- | ---------------- | ------- | ------- | ---------
+analyzerIndex | /Person     | [address, name, email] | {address=MyCharacterAnalyzer, email.. | Initialized | 1695             | 1008    | 962     | 1004
+```
+
 ## <a id="topic_D62F3D42B1D84CF68F03D54D5122806A" class="no-quick-link"></a>describe member
 
 Display details of a member with given name/id.
@@ -245,13 +287,12 @@ Display details of a member with given name/id.
 describe member --name=value
 ```
 
-<a id="topic_D62F3D42B1D84CF68F03D54D5122806A__table_psn_c2h_2w"></a>
+**Parameters, describe member:**
 
 | Name                                          | Description                                                                               |
 |-----------------------------------------------|-------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">&#8209;&#8209;name </span> | *Required.* Display information about a member, including name, ID, groups, regions, etc. |
 
-<span class="tablecap">Table 4. Describe Member Parameters</span>
 
 **Example Commands:**
 
@@ -298,7 +339,7 @@ Display information about an offline member's disk store.
 describe offline-disk-store --name=value --disk-dirs=value(,value)* [--pdx=value] [--region=value]
 ```
 
-<a id="topic_kys_yvk_2l__table_rlg_f2h_2w"></a>
+**Parameters, describe offline-disk-store:**
 
 | Name                                               | Description                                                                  |
 |----------------------------------------------------|------------------------------------------------------------------------------|
@@ -307,7 +348,6 @@ describe offline-disk-store --name=value --disk-dirs=value(,value)* [--pdx=value
 | <span class="keyword parmname">\\-\\-pdx</span>        | If set (or set to true), display all the pdx types stored in the disk store. |
 | <span class="keyword parmname">\\-\\-region</span>     | Name and path of the region in the disk store to be described.               |
 
-<span class="tablecap">Table 5. Describe Offline-Disk-Store Parameters</span>
 
 **Example Commands:**
 
@@ -375,13 +415,12 @@ Display the attributes and key information of a region.
 describe region --name=value
 ```
 
-<a id="topic_DECF7D3D33F54071B6B8AD4EA7E3F90B__table_wvt_32h_2w"></a>
+**Parameters, describe region:**
 
 | Name                                          | Description                                          |
 |-----------------------------------------------|------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name </span> | *Required.* Name/Path of the region to be described. |
 
-<span class="tablecap">Table 6. Describe Region Parameters</span>
 
 **Example Commands:**
 

--- a/geode-docs/tools_modules/gfsh/command-pages/destroy.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/destroy.html.md.erb
@@ -18,24 +18,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<a id="concept_B8A3E21674294C65AE9F9A60F37A284E"></a>
 
 
 Delete or unregister functions, remove indexes, disk stores and regions.
 
--   **[destroy disk-store](../../../tools_modules/gfsh/command-pages/destroy.html#topic_yfr_l2z_ck)**
+-   **[destroy disk-store](#topic_yfr_l2z_ck)**
 
     Deletes a disk store and all files on disk used by the disk store. Data for closed regions that previously used this disk store is lost.
 
--   **[destroy function](../../../tools_modules/gfsh/command-pages/destroy.html#topic_E48C2DF809054C12A162026D8A2139BB)**
+-   **[destroy function](#topic_E48C2DF809054C12A162026D8A2139BB)**
 
     Destroy or unregister a function.
 
--   **[destroy index](../../../tools_modules/gfsh/command-pages/destroy.html#topic_D00219CCD6F64C1582A0802AC5CDF3F3)**
+-   **[destroy index](#topic_D00219CCD6F64C1582A0802AC5CDF3F3)**
 
     Destroy or remove the specified index.
 
--   **[destroy region](../../../tools_modules/gfsh/command-pages/destroy.html#topic_BEDACECF4599407794ACBC0E56B30F65)**
+-   **[destroy lucene index](#destroy_lucene_index)**
+
+    Destroy or remove the specified Lucene index.
+
+-   **[destroy region](#topic_BEDACECF4599407794ACBC0E56B30F65)**
 
     Destroy or remove a region.
 
@@ -51,14 +54,13 @@ Deletes a disk store and all files on disk used by the disk store. Data for clos
 destroy disk-store --name=value [--group=value(,value)*]
 ```
 
-<a id="topic_yfr_l2z_ck__table_ypc_1dh_2w"></a>
+**Parameters, destroy disk-store:**
 
 | Name                                          | Description                                                                                                                          |
 |-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name</span>  | *Required.* Name of the disk store to be deleted.                                                                                    |
 | <span class="keyword parmname">&#8209;&#8209;group</span> | Group(s) of members on which the disk store will be destroyed. If no group is specified, the disk store is destroyed on all members. |
 
-<span class="tablecap">Table 1. Destroy Disk-Store Parameters</span>
 
 **Example Commands:**
 
@@ -89,7 +91,7 @@ The default is for the function to be unregistered from all members.
 destroy function --id=value [--group=value] [--member=value]
 ```
 
-<a id="topic_E48C2DF809054C12A162026D8A2139BB__table_rq1_ddh_2w"></a>
+**Parameters, destroy function:**
 
 | Name                                           | Description                                                                                |
 |------------------------------------------------|--------------------------------------------------------------------------------------------|
@@ -97,7 +99,6 @@ destroy function --id=value [--group=value] [--member=value]
 | <span class="keyword parmname">\\-\\-groups</span> | One or more groups of members from which this function will be unregistered.               |
 | <span class="keyword parmname">&#8209;&#8209;member</span> | Name or ID of the member from which this function will be unregistered.                    |
 
-<span class="tablecap">Table 2. Destroy Function Parameters</span>
 
 **Example Commands:**
 
@@ -123,22 +124,53 @@ destroy index [--name=value] [--region=value] [--member=value]
 **Note:**
 You must specify at least one of the parameter options. If you enter `destroy index` without any parameters, the command will ask you to specify at least one option.
 
-<a id="topic_D00219CCD6F64C1582A0802AC5CDF3F3__table_n24_fdh_2w"></a>
+**Parameters, destroy index:**
 
 | Name                                           | Description                                                                  |
 |------------------------------------------------|------------------------------------------------------------------------------|
-| <span class="keyword parmname">\\-\\-name</span>   | Name for the index to be removed.                                            |
-| <span class="keyword parmname">\\-\\-member</span> | Id of the member on which index is to be created.                            |
-| <span class="keyword parmname">\\-\\-region</span> | Name of the region , from where an index or all indexes are to be destroyed. |
-| <span class="keyword parmname">\\-\\-group</span>  | The index will be created on all the members in this member group.           |
+| <span class="keyword parmname">\\-\\-name</span>   | Name of the index to be removed.                                            |
+| <span class="keyword parmname">\\-\\-member</span> | Id of the member on which index is to be removed.                            |
+| <span class="keyword parmname">\\-\\-region</span> | Name of the region from which an index or all indexes are to be destroyed. |
+| <span class="keyword parmname">\\-\\-group</span>  | The index will be removed on all the members in this member group.           |
 
-<span class="tablecap">Table 3. Destroy Index Parameters</span>
 
 **Example Commands:**
 
 ``` pre
 destroy index --member=server2
 destroy index --name=MyKeyIndex
+```
+
+## <a id="destroy_lucene_index" class="no-quick-link"></a>destroy lucene index
+
+Destroy or remove the specified Lucene index.
+
+See also [create lucene index](create.html#create_lucene_index), [describe lucene index](describe.html#describe_lucene_index), [list lucene indexes](list.html#list_lucene_indexes) and [search lucene](search.html#search_lucene).
+
+**Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+destroy lucene index [--name=value] [--region=value]
+```
+
+**Note:**
+You must specify at least one of the parameter options. If you enter `destroy lucene index` without any parameters, the command will ask you to specify at least one option.
+
+**Parameters, destroy lucene index:**
+
+| Name                                           | Description                                                                  |
+|------------------------------------------------|------------------------------------------------------------------------------|
+| <span class="keyword parmname">\\-\\-name</span>   | Name of the index to be removed.                                            |
+| <span class="keyword parmname">\\-\\-region</span> | Name of the region from which an index or all indexes are to be removed. |
+
+
+**Example Commands:**
+
+``` pre
+destroy lucene index --member=server2
+destroy lucene index --name=MyKeyIndex
 ```
 
 ## <a id="topic_BEDACECF4599407794ACBC0E56B30F65" class="no-quick-link"></a>destroy region
@@ -153,13 +185,12 @@ Destroy or remove a region.
 destroy region --name=value
 ```
 
-<a id="topic_BEDACECF4599407794ACBC0E56B30F65__table_yb5_3dh_2w"></a>
+**Parameters, destroy region:**
 
 | Name                                         | Description                                            |
 |----------------------------------------------|--------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name</span> | *Required.* Name and path of the region to be removed. |
 
-<span class="tablecap">Table 4. Destroy Region Parameters</span>
 
 **Example Commands:**
 

--- a/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
@@ -19,7 +19,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<a id="topic_AE5B406FAE7F4152B2919EDF45F4EE80"></a>
 
 
 List existing Geode resources such as deployed applications, disk-stores, functions, members, servers, and regions.
@@ -55,6 +54,10 @@ List existing Geode resources such as deployed applications, disk-stores, functi
 -   **[list indexes](#topic_B3B51B6DEA484EE086C4F657EC9831F2)**
 
     Display the list of indexes created for all members.
+
+-   **[list lucene indexes](#list_lucene_indexes)**
+
+    List Lucene indexes created for all members.
 
 -   **[list members](#topic_5B5BFB2E5F314210858641BE3A689637)**
 
@@ -127,13 +130,12 @@ Display a list of JARs that were deployed to members using the deploy command.
 list deployed [--group=value(,value)*]
 ```
 
-<a id="topic_59DF60DE71AD4097B281749425254BFF__table_ch5_b2g_2w"></a>
+**Parameters, list deployed:**
 
 | Name                                          | Description                                                                                                          |
 |-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">&#8209;&#8209;group</span> | Group(s) of members for which deployed JARs will be displayed. If not specified, JARs for all members are displayed. |
 
-<span class="tablecap">Table 1. List Deployed Parameters</span>
 
 **Example Commands:**
 
@@ -211,7 +213,7 @@ List durable client CQs associated with the specified durable client id.
 list durable-cqs --durable-client-id=value [--member=value] [--group=value]
 ```
 
-<a id="topic_66016A698C334F4EBA19B99F51B0204B__table_esj_32g_2w"></a>
+**Parameters, list durable-cqs:**
 
 | Name                                                       | Description                                                                                            |
 |------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
@@ -219,7 +221,6 @@ list durable-cqs --durable-client-id=value [--member=value] [--group=value]
 | <span class="keyword parmname">\\-\\-member</span>             | Name or Id of the member for which the durable client is registered and durable CQs will be displayed. |
 | <span class="keyword parmname">\\-\\-group</span>              | Group of members for which the durable client is registered and durable CQs will be displayed.         |
 
-<span class="tablecap">Table 2. List Durable-CQs Parameters</span>
 
 **Example Commands**:
 
@@ -267,7 +268,7 @@ list functions [--matches=value] [--group=value(,value)*]
 [--member=value(,value)*]
 ```
 
-<a id="topic_DCC7CCBBEF5942B783A8F2A4A5B2FABF__table_d3y_l2g_2w"></a>
+**Parameters, list functions:**
 
 | Name                                             | Description                                                                                                                                                                                     |
 |--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -275,7 +276,6 @@ list functions [--matches=value] [--group=value(,value)*]
 | <span class="keyword parmname">\\-\\-group</span>    | Group(s) of members for which functions will be displayed. Use a comma separated list for multiple groups.                                                                                      |
 | <span class="keyword parmname">&#8209;&#8209;member </span>  | Name or ID of the member(s) for which functions will be displayed. Use a comma separated list for multiple members.                                                                             |
 
-<span class="tablecap">Table 3. List Functions Parameters</span>
 
 **Example Commands:**
 
@@ -325,14 +325,13 @@ Displays the gateway senders and receivers for a member or members.
 list gateways [--group=value(,value)*]
 ```
 
-<a id="topic_B1D89671C7B74074899C7D52F15849ED__table_n3w_q2g_2w"></a>
+**Parameters, list gateways:**
 
 | Name                                           | Description                                                                                                                    |
 |------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">&#8209;&#8209;member</span> | Member(s) whose gateways senders and receiver display.                                                                         |
 | <span class="keyword parmname">\\-\\-group</span>  | Group(s) of members for which Gateway Senders and Receivers will be displayed. Use a comma separated list for multiple groups. |
 
-<span class="tablecap">Table 4. List Gateways Parameters</span>
 
 **Example Commands:**
 
@@ -352,13 +351,12 @@ Display the list of indexes created for all members.
 list indexes [--with-stats(=value)?]
 ```
 
-<a id="topic_B3B51B6DEA484EE086C4F657EC9831F2__table_hth_t2g_2w"></a>
+**Parameters, list indexes:**
 
 | Name                                               | Description                                            | Default Value |
 |----------------------------------------------------|--------------------------------------------------------|---------------|
 | <span class="keyword parmname">\\-\\-with-stats</span> | Specifies whether statistics should also be displayed. | false         |
 
-<span class="tablecap">Table 5. List Indexes Parameters </span>
 
 **Example Commands:**
 
@@ -398,6 +396,50 @@ gfsh> list indexes
 No Indexes Found
 ```
 
+## <a id="list_lucene_indexes" class="no-quick-link"></a>list lucene indexes
+
+Display the list of Lucene indexes created for all members. The optional `--with-stats` qualifier shows activity on the indexes.
+
+See also [create lucene index](create.html#create_lucene_index), [describe lucene index](describe.html#describe_lucene_index), [destroy lucene index](destroy.html#destroy_lucene_index) and [search lucene](search.html#search_lucene).
+
+**Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+list lucene indexes [--with-stats(=value)]
+```
+
+**Parameters, list lucene indexes:**
+
+| Name                                               | Description                                            | Default Value |
+|----------------------------------------------------|--------------------------------------------------------|---------------|
+| <span class="keyword parmname">\\-\\-with-stats</span> | Specifies whether statistics should also be displayed. | false if not specified, true if specified         |
+
+
+**Example Commands:**
+
+``` pre
+list lucene indexes
+```
+
+**Sample Output:**
+
+``` pre
+gfsh>list lucene indexes --with-stats
+Index Name | Region Path |     Indexed Fields     | Field Analy.. | Status  | Query Executions | Updates | Commits | Documents
+---------- | ----------- | ---------------------- | ------------- | ------- | ---------------- | ------- | ------- | ---------
+testIndex  | /testRegion | [__REGION_VALUE_FIELD] | {__REGION_V.. | Defined | NA               | NA      | NA      | NA
+
+gfsh>list lucene indexes
+ Index Name   | Region Path |                           Indexed Fields                           | Field Analy.. | Status
+------------- | ----------- | ------------------------------------------------------------------ | ------------- | -----------
+analyzerIndex | /Person     | [revenue, address, name, email]                                    | {revenue=St.. | Initialized
+customerIndex | /Customer   | [symbol, revenue, SSN, name, email, address, __REGION_VALUE_FIELD] | {}            | Initialized
+pageIndex     | /Page       | [id, title, content]                                               | {}            | Initialized
+personIndex   | /Person     | [name, email, address, revenue]                                    | {}            | Initialized
+```
+
 ## <a id="topic_5B5BFB2E5F314210858641BE3A689637" class="no-quick-link"></a>list members
 
 Display all or a subset of members.
@@ -410,13 +452,12 @@ Display all or a subset of members.
 list members [--group=value]
 ```
 
-<a id="topic_5B5BFB2E5F314210858641BE3A689637__table_r2h_x2g_2w"></a>
+**Parameters, list members:**
 
 | Name                                          | Description                                     |
 |-----------------------------------------------|-------------------------------------------------|
 | <span class="keyword parmname">\\-\\-group</span> | Group name for which members will be displayed. |
 
-<span class="tablecap">Table 6. List Members Parameters</span>
 
 **Example Commands:**
 
@@ -446,14 +487,13 @@ Display regions of a member or members. If no parameter is specified, all region
 list regions [--group=value] [--member=value]
 ```
 
-<a id="topic_F0ECEFF26086474498598035DD83C588__table_ckh_1fg_2w"></a>
+**Parameters, list regions:**
 
 | Name                                            | Description                                                                 |
 |-------------------------------------------------|-----------------------------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-group</span>   | Group of members for which regions will be displayed.                       |
 | <span class="keyword parmname">\\-\\-member </span> | Name or ID of the member of the member for which regions will be displayed. |
 
-<span class="tablecap">Table 7. List Regions Parameters</span>
 
 **Example Commands:**
 

--- a/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
@@ -1,0 +1,114 @@
+---
+title:  search lucene
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## <a id="search_lucene" class="no-quick-link"></a>search lucene
+
+Search a Lucene index
+
+See also [create lucene index](create.html#create_lucene_index), [describe lucene index](describe.html#describe_lucene_index), [destroy lucene index](destroy.html#destroy_lucene_index) and [list lucene indexes](list.html#list_lucene_indexes).
+
+**Availability:** Online.
+
+**Syntax:**
+
+``` pre
+search lucene --name=value --region=value --queryStrings=value --defaultField=value
+    [--limit=value] [--pageSize=value] [--keys-only=value]
+```
+
+**Parameters, search lucene:**
+
+<table>
+<colgroup>
+<col width="33%" />
+<col width="34%" />
+<col width="33%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Name</th>
+<th>Description</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><span class="keyword parmname">\-\-name</span></td>
+<td><em>Required</em>. Name of the lucene index to search.</td>
+<td> </td>
+</tr>
+<tr>
+<td><span class="keyword parmname">\-\-region</span></td>
+<td><em>Required</em>. Name/Path of the region where the lucene index exists.</td>
+<td> </td>
+</tr>
+<tr>
+<td><span class="keyword parmname" style="whitespace:nowrap;">&#8209;&#8208;queryStrings</span></td>
+<td><em>Required</em>. Query string to search the lucene index.</td>
+<td> </td>
+</tr>
+<tr>
+<td><span class="keyword parmname" style="whitespace:nowrap;">&#8209;&#8208;defaultField</span></td>
+<td><em>Required</em>. Default field to search in.</td>
+<td> </td>
+</tr>
+<tr>
+<td><span class="keyword parmname">\-\-limit</span></td>
+<td>Number of search results needed.</td>
+<td>If the parameter is not specified: -1</td>
+</tr>
+<tr>
+<td><span class="keyword parmname">\-\-pageSize</span></td>
+<td>Number of results to be returned in a page.</td>
+<td>If the parameter is not specified: -1</td>
+</tr>
+<td><span class="keyword parmname">\-\-keys-only</span></td>
+<td>Return only keys of search results.</td>
+<td>If the parameter is not specified: false</td>
+</tr>
+</table>
+
+**Example Commands:**
+
+``` pre
+gfsh> search lucene --name=testIndex --region=/testRegion --queryStrings=value1 --defaultField=__REGION_VALUE_FIELD
+ 
+```
+
+**Sample Output:**
+
+``` pre
+gfsh>search lucene --name=testIndex --region=/testRegion --queryStrings=value* --defaultField=__REGION_VALUE_FIELD
+key | value  | score
+--- | ------ | -----
+3   | value3 | 1
+2   | value2 | 1
+1   | value1 | 1
+
+gfsh>search lucene --region=/Person --name=analyzerIndex --defaultField=address --queryStrings="97763"
+ key   |                                                   value                                                   | score
+------ | --------------------------------------------------------------------------------------------------------- | ---------
+key763 | Person{name='Fred Freeloader', email='ffl@example.com', address='763 Miles Dv, Portland_OR_97763', re.. | 1.6694657
+
+
+```
+
+

--- a/geode-docs/tools_modules/gfsh/gfsh_quick_reference.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/gfsh_quick_reference.html.md.erb
@@ -25,34 +25,36 @@ This quick reference sorts all commands into functional areas.
 
 Click a command to see additional information, including syntax, a list of options, and examples.
 
--   **[Basic Geode gfsh Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_77DA6E3929404EB4AC24230CC7C21493)**
+-   **[Basic Geode gfsh Commands](quick_ref_commands_by_area.html#topic_77DA6E3929404EB4AC24230CC7C21493)**
 
--   **[Configuration Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_EB854534301A477BB01058B3B142AE1D)**
+-   **[Configuration Commands](quick_ref_commands_by_area.html#topic_EB854534301A477BB01058B3B142AE1D)**
 
--   **[Data Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_C7DB8A800D6244AE8FF3ADDCF139DCE4)**
+-   **[Data Commands](quick_ref_commands_by_area.html#topic_C7DB8A800D6244AE8FF3ADDCF139DCE4)**
 
--   **[Deployment Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_1B47A0E110124EB6BF08A467EB510412)**
+-   **[Deployment Commands](quick_ref_commands_by_area.html#topic_1B47A0E110124EB6BF08A467EB510412)**
 
--   **[Disk Store Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_1ACC91B493EE446E89EC7DBFBBAE00EA)**
+-   **[Disk Store Commands](quick_ref_commands_by_area.html#topic_1ACC91B493EE446E89EC7DBFBBAE00EA)**
 
--   **[Durable CQ and Client Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_10613D4850F04A3EB507F6B441AD3413)**
+-   **[Durable CQ and Client Commands](quick_ref_commands_by_area.html#topic_10613D4850F04A3EB507F6B441AD3413)**
 
--   **[Function Execution Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_8BB061D1A7A9488C819FE2B7881A1278)**
+-   **[Function Execution Commands](quick_ref_commands_by_area.html#topic_8BB061D1A7A9488C819FE2B7881A1278)**
 
--   **[Gateway (WAN) Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_F0AE5CE40D6D49BF92247F5EF4F871D2)**
+-   **[Gateway (WAN) Commands](quick_ref_commands_by_area.html#topic_F0AE5CE40D6D49BF92247F5EF4F871D2)**
 
--   **[Geode Monitoring Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_B742E9E862BA457082E2346581C97D03)**
+-   **[Geode Monitoring Commands](quick_ref_commands_by_area.html#topic_B742E9E862BA457082E2346581C97D03)**
 
--   **[Index Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_688C66526B4649AFA51C0F72F34FA45E)**
+-   **[Index Commands](quick_ref_commands_by_area.html#topic_688C66526B4649AFA51C0F72F34FA45E)**
 
--   **[JMX Connection Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_2A6DA4078E4E496A9F725A29BC4CFD0D)**
+-   **[JMX Connection Commands](quick_ref_commands_by_area.html#topic_2A6DA4078E4E496A9F725A29BC4CFD0D)**
 
--   **[Locator Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_1C82E6F1B2AF4A65A8DA6B3C846BAC13)**
+-   **[Locator Commands](quick_ref_commands_by_area.html#topic_1C82E6F1B2AF4A65A8DA6B3C846BAC13)**
 
--   **[PDX Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_cvg_bls_5q)**
+-   **[Lucene Commands](quick_ref_commands_by_area.html#topic_lucene_commands)**
 
--   **[Region Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_EF03119A40EE492984F3B6248596E1DD)**
+-   **[PDX Commands](quick_ref_commands_by_area.html#topic_cvg_bls_5q)**
 
--   **[Server Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_8A341FF86958466E9E64CF06CD21FED9)**
+-   **[Region Commands](quick_ref_commands_by_area.html#topic_EF03119A40EE492984F3B6248596E1DD)**
+
+-   **[Server Commands](quick_ref_commands_by_area.html#topic_8A341FF86958466E9E64CF06CD21FED9)**
 
 

--- a/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
@@ -277,6 +277,20 @@ limitations under the License.
 
 <span class="tablecap">Table 13. Locator Commands</span>
 
+## <a id="topic_lucene_commands" class="no-quick-link"></a>Lucene Commands
+
+<a id="topic_1C82E6F1B2AF4A65A8DA6B3C846BAC13__table_hy4_4z1_3l"></a>
+
+| Command                                                                                                                                                          | Description                                                                                                                                                                                                                                                                     | Availability    |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| [create lucene index](command-pages/create.html#create_lucene_index)                                | Create a Lucene index. | online |
+| [describe lucene index](command-pages/describe.html#describe_lucene_index) | Describe a Lucene index. | online |
+| [destroy lucene index](command-pages/destroy.html#destroy_lucene_index) | Destroy a Lucene index. | online |
+| [list lucene indexes](command-pages/list.html#list_lucene_indexes) | List Lucene indexes created for all members. The optional `--with-stats` qualifier shows activity on the indexes. | online |
+| [search lucene](command-pages/search.html#search_lucene) | Search a Lucene index. | online |
+
+<span class="tablecap">Table 14. Lucene Commands</span>
+
 ## <a id="topic_cvg_bls_5q" class="no-quick-link"></a>PDX Commands
 
 <a id="topic_cvg_bls_5q__table_tdf_cls_5q"></a>
@@ -286,7 +300,7 @@ limitations under the License.
 | [configure pdx](command-pages/configure.html#topic_jdkdiqbgphqh)                         | Configure Portable Data eXchange for all the cache(s) in the cluster. | online, offline |
 | [pdx rename](command-pages/pdx.html) | Renames PDX types in an offline disk store.                           | online, offline |
 
-<span class="tablecap">Table 14. PDX Commands</span>
+<span class="tablecap">Table 15. PDX Commands</span>
 
 ## <a id="topic_EF03119A40EE492984F3B6248596E1DD" class="no-quick-link"></a>Region Commands
 
@@ -301,7 +315,7 @@ limitations under the License.
 | [list regions](command-pages/list.html#topic_F0ECEFF26086474498598035DD83C588) | Display regions of a member or members. If no parameter is specified, all regions in the Geode distributed system are listed. | online       |
 | [rebalance](command-pages/rebalance.html)                                                                                                                                     | Rebalance partitioned regions.                                                                                                                             | online       |
 
-<span class="tablecap">Table 15. Region Commands</span>
+<span class="tablecap">Table 16. Region Commands</span>
 
 ## <a id="topic_8A341FF86958466E9E64CF06CD21FED9" class="no-quick-link"></a>Server Commands
 
@@ -313,6 +327,6 @@ limitations under the License.
 | [status server](command-pages/status.html#topic_E5DB49044978404D9D6B1971BF5D400D) | Display the status of the specified Geode cache server. | online, offline |
 | [stop server](command-pages/stop.html#topic_723EE395A63A40D6819618AFC2902115)                                  | Stop a Geode cache server.                              | online, offline |
 
-<span class="tablecap">Table 16. Server Commands</span>
+<span class="tablecap">Table 17. Server Commands</span>
 
 

--- a/geode-docs/tools_modules/lucene_integration.html.md.erb
+++ b/geode-docs/tools_modules/lucene_integration.html.md.erb
@@ -82,22 +82,24 @@ Collection<Person> results = query.findValues();
 
 ## <a id="gfsh-api" class="no-quick-link"></a>Gfsh API
 
-The gfsh command-line utility supports four Apache Lucene actions:
+The gfsh command-line utility supports five Apache Lucene actions:
 
-<dt><b>create lucene index</b></dt>
-    <dd>Create a lucene index that can be used to execute queries.</dd>
-<dt><b>describe lucene index</b></dt>
-    <dd>Display the describe of lucene indexes created for all members.</dd>
-<dt><b>list lucene indexes [with-stats]</b></dt>
-    <dd>Display the list of lucene indexes created for all members. The optional `with-stats` qualifier shows activity on the indexes.</dd>
-<dt><b>search lucene</b></dt>
-    <dd>Search lucene index</dd>
+<dt><a href="gfsh/command-pages/create.html#create_lucene_index"><b>create lucene index</b></a></dt>
+    <dd>Create a Lucene index that can be used to execute queries.</dd>
+<dt><a href="gfsh/command-pages/describe.html#describe_lucene_index"><b>describe lucene index</b></a></dt>
+    <dd>Describe a Lucene index.</dd>
+<dt><a href="gfsh/command-pages/destroy.html#destroy_lucene_index"><b>destroy lucene index</b></a></dt>
+    <dd>Destroy a Lucene index.</dd>
+<dt><a href="gfsh/command-pages/list.html#list_lucene_indexes"><b>list lucene indexes</b></a></dt>
+    <dd>List Lucene indexes created for all members.</dd>
+<dt><a href="gfsh/command-pages/search.html#search_lucene"><b>search lucene</b></a></dt>
+    <dd>Search a Lucene index</dd>
 
 **Gfsh command-line examples:**
 
 ``` pre
 // List Index
-gfsh> list lucene indexes [with-stats]
+gfsh> list lucene indexes --with-stats
 
 // Create Index
 gfsh>create lucene index --name=indexName --region=/orders --field=customer,tags


### PR DESCRIPTION
Add five new Lucene-related gfsh commands to the gfsh command reference pages:
create lucene index, describe lucene index, destroy lucene index, list lucene indexes, search lucene.