### PR TITLE
GEODE-2639: Added DUnit tests for expiration on Lucene

### DIFF
--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
@@ -55,7 +55,7 @@ public class ExpirationDUnitTest extends LuceneQueriesAccessorBase {
       RegionTestableType regionTestType) {
     SerializableRunnableIF createIndex = () -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      luceneService.createIndex(INDEX_NAME, REGION_NAME, "text");
+      luceneService.createIndexFactory().setFields("text").create(INDEX_NAME, REGION_NAME);
     };
 
     dataStore1.invoke(() -> initDataStore(createIndex, regionTestType));

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene;
+
+import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
+import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@Category(DistributedTest.class)
+@RunWith(JUnitParamsRunner.class)
+public class ExpirationDUnitTest extends LuceneQueriesAccessorBase {
+
+  protected final static int EXTRA_WAIT_TIME_SEC = 15;
+
+  protected RegionTestableType[] getPartitionRegionsWithExpirationSet() {
+    return new RegionTestableType[] {RegionTestableType.PARTITION_WITH_EXPIRATION_DESTROY,
+        RegionTestableType.PARTITION_WITH_EXPIRATION_INVALIDATE,
+        RegionTestableType.PARTITION_REDUNDANT_WITH_EXPIRATION_DESTROY,
+        RegionTestableType.PARTITION_REDUNDANT_WITH_EXPIRATION_INVALIDATE,
+        RegionTestableType.PARTITION_REDUNDANT_PERSISTENT_WITH_EXPIRATION_DESTROY,
+        RegionTestableType.PARTITION_REDUNDANT_PERSISTENT_WITH_EXPIRATION_INVALIDATE};
+  }
+
+  @Test
+  @Parameters(method = "getPartitionRegionsWithExpirationSet")
+  public void regionWithExpirationSetMustAlsoRemoveLuceneIndexEntries(
+      RegionTestableType regionTestType) {
+    SerializableRunnableIF createIndex = () -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      luceneService.createIndex(INDEX_NAME, REGION_NAME, "text");
+    };
+
+    dataStore1.invoke(() -> initDataStore(createIndex, regionTestType));
+    dataStore2.invoke(() -> initDataStore(createIndex, regionTestType));
+    accessor.invoke(() -> initDataStore(createIndex, regionTestType));
+
+    accessor.invoke(() -> {
+      Cache cache = getCache();
+      Region region = cache.getRegion(REGION_NAME);
+      IntStream.range(0, NUM_BUCKETS).forEach(i -> region.put(i, new TestObject("hello world")));
+    });
+
+    accessor.invoke(() -> Awaitility.await()
+        .atMost(EXPIRATION_TIMEOUT_SEC + EXTRA_WAIT_TIME_SEC, TimeUnit.SECONDS).until(() -> {
+          LuceneService luceneService = LuceneServiceProvider.get(getCache());
+          LuceneQuery<Integer, TestObject> luceneQuery = luceneService.createLuceneQueryFactory()
+              .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+
+          List<LuceneResultStruct<Integer, TestObject>> luceneResultList = null;
+          try {
+            luceneResultList = luceneQuery.findResults();
+          } catch (LuceneQueryException e) {
+            e.printStackTrace();
+            fail();
+          }
+          assertEquals(0, luceneResultList.size());
+        }));
+  }
+
+}


### PR DESCRIPTION
	* Tests added to validate the effect of the expiration of Lucene Index entries.
	* Once the entries expire, the lucene index entries must be updated.

@jhuynh1 @upthewaterspout @boglesby @ladyVader @gesterzhou 