### PR TITLE
GEODE-2674: Changing the lucene listener to get from the region

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventSubstitutionFilter.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventSubstitutionFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.cache.lucene.internal;
+
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.wan.GatewayEventSubstitutionFilter;
+import org.apache.geode.internal.cache.Token;
+
+/**
+ * A substitution filter which throws away the value of the entry and replaces it with an INVALID
+ * token. For the lucene index, we will just fetch the new value from the region, so we don't need
+ * the value.
+ */
+public class LuceneEventSubstitutionFilter implements GatewayEventSubstitutionFilter {
+  @Override
+  public Object getSubstituteValue(final EntryEvent event) {
+    return "";
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexImpl.java
@@ -180,6 +180,7 @@ public abstract class LuceneIndexImpl implements InternalLuceneIndex {
       return null;
     }
     LuceneEventListener listener = new LuceneEventListener(repositoryManager);
+    factory.setGatewayEventSubstitutionListener(new LuceneEventSubstitutionFilter());
     String aeqId = LuceneServiceImpl.getUniqueIndexName(getName(), regionPath);
     AsyncEventQueue indexQueue = factory.create(aeqId, listener);
     return indexQueue;


### PR DESCRIPTION
Rather than use the value that is in the queue, use the latest value
from the region to update the lucene index.

This ensures that even if the queue contains spurious events due to
retries or other issues, we put the correct value in the index.

This also potentially saves memory and disk space for the queue, because
the queue does not need to hold the value for the entry.

@boglesby @gesterzhou @jhuynh1 @ladyVader @nabarunnag 