### PR TITLE
GEODE-2619: Lucene APIs unwrap function exception and throw the cause.

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionException;
@@ -117,10 +118,10 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
     } catch (FunctionException e) {
       if (e.getCause() instanceof LuceneQueryException) {
         throw new LuceneQueryException(e);
-      } else {
-        e.printStackTrace();
-        throw e;
+      } else if (e.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) e.getCause();
       }
+      throw e;
 
     }
     return entries;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PageableLuceneQueryResultsImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PageableLuceneQueryResultsImpl.java
@@ -23,8 +23,10 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Execution;
+import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.lucene.PageableLuceneQueryResults;
@@ -80,20 +82,28 @@ public class PageableLuceneQueryResultsImpl<K, V> implements PageableLuceneQuery
 
 
   public List<LuceneResultStruct<K, V>> getHitEntries(int fromIndex, int toIndex) {
-    List<EntryScore<K>> scores = hits.subList(fromIndex, toIndex);
-    Set<K> keys = new HashSet<K>(scores.size());
-    for (EntryScore<K> score : scores) {
-      keys.add(score.getKey());
-    }
+    ArrayList<LuceneResultStruct<K, V>> results = null;
+    try {
+      List<EntryScore<K>> scores = hits.subList(fromIndex, toIndex);
+      Set<K> keys = new HashSet<K>(scores.size());
+      for (EntryScore<K> score : scores) {
+        keys.add(score.getKey());
+      }
 
-    Map<K, V> values = getValues(keys);
+      Map<K, V> values = getValues(keys);
 
-    ArrayList<LuceneResultStruct<K, V>> results =
-        new ArrayList<LuceneResultStruct<K, V>>(values.size());
-    for (EntryScore<K> score : scores) {
-      V value = values.get(score.getKey());
-      if (value != null)
-        results.add(new LuceneResultStructImpl(score.getKey(), value, score.getScore()));
+
+      results = new ArrayList<LuceneResultStruct<K, V>>(values.size());
+      for (EntryScore<K> score : scores) {
+        V value = values.get(score.getKey());
+        if (value != null)
+          results.add(new LuceneResultStructImpl(score.getKey(), value, score.getScore()));
+      }
+    } catch (FunctionException functionException) {
+      if (functionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) functionException.getCause();
+      }
+      throw functionException;
     }
     return results;
   }


### PR DESCRIPTION
	* This is done so that users do not encounter Function Exceptions while executing Lucene APIs.