### PR TITLE
GEODE-2738: Corrected spelling of "occured" to occurred

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -2952,7 +2952,7 @@ public abstract class DataSerializer {
    * loaded using the current thread's {@link Thread#getContextClassLoader context class loader}
    * before the one normally used by Java serialization is consulted.
    *
-   * @throws IOException A problem occured while reading from <code>in</code> (may wrap another
+   * @throws IOException A problem occurred while reading from <code>in</code> (may wrap another
    *         exception)
    * @throws ClassNotFoundException The class of an object read from <code>in</code> could not be
    *         found

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ExecuteFunctionNoAckOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ExecuteFunctionNoAckOp.java
@@ -86,7 +86,7 @@ public class ExecuteFunctionNoAckOp {
     } catch (Exception ex) {
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "ExecuteFunctionNoAckOp#execute : Exception occured while Sending Function Execution Message:"
+            "ExecuteFunctionNoAckOp#execute : Exception occurred while Sending Function Execution Message:"
                 + op.getMessage() + " to server using pool: " + pool,
             ex);
       }
@@ -127,7 +127,7 @@ public class ExecuteFunctionNoAckOp {
     } catch (Exception ex) {
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "ExecuteFunctionNoAckOp#execute : Exception occured while Sending Function Execution Message:"
+            "ExecuteFunctionNoAckOp#execute : Exception occurred while Sending Function Execution Message:"
                 + op.getMessage() + " to server using pool: " + pool,
             ex);
       }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionNoAckOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionNoAckOp.java
@@ -69,7 +69,7 @@ public class ExecuteRegionFunctionNoAckOp {
     } catch (Exception ex) {
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "ExecuteRegionFunctionNoAckOp#execute : Exception occured while Sending Function Execution Message: {} to server using pool: {}",
+            "ExecuteRegionFunctionNoAckOp#execute : Exception occurred while Sending Function Execution Message: {} to server using pool: {}",
             op.getMessage(), pool, ex);
       }
       if (ex.getMessage() != null)
@@ -94,7 +94,7 @@ public class ExecuteRegionFunctionNoAckOp {
     } catch (Exception ex) {
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "ExecuteRegionFunctionNoAckOp#execute : Exception occured while Sending Function Execution Message: {} to server using pool: {}",
+            "ExecuteRegionFunctionNoAckOp#execute : Exception occurred while Sending Function Execution Message: {} to server using pool: {}",
             op.getMessage(), pool, ex);
       }
       if (ex.getMessage() != null)

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
@@ -90,7 +90,7 @@ public class LiveServerPinger extends EndpointListenerAdapter {
           PingOp.execute(pool, endpoint.getLocation());
         } catch (Exception e) {
           if (logger.isDebugEnabled()) {
-            logger.debug("Error occured while pinging server: {} - {}", endpoint.getLocation(),
+            logger.debug("Error occurred while pinging server: {} - {}", endpoint.getLocation(),
                 e.getMessage());
           }
           GemFireCacheImpl cache = GemFireCacheImpl.getInstance();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/AbstractCompiledValue.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/AbstractCompiledValue.java
@@ -57,7 +57,7 @@ public abstract class AbstractCompiledValue implements CompiledValue, Filter, OQ
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException {
     Support.assertionFailed(
-        "This method should not have invoked as CompieldComparison & CompiledUndefined are the only classes on which this invocation should have occured ");
+        "This method should not have invoked as CompieldComparison & CompiledUndefined are the only classes on which this invocation should have occurred ");
     return null;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledSelect.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledSelect.java
@@ -420,7 +420,7 @@ public class CompiledSelect extends AbstractCompiledValue {
         CompiledIteratorDef iterDef = (CompiledIteratorDef) iter.next();
         RuntimeIterator rIter = iterDef.getRuntimeIterator(context);
         context.bindIterator(rIter);
-        // Asif . Ideally the function below should always be called after binding has occured
+        // Asif . Ideally the function below should always be called after binding has occurred
         // So that the interal ID gets set during binding to the scope. If not so then chances
         // are that internal_id is still null causing index_interanl_id to be null.
         // Though in our case it may not be an issue as the compute depedency phase must have

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/OrderByComparator.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/OrderByComparator.java
@@ -96,7 +96,7 @@ public class OrderByComparator implements Comparator {
       Object[] list2 = this.evaluateSortCriteria(obj2);
 
       if (list1.length != list2.length) {
-        Support.assertionFailed("Error Occured due to improper sort criteria evaluation ");
+        Support.assertionFailed("Error Occurred due to improper sort criteria evaluation ");
       } else {
         for (int i = 0; i < list1.length; i++) {
           Object arr1[] = (Object[]) list1[i];

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
@@ -1719,7 +1719,7 @@ class IndexConditioningHelper {
    * fields in the resultset obtained from Index usage. This List will be populated only if there
    * exists fields in index resultset which will not be selected.If all the fields of index
    * resultset will be used , then this List should be null or empty. It is used in preventing
-   * unnecessary expansion of same type, when a similar expansion has already occured. as for eg
+   * unnecessary expansion of same type, when a similar expansion has already occurred. as for eg
    * 
    * consider a index result containing 3 fields field1 field2 & field3 . Assume that field3 is for
    * cutdown. Since the expansion iterators can either be independent of all the fields in the index

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/cq/CqAttributesImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/cq/CqAttributesImpl.java
@@ -155,7 +155,7 @@ public class CqAttributesImpl implements CqAttributes, CqAttributesMutator, Clon
           // Handle client side exceptions.
         } catch (Exception ex) {
           logger.warn(LocalizedMessage.create(
-              LocalizedStrings.CqAttributesFactory_EXCEPTION_OCCURED_WHILE_CLOSING_CQ_LISTENER_ERROR_0,
+              LocalizedStrings.CqAttributesFactory_EXCEPTION_OCCURRED_WHILE_CLOSING_CQ_LISTENER_ERROR_0,
               ex.getLocalizedMessage()));
           if (logger.isDebugEnabled()) {
             logger.debug(ex.getMessage(), ex);
@@ -173,7 +173,7 @@ public class CqAttributesImpl implements CqAttributes, CqAttributesMutator, Clon
           // is still usable:
           SystemFailure.checkFailure();
           logger.warn(LocalizedMessage.create(
-              LocalizedStrings.CqAttributesFactory_RUNTIME_EXCEPTION_OCCURED_WHILE_CLOSING_CQ_LISTENER_ERROR_0,
+              LocalizedStrings.CqAttributesFactory_RUNTIME_EXCEPTION_OCCURRED_WHILE_CLOSING_CQ_LISTENER_ERROR_0,
               t.getLocalizedMessage()));
           if (logger.isDebugEnabled()) {
             logger.debug(t.getMessage(), t);
@@ -227,7 +227,7 @@ public class CqAttributesImpl implements CqAttributes, CqAttributesMutator, Clon
             // is still usable:
             SystemFailure.checkFailure();
             logger.warn(LocalizedMessage.create(
-                LocalizedStrings.CqAttributesFactory_RUNTIME_EXCEPTION_OCCURED_CLOSING_CQ_LISTENER_ERROR_0,
+                LocalizedStrings.CqAttributesFactory_RUNTIME_EXCEPTION_OCCURRED_CLOSING_CQ_LISTENER_ERROR_0,
                 t.getLocalizedMessage()));
             if (logger.isDebugEnabled()) {
               logger.debug(t.getMessage(), t);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
@@ -939,7 +939,7 @@ public abstract class AbstractIndex implements IndexProtocol {
 
     private int initEntriesUpdated = 0;
 
-    private boolean hasInitOccuredOnce = false;
+    private boolean hasInitOccurredOnce = false;
 
     private ExecutionContext initContext = null;
 
@@ -1047,7 +1047,7 @@ public abstract class AbstractIndex implements IndexProtocol {
         for (int i = 0; i < this.iteratorSize; i++) {
           CompiledIteratorDef iterDef = (CompiledIteratorDef) this.indexInitIterators.get(i);
           RuntimeIterator rIter = null;
-          if (!this.hasInitOccuredOnce) {
+          if (!this.hasInitOccurredOnce) {
             iterDef.computeDependencies(this.initContext);
             rIter = iterDef.getRuntimeIterator(this.initContext);
             this.initContext.addToIndependentRuntimeItrMapForIndexCreation(iterDef);
@@ -1057,7 +1057,7 @@ public abstract class AbstractIndex implements IndexProtocol {
           }
           this.initContext.bindIterator(rIter);
         }
-        this.hasInitOccuredOnce = true;
+        this.hasInitOccurredOnce = true;
         if (this.indexResultSetType == null) {
           this.indexResultSetType = createIndexResultSetType();
         }
@@ -1345,7 +1345,7 @@ public abstract class AbstractIndex implements IndexProtocol {
       // TODO: Create a new LocalizedString for this.
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "Exception occured while verifying a Region Entry value during a Query when the Region Entry is under update operation",
+            "Exception occurred while verifying a Region Entry value during a Query when the Region Entry is under update operation",
             e);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -1174,8 +1174,8 @@ public class CompactRangeIndex extends AbstractIndex {
     private CompiledValue modifiedIndexExpr = null;
     private ObjectType addnlProjType = null;
     private int initEntriesUpdated = 0;
-    private boolean hasInitOccuredOnce = false;
-    private boolean hasIndxUpdateOccuredOnce = false;
+    private boolean hasInitOccurredOnce = false;
+    private boolean hasIndxUpdateOccurredOnce = false;
     private ExecutionContext initContext = null;
     private int iteratorSize = -1;
 
@@ -1464,7 +1464,7 @@ public class CompactRangeIndex extends AbstractIndex {
         for (int i = 0; i < this.iteratorSize; i++) {
           CompiledIteratorDef iterDef = (CompiledIteratorDef) this.indexInitIterators.get(i);
           RuntimeIterator rIter = null;
-          if (!this.hasInitOccuredOnce) {
+          if (!this.hasInitOccurredOnce) {
             iterDef.computeDependencies(this.initContext);
             rIter = iterDef.getRuntimeIterator(this.initContext);
             this.initContext.addToIndependentRuntimeItrMapForIndexCreation(iterDef);
@@ -1474,7 +1474,7 @@ public class CompactRangeIndex extends AbstractIndex {
           }
           this.initContext.bindIterator(rIter);
         }
-        this.hasInitOccuredOnce = true;
+        this.hasInitOccurredOnce = true;
         if (this.indexResultSetType == null) {
           this.indexResultSetType = createIndexResultSetType();
         }
@@ -1725,7 +1725,7 @@ public class CompactRangeIndex extends AbstractIndex {
       // We obtain the object currently in vm, we are using this old value
       // only to detect if in place modifications have occurred
       // if the object is not in memory, obviously an in place modification could
-      // not have occured
+      // not have occurred
       this.oldValue = indexStore.getTargetObjectInVM(entry);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -1085,8 +1085,8 @@ public class HashIndex extends AbstractIndex {
     private CompiledValue modifiedIndexExpr = null;
     private ObjectType addnlProjType = null;
     private int initEntriesUpdated = 0;
-    private boolean hasInitOccuredOnce = false;
-    private boolean hasIndxUpdateOccuredOnce = false;
+    private boolean hasInitOccurredOnce = false;
+    private boolean hasIndxUpdateOccurredOnce = false;
     private ExecutionContext initContext = null;
     private int iteratorSize = -1;
 
@@ -1186,7 +1186,7 @@ public class HashIndex extends AbstractIndex {
         for (int i = 0; i < this.iteratorSize; i++) {
           CompiledIteratorDef iterDef = (CompiledIteratorDef) this.indexInitIterators.get(i);
           RuntimeIterator rIter = null;
-          if (!this.hasInitOccuredOnce) {
+          if (!this.hasInitOccurredOnce) {
             iterDef.computeDependencies(this.initContext);
             rIter = iterDef.getRuntimeIterator(this.initContext);
             this.initContext.addToIndependentRuntimeItrMapForIndexCreation(iterDef);
@@ -1196,7 +1196,7 @@ public class HashIndex extends AbstractIndex {
           }
           this.initContext.bindIterator(rIter);
         }
-        this.hasInitOccuredOnce = true;
+        this.hasInitOccurredOnce = true;
         if (this.indexResultSetType == null) {
           this.indexResultSetType = createIndexResultSetType();
         }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -329,7 +329,8 @@ public class MemoryIndexStore implements IndexStore {
               DefaultQuery.testHook.doTestHook("REMOVE_CALLED_FROM_ELEM_ARRAY");
             }
             // This could be IndexElementArray and might be changing to Set
-            // If the remove occured before changing to a set, then next time it will not be "found"
+            // If the remove occurred before changing to a set, then next time it will not be
+            // "found"
             // However the end effect would be that it was removed
             if (entries instanceof IndexElemArray) {
               if (!this.valueToEntriesMap.replace(newKey, entries, entries)) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2704,7 +2704,7 @@ public class InternalDistributedSystem extends DistributedSystem
           if (e.getMessage().contains("Rejecting the attempt of a member using an older version")) {
             logger.warn(
                 LocalizedMessage.create(
-                    LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT),
+                    LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURRED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT),
                 e);
             attemptingToReconnect = false;
             return;
@@ -2718,7 +2718,7 @@ public class InternalDistributedSystem extends DistributedSystem
         } catch (Exception ee) {
           logger.warn(
               LocalizedMessage.create(
-                  LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT),
+                  LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURRED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT),
               ee);
           attemptingToReconnect = false;
           return;
@@ -2750,20 +2750,21 @@ public class InternalDistributedSystem extends DistributedSystem
                 // this try failed. The new cache will call reconnect again
               }
             } catch (CacheXmlException e) {
-              logger.warn("Exception occured while trying to create the cache during reconnect", e);
+              logger.warn("Exception occurred while trying to create the cache during reconnect",
+                  e);
               reconnectDS.disconnect();
               reconnectDS = null;
               reconnectCancelled = true;
               break;
             } catch (CancelException ignor) {
-              logger.warn("Exception occured while trying to create the cache during reconnect",
+              logger.warn("Exception occurred while trying to create the cache during reconnect",
                   ignor);
               reconnectDS.disconnect();
               reconnectDS = null;
             } catch (Exception e) {
               logger.warn(
                   LocalizedMessage.create(
-                      LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURED_WHILE_TRYING_TO_CREATE_THE_CACHE_DURING_RECONNECT),
+                      LocalizedStrings.InternalDistributedSystem_EXCEPTION_OCCURRED_WHILE_TRYING_TO_CREATE_THE_CACHE_DURING_RECONNECT),
                   e);
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1255,7 +1255,7 @@ public class InternalLocator extends Locator implements ConnectListener {
     try {
       response = statusFuture.get(5, TimeUnit.SECONDS);
     } catch (Exception e) {
-      logger.info("Exception occured while fetching the status {}", CliUtil.stackTraceAsString(e));
+      logger.info("Exception occurred while fetching the status {}", CliUtil.stackTraceAsString(e));
       response = new SharedConfigurationStatusResponse();
       response.setStatus(SharedConfigurationStatus.UNDETERMINED);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -1591,7 +1591,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                 if (txEvent != null) {
                   txEvent.addDestroy(owner, re, re.getKey(), aCallbackArgument);
                 }
-                boolean clearOccured = false;
+                boolean clearOccurred = false;
                 try {
                   processAndGenerateTXVersionTag(owner, cbEvent, re, txEntryState);
                   if (inTokenMode) {
@@ -1618,10 +1618,10 @@ public abstract class AbstractRegionMap implements RegionMap {
                   EntryLogger.logTXDestroy(_getOwnerObject(), key);
                   owner.updateSizeOnRemove(key, oldSize);
                 } catch (RegionClearedException rce) {
-                  clearOccured = true;
+                  clearOccurred = true;
                 }
                 owner.txApplyDestroyPart2(re, re.getKey(), inTokenMode,
-                    clearOccured /* Clear Conflciting with the operation */);
+                    clearOccurred /* Clear Conflciting with the operation */);
                 if (invokeCallbacks) {
                   switchEventOwnerAndOriginRemote(cbEvent, hasRemoteOrigin);
                   if (pendingCallbacks == null) {
@@ -1632,7 +1632,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     cbEventInPending = true;
                   }
                 }
-                if (!clearOccured) {
+                if (!clearOccurred) {
                   lruEntryDestroy(re);
                 }
                 if (owner.concurrencyChecksEnabled && txEntryState != null && cbEvent != null) {
@@ -1856,7 +1856,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
     boolean didInvalidate = false;
     RegionEntry invalidatedRe = null;
-    boolean clearOccured = false;
+    boolean clearOccurred = false;
     DiskRegion dr = owner.getDiskRegion();
     boolean ownerIsInitialized = owner.isInitialized();
     try {
@@ -1966,11 +1966,11 @@ public abstract class AbstractRegionMap implements RegionMap {
                           // generate versionTag for the event
                           EntryLogger.logInvalidate(event);
                           owner.recordEvent(event);
-                          clearOccured = true;
+                          clearOccurred = true;
                         }
                         owner.basicInvalidatePart2(oldRe, event,
-                            clearOccured /* conflict with clear */, invokeCallbacks);
-                        if (!clearOccured) {
+                            clearOccurred /* conflict with clear */, invokeCallbacks);
+                        if (!clearOccurred) {
                           if (isCreate) {
                             lruEntryCreate(oldRe);
                           } else {
@@ -2011,11 +2011,11 @@ public abstract class AbstractRegionMap implements RegionMap {
                     // TODO: deltaGII: do we even need RegionClearedException?
                     // generate versionTag for the event
                     owner.recordEvent(event);
-                    clearOccured = true;
+                    clearOccurred = true;
                   }
-                  owner.basicInvalidatePart2(newRe, event, clearOccured /* conflict with clear */,
+                  owner.basicInvalidatePart2(newRe, event, clearOccurred /* conflict with clear */,
                       invokeCallbacks);
-                  if (!clearOccured) {
+                  if (!clearOccurred) {
                     lruEntryCreate(newRe);
                     incEntryCount(1);
                   }
@@ -2183,7 +2183,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                         // generate versionTag for the event
                         EntryLogger.logInvalidate(event);
                         _getOwner().recordEvent(event);
-                        clearOccured = true;
+                        clearOccurred = true;
                       } catch (ConcurrentCacheModificationException ccme) {
                         VersionTag tag = event.getVersionTag();
                         if (tag != null && tag.isTimeStampUpdated()) {
@@ -2192,9 +2192,9 @@ public abstract class AbstractRegionMap implements RegionMap {
                         }
                         throw ccme;
                       }
-                      owner.basicInvalidatePart2(re, event, clearOccured /* conflict with clear */,
+                      owner.basicInvalidatePart2(re, event, clearOccurred /* conflict with clear */,
                           invokeCallbacks);
-                      if (!clearOccured) {
+                      if (!clearOccurred) {
                         if (oldWasTombstone) {
                           lruEntryCreate(re);
                         } else {
@@ -2228,7 +2228,7 @@ public abstract class AbstractRegionMap implements RegionMap {
           if (invalidatedRe != null) {
             owner.basicInvalidatePart3(invalidatedRe, event, invokeCallbacks);
           }
-          if (didInvalidate && !clearOccured) {
+          if (didInvalidate && !clearOccurred) {
             try {
               lruUpdateCallback();
             } catch (DiskAccessException dae) {
@@ -2397,7 +2397,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     }
                     oldRe.setValueResultOfSearch(false);
                     processAndGenerateTXVersionTag(owner, cbEvent, oldRe, txEntryState);
-                    boolean clearOccured = false;
+                    boolean clearOccurred = false;
                     try {
                       oldRe.setValue(owner, oldRe.prepareValueForCache(owner, newValue, true));
                       EntryLogger.logTXInvalidate(_getOwnerObject(), key);
@@ -2406,10 +2406,10 @@ public abstract class AbstractRegionMap implements RegionMap {
                         owner.unscheduleTombstone(oldRe);
                       }
                     } catch (RegionClearedException rce) {
-                      clearOccured = true;
+                      clearOccurred = true;
                     }
                     owner.txApplyInvalidatePart2(oldRe, oldRe.getKey(), didDestroy, true,
-                        clearOccured);
+                        clearOccurred);
                     // didInvalidate = true;
                     if (invokeCallbacks) {
                       switchEventOwnerAndOriginRemote(cbEvent, hasRemoteOrigin);
@@ -2421,7 +2421,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                         cbEventInPending = true;
                       }
                     }
-                    if (!clearOccured) {
+                    if (!clearOccurred) {
                       lruEntryUpdate(oldRe);
                     }
                     if (shouldPerformConcurrencyChecks(owner, cbEvent) && txEntryState != null) {
@@ -2445,7 +2445,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                 cbEvent.setRegionEntry(newRe);
                 txRemoveOldIndexEntry(Operation.INVALIDATE, newRe);
                 newRe.setValueResultOfSearch(false);
-                boolean clearOccured = false;
+                boolean clearOccurred = false;
                 try {
                   processAndGenerateTXVersionTag(owner, cbEvent, newRe, txEntryState);
                   newRe.setValue(owner, newRe.prepareValueForCache(owner, newValue, true));
@@ -2453,9 +2453,10 @@ public abstract class AbstractRegionMap implements RegionMap {
                   owner.updateSizeOnCreate(newRe.getKey(), 0);// we are putting in a new invalidated
                                                               // entry
                 } catch (RegionClearedException rce) {
-                  clearOccured = true;
+                  clearOccurred = true;
                 }
-                owner.txApplyInvalidatePart2(newRe, newRe.getKey(), didDestroy, true, clearOccured);
+                owner.txApplyInvalidatePart2(newRe, newRe.getKey(), didDestroy, true,
+                    clearOccurred);
 
                 if (invokeCallbacks) {
                   switchEventOwnerAndOriginRemote(cbEvent, hasRemoteOrigin);
@@ -2468,7 +2469,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                   }
                 }
                 opCompleted = true;
-                if (!clearOccured) {
+                if (!clearOccurred) {
                   lruEntryCreate(newRe);
                   incEntryCount(1);
                 }
@@ -2516,7 +2517,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                 }
                 re.setValueResultOfSearch(false);
                 processAndGenerateTXVersionTag(owner, cbEvent, re, txEntryState);
-                boolean clearOccured = false;
+                boolean clearOccurred = false;
                 try {
                   re.setValue(owner, re.prepareValueForCache(owner, newValue, true));
                   EntryLogger.logTXInvalidate(_getOwnerObject(), key);
@@ -2525,9 +2526,9 @@ public abstract class AbstractRegionMap implements RegionMap {
                   }
                   owner.updateSizeOnPut(key, oldSize, 0);
                 } catch (RegionClearedException rce) {
-                  clearOccured = true;
+                  clearOccurred = true;
                 }
-                owner.txApplyInvalidatePart2(re, re.getKey(), didDestroy, true, clearOccured);
+                owner.txApplyInvalidatePart2(re, re.getKey(), didDestroy, true, clearOccurred);
                 // didInvalidate = true;
                 if (invokeCallbacks) {
                   switchEventOwnerAndOriginRemote(cbEvent, hasRemoteOrigin);
@@ -2539,7 +2540,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     cbEventInPending = true;
                   }
                 }
-                if (!clearOccured) {
+                if (!clearOccurred) {
                   lruEntryUpdate(re);
                 }
                 if (shouldPerformConcurrencyChecks(owner, cbEvent) && txEntryState != null) {
@@ -2645,7 +2646,7 @@ public abstract class AbstractRegionMap implements RegionMap {
       boolean requireOldValue, final boolean overwriteDestroyed)
       throws CacheWriterException, TimeoutException {
     final LocalRegion owner = _getOwner();
-    boolean clearOccured = false;
+    boolean clearOccurred = false;
     if (owner == null) {
       // "fix" for bug 32440
       Assert.assertTrue(false, "The owner for RegionMap " + this + " is null for event " + event);
@@ -2784,7 +2785,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     owner.recordEvent(event);
                     eventRecorded = true;
                   } catch (RegionClearedException rce) {
-                    clearOccured = true;
+                    clearOccurred = true;
                     owner.recordEvent(event);
                   } catch (ConcurrentCacheModificationException ccme) {
                     VersionTag tag = event.getVersionTag();
@@ -2797,10 +2798,10 @@ public abstract class AbstractRegionMap implements RegionMap {
                   if (uninitialized) {
                     event.inhibitCacheListenerNotification(true);
                   }
-                  updateLru(clearOccured, re, event);
+                  updateLru(clearOccurred, re, event);
 
                   lastModifiedTime = owner.basicPutPart2(event, re, !uninitialized,
-                      lastModifiedTime, clearOccured);
+                      lastModifiedTime, clearOccurred);
                 } finally {
                   notifyIndex(re, false);
                 }
@@ -2837,7 +2838,7 @@ public abstract class AbstractRegionMap implements RegionMap {
           } finally {
             // bug 32589, post update may throw an exception if exception occurs
             // for any recipients
-            if (!clearOccured) {
+            if (!clearOccurred) {
               try {
                 lruUpdateCallback();
               } catch (DiskAccessException dae) {
@@ -2958,8 +2959,8 @@ public abstract class AbstractRegionMap implements RegionMap {
     updateSize(event, oldSize, true/* isUpdate */, wasTombstone);
   }
 
-  private void updateLru(boolean clearOccured, RegionEntry re, EntryEventImpl event) {
-    if (!clearOccured) {
+  private void updateLru(boolean clearOccurred, RegionEntry re, EntryEventImpl event) {
+    if (!clearOccurred) {
       if (event.getOperation().isCreate()) {
         lruEntryCreate(re);
       } else {
@@ -3136,7 +3137,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     cbEvent.setOldValue(re.getValueInVM(owner)); // OFFHEAP eei
                   }
 
-                  boolean clearOccured = false;
+                  boolean clearOccurred = false;
                   // Set RegionEntry updateInProgress
                   if (owner.indexMaintenanceSynchronous) {
                     re.setUpdateInProgress(true);
@@ -3169,14 +3170,14 @@ public abstract class AbstractRegionMap implements RegionMap {
                         }
                       }
                     } catch (RegionClearedException rce) {
-                      clearOccured = true;
+                      clearOccurred = true;
                     }
                     {
                       long lastMod = owner.cacheTimeMillis();
                       EntryLogger.logTXPut(_getOwnerObject(), key, nv);
                       re.updateStatsForPut(lastMod, lastMod);
                       owner.txApplyPutPart2(re, re.getKey(), newValue, lastMod, false, didDestroy,
-                          clearOccured);
+                          clearOccurred);
                     }
                   } finally {
                     if (re != null && owner.indexMaintenanceSynchronous) {
@@ -3194,7 +3195,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                       cbEventInPending = true;
                     }
                   }
-                  if (!clearOccured) {
+                  if (!clearOccurred) {
                     lruEntryUpdate(re);
                   }
                 }
@@ -3231,7 +3232,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                     cbEvent.setRegionEntry(oldRe);
                     cbEvent.setOldValue(oldRe.getValueInVM(owner)); // OFFHEAP eei
                   }
-                  boolean clearOccured = false;
+                  boolean clearOccurred = false;
                   // Set RegionEntry updateInProgress
                   if (owner.indexMaintenanceSynchronous) {
                     oldRe.setUpdateInProgress(true);
@@ -3269,14 +3270,14 @@ public abstract class AbstractRegionMap implements RegionMap {
                         }
                       }
                     } catch (RegionClearedException rce) {
-                      clearOccured = true;
+                      clearOccurred = true;
                     }
                     {
                       long lastMod = owner.cacheTimeMillis();
                       EntryLogger.logTXPut(_getOwnerObject(), key, nv);
                       oldRe.updateStatsForPut(lastMod, lastMod);
                       owner.txApplyPutPart2(oldRe, oldRe.getKey(), newValue, lastMod, false,
-                          didDestroy, clearOccured);
+                          didDestroy, clearOccurred);
                     }
                   } finally {
                     if (oldRe != null && owner.indexMaintenanceSynchronous) {
@@ -3298,7 +3299,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                       cbEventInPending = true;
                     }
                   }
-                  if (!clearOccured) {
+                  if (!clearOccurred) {
                     lruEntryUpdate(oldRe);
                   }
                 }
@@ -3310,7 +3311,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                 cbEvent.setRegionEntry(newRe);
                 cbEvent.setOldValue(null);
               }
-              boolean clearOccured = false;
+              boolean clearOccurred = false;
               // Set RegionEntry updateInProgress
               if (owner.indexMaintenanceSynchronous) {
                 newRe.setUpdateInProgress(true);
@@ -3335,14 +3336,14 @@ public abstract class AbstractRegionMap implements RegionMap {
                   owner.updateSizeOnCreate(newRe.getKey(),
                       owner.calculateRegionEntryValueSize(newRe));
                 } catch (RegionClearedException rce) {
-                  clearOccured = true;
+                  clearOccurred = true;
                 }
                 {
                   long lastMod = owner.cacheTimeMillis();
                   EntryLogger.logTXPut(_getOwnerObject(), key, nv);
                   newRe.updateStatsForPut(lastMod, lastMod);
                   owner.txApplyPutPart2(newRe, newRe.getKey(), newValue, lastMod, true, didDestroy,
-                      clearOccured);
+                      clearOccurred);
                 }
               } finally {
                 if (newRe != null && owner.indexMaintenanceSynchronous) {
@@ -3362,7 +3363,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                   cbEventInPending = true;
                 }
               }
-              if (!clearOccured) {
+              if (!clearOccurred) {
                 lruEntryCreate(newRe);
                 incEntryCount(1);
               }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -3409,7 +3409,7 @@ public class DiskStoreImpl implements DiskStore {
 
     // log the error
     final StringId sid =
-        LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_DISKSTORE_0_THE_CACHE_WILL_BE_CLOSED;
+        LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_DISKSTORE_0_THE_CACHE_WILL_BE_CLOSED;
     logger.error(LocalizedMessage.create(sid, DiskStoreImpl.this.getName()), dae);
 
     final ThreadGroup exceptionHandlingGroup =
@@ -3424,7 +3424,7 @@ public class DiskStoreImpl implements DiskStore {
 
         } catch (Exception e) {
           logger.error(LocalizedMessage.create(
-              LocalizedStrings.LocalRegion_AN_EXCEPTION_OCCURED_WHILE_CLOSING_THE_CACHE), e);
+              LocalizedStrings.LocalRegion_AN_EXCEPTION_OCCURRED_WHILE_CLOSING_THE_CACHE), e);
         }
       }
     };

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -3900,20 +3900,20 @@ public class DistributedRegion extends LocalRegion implements CacheDistributionA
       stats.endFunctionExecution(start, function.hasResult());
     } catch (FunctionException functionException) {
       if (logger.isDebugEnabled()) {
-        logger.debug("FunctionException occured on remote node  while executing Function: {}",
+        logger.debug("FunctionException occurred on remote node  while executing Function: {}",
             function.getId(), functionException);
       }
       stats.endFunctionExecutionWithException(function.hasResult());
       throw functionException;
     } catch (CacheClosedException cacheClosedexception) {
       if (logger.isDebugEnabled()) {
-        logger.debug("CacheClosedException occured on remote node  while executing Function: {}",
+        logger.debug("CacheClosedException occurred on remote node  while executing Function: {}",
             function.getId(), cacheClosedexception);
       }
       throw cacheClosedexception;
     } catch (Exception exception) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Exception occured on remote node  while executing Function: {}",
+        logger.debug("Exception occurred on remote node  while executing Function: {}",
             function.getId(), exception);
       }
       stats.endFunctionExecutionWithException(function.hasResult());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
@@ -178,7 +178,7 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
       // now, so don't let this thread continue.
       throw err;
     } catch (Throwable t) {
-      logger.debug("{} exception occured while processing message: {}", this, t.getMessage(), t);
+      logger.debug("{} exception occurred while processing message: {}", this, t.getMessage(), t);
       // Whenever you catch Error or Throwable, you must also
       // catch VirtualMachineError (see above). However, there is
       // _still_ a possibility that you are dealing with a cascading

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -1031,7 +1031,7 @@ public class GemFireCacheImpl
       ClusterConfigurationLoader.deployJarsReceivedFromClusterConfiguration(this, response);
     } catch (IOException | ClassNotFoundException e) {
       throw new GemFireConfigException(
-          LocalizedStrings.GemFireCache_EXCEPTION_OCCURED_WHILE_DEPLOYING_JARS_FROM_SHARED_CONDFIGURATION
+          LocalizedStrings.GemFireCache_EXCEPTION_OCCURRED_WHILE_DEPLOYING_JARS_FROM_SHARED_CONDFIGURATION
               .toLocalizedString(),
           e);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -6866,7 +6866,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     // log the error
     StringId sid =
-        LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_CACHE_WILL_BE_CLOSED;
+        LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_CACHE_WILL_BE_CLOSED;
     logger.error(LocalizedMessage.create(sid, this.fullPath), dae);
 
     // forward the error to the disk store
@@ -9447,7 +9447,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           // Asif : Create an anonymous inner class of CacheRuntimeException so
           // that a RuntimeException is thrown
           throw new CacheRuntimeException(
-              LocalizedStrings.LocalRegion_EXCEPTION_OCCURED_WHILE_RE_CREATING_INDEX_DATA_ON_CLEARED_REGION
+              LocalizedStrings.LocalRegion_EXCEPTION_OCCURRED_WHILE_RE_CREATING_INDEX_DATA_ON_CLEARED_REGION
                   .toLocalizedString(),
               qe) {
             private static final long serialVersionUID = 0L;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/MemberFunctionStreamingMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/MemberFunctionStreamingMessage.java
@@ -197,7 +197,7 @@ public class MemberFunctionStreamingMessage extends DistributionMessage
       stats.endFunctionExecution(start, this.functionObject.hasResult());
     } catch (FunctionException functionException) {
       if (logger.isDebugEnabled()) {
-        logger.debug("FunctionException occured on remote member while executing Function: {}",
+        logger.debug("FunctionException occurred on remote member while executing Function: {}",
             this.functionObject.getId(), functionException);
       }
       stats.endFunctionExecutionWithException(this.functionObject.hasResult());
@@ -214,7 +214,7 @@ public class MemberFunctionStreamingMessage extends DistributionMessage
       replyWithException(dm, rex);
     } catch (Exception exception) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Exception occured on remote member while executing Function: {}",
+        logger.debug("Exception occurred on remote member while executing Function: {}",
             this.functionObject.getId(), exception);
       }
       stats.endFunctionExecutionWithException(this.functionObject.hasResult());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -3561,7 +3561,7 @@ public final class Oplog implements CompactableOplog, Flushable {
       getOplogSet().getChild().create(region, entry, value, async);
     } else {
       DiskId did = entry.getDiskId();
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       byte prevUsrBit = did.getUserBits();
       int len = did.getValueLength();
       try {
@@ -3580,20 +3580,20 @@ public final class Oplog implements CompactableOplog, Flushable {
         }
         basicCreate(region.getDiskRegion(), entry, value, userBits, async);
       } catch (IOException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         region.getCancelCriterion().checkCancelInProgress(ex);
         throw new DiskAccessException(LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0
             .toLocalizedString(this.diskFile.getPath()), ex, region.getFullPath());
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
-        exceptionOccured = true;
+        exceptionOccurred = true;
         region.getCancelCriterion().checkCancelInProgress(ie);
         throw new DiskAccessException(
             LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0_DUE_TO_FAILURE_IN_ACQUIRING_READ_LOCK_FOR_ASYNCH_WRITING
                 .toLocalizedString(this.diskFile.getPath()),
             ie, region.getFullPath());
       } finally {
-        if (exceptionOccured) {
+        if (exceptionOccurred) {
           did.setValueLength(len);
           did.setUserBits(prevUsrBit);
         }
@@ -4487,7 +4487,7 @@ public final class Oplog implements CompactableOplog, Flushable {
       getOplogSet().getChild().modify(region, entry, value, async);
     } else {
       DiskId did = entry.getDiskId();
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       byte prevUsrBit = did.getUserBits();
       int len = did.getValueLength();
       try {
@@ -4504,20 +4504,20 @@ public final class Oplog implements CompactableOplog, Flushable {
         }
         basicModify(region.getDiskRegion(), entry, value, userBits, async, false);
       } catch (IOException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         region.getCancelCriterion().checkCancelInProgress(ex);
         throw new DiskAccessException(LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0
             .toLocalizedString(this.diskFile.getPath()), ex, region.getFullPath());
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
-        exceptionOccured = true;
+        exceptionOccurred = true;
         region.getCancelCriterion().checkCancelInProgress(ie);
         throw new DiskAccessException(
             LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0_DUE_TO_FAILURE_IN_ACQUIRING_READ_LOCK_FOR_ASYNCH_WRITING
                 .toLocalizedString(this.diskFile.getPath()),
             ie, region.getFullPath());
       } finally {
-        if (exceptionOccured) {
+        if (exceptionOccurred) {
           did.setValueLength(len);
           did.setUserBits(prevUsrBit);
         }
@@ -4606,7 +4606,7 @@ public final class Oplog implements CompactableOplog, Flushable {
       getOplogSet().getChild().copyForwardModifyForCompact(dr, entry, wrapper);
     } else {
       DiskId did = entry.getDiskId();
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       int len = did.getValueLength();
       try {
         // TODO: compaction needs to get version?
@@ -4622,12 +4622,12 @@ public final class Oplog implements CompactableOplog, Flushable {
         // will be grouped. This is not a true async write; just a grouped one.
         basicModify(dr, entry, vw, userBits, true, true);
       } catch (IOException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         getParent().getCancelCriterion().checkCancelInProgress(ex);
         throw new DiskAccessException(LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0
             .toLocalizedString(this.diskFile.getPath()), ex, getParent());
       } catch (InterruptedException ie) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         Thread.currentThread().interrupt();
         getParent().getCancelCriterion().checkCancelInProgress(ie);
         throw new DiskAccessException(
@@ -4638,7 +4638,7 @@ public final class Oplog implements CompactableOplog, Flushable {
         if (wrapper.getOffHeapData() != null) {
           wrapper.setOffHeapData(null, (byte) 0);
         }
-        if (exceptionOccured) {
+        if (exceptionOccurred) {
           did.setValueLength(len);
         }
       }
@@ -4964,26 +4964,26 @@ public final class Oplog implements CompactableOplog, Flushable {
       getOplogSet().getChild().remove(region, entry, async, isClear);
     } else {
       DiskId did = entry.getDiskId();
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       byte prevUsrBit = did.getUserBits();
       int len = did.getValueLength();
       try {
         basicRemove(dr, entry, async, isClear);
       } catch (IOException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         getParent().getCancelCriterion().checkCancelInProgress(ex);
         throw new DiskAccessException(LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0
             .toLocalizedString(this.diskFile.getPath()), ex, dr.getName());
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
         region.getCancelCriterion().checkCancelInProgress(ie);
-        exceptionOccured = true;
+        exceptionOccurred = true;
         throw new DiskAccessException(
             LocalizedStrings.Oplog_FAILED_WRITING_KEY_TO_0_DUE_TO_FAILURE_IN_ACQUIRING_READ_LOCK_FOR_ASYNCH_WRITING
                 .toLocalizedString(this.diskFile.getPath()),
             ie, dr.getName());
       } finally {
-        if (exceptionOccured) {
+        if (exceptionOccurred) {
           did.setValueLength(len);
           did.setUserBits(prevUsrBit);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRQueryProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRQueryProcessor.java
@@ -584,7 +584,7 @@ public class PRQueryProcessor {
         return _ex;
       }
 
-      public boolean exceptionOccured() {
+      public boolean exceptionOccurred() {
         return _ex != null;
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -816,7 +816,7 @@ public class PartitionedRegion extends LocalRegion
           Object[] prms =
               new Object[] {this.getFullPath(), colocatedWith, config.getColocatedWith()};
           DiskAccessException dae = new DiskAccessException(
-              LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_REGION_WILL_BE_CLOSED
+              LocalizedStrings.LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_REGION_WILL_BE_CLOSED
                   .toLocalizedString(this.getFullPath()),
               null, dsi);
           dsi.handleDiskAccessException(dae);
@@ -1794,7 +1794,7 @@ public class PartitionedRegion extends LocalRegion
         throw e;
       } catch (QueryException qe) {
         throw new QueryInvocationTargetException(
-            LocalizedStrings.PartitionedRegion_UNEXPECTED_QUERY_EXCEPTION_OCCURED_DURING_QUERY_EXECUTION_0
+            LocalizedStrings.PartitionedRegion_UNEXPECTED_QUERY_EXCEPTION_OCCURRED_DURING_QUERY_EXECUTION_0
                 .toLocalizedString(qe.getMessage()),
             qe);
       } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -2957,7 +2957,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
       stats.endFunctionExecution(start, function.hasResult());
     } catch (FunctionException functionException) {
       if (logger.isDebugEnabled()) {
-        logger.debug("FunctionException occured on remote node while executing Function: {}",
+        logger.debug("FunctionException occurred on remote node while executing Function: {}",
             function.getId(), functionException);
       }
       stats.endFunctionExecutionWithException(function.hasResult());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PlaceHolderDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PlaceHolderDiskRegion.java
@@ -174,7 +174,7 @@ public class PlaceHolderDiskRegion extends AbstractDiskRegion implements DiskRec
 
   public void handleDiskAccessException(DiskAccessException dae) {
     getDiskStore().getCache().getLoggerI18n().error(
-        LocalizedStrings.PlaceHolderDiskRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_RECOVERING_FROM_DISK,
+        LocalizedStrings.PlaceHolderDiskRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_RECOVERING_FROM_DISK,
         getName(), dae);
 
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
@@ -161,7 +161,7 @@ final class ProxyRegionMap implements RegionMap {
     }
     owner.recordEvent(event);
     this.owner.basicDestroyPart2(markerEntry, event, inTokenMode,
-        false /* Clear conflict occured */, duringRI, true);
+        false /* Clear conflict occurred */, duringRI, true);
     this.owner.basicDestroyPart3(markerEntry, event, inTokenMode, duringRI, true, expectedOldValue);
     return true;
   }
@@ -246,7 +246,7 @@ final class ProxyRegionMap implements RegionMap {
       ClientProxyMembershipID bridgeContext, boolean isOriginRemote, TXEntryState txEntryState,
       VersionTag versionTag, long tailKey) {
     this.owner.txApplyDestroyPart2(markerEntry, key, inTokenMode,
-        false /* Clear conflict occured */);
+        false /* Clear conflict occurred */);
     if (!inTokenMode) {
       if (txEvent != null) {
         txEvent.addDestroy(this.owner, markerEntry, key, aCallbackArgument);
@@ -281,7 +281,7 @@ final class ProxyRegionMap implements RegionMap {
       ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
       long tailKey) {
     this.owner.txApplyInvalidatePart2(markerEntry, key, didDestroy, true,
-        false /* Clear conflic occured */);
+        false /* Clear conflic occurred */);
     if (this.owner.isInitialized()) {
       if (txEvent != null) {
         txEvent.addInvalidate(this.owner, markerEntry, key, newValue, aCallbackArgument);
@@ -319,7 +319,7 @@ final class ProxyRegionMap implements RegionMap {
     Operation putOp = p_putOp.getCorrespondingCreateOp();
     long lastMod = owner.cacheTimeMillis();
     this.owner.txApplyPutPart2(markerEntry, key, newValue, lastMod, true, didDestroy,
-        false /* Clear conflict occured */);
+        false /* Clear conflict occurred */);
     if (this.owner.isInitialized()) {
       if (txEvent != null) {
         txEvent.addPut(putOp, this.owner, markerEntry, key, newValue, aCallbackArgument);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateEntryVersionOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateEntryVersionOperation.java
@@ -135,7 +135,7 @@ public class UpdateEntryVersionOperation extends DistributedCacheOperation {
       } catch (ConcurrentCacheModificationException e) {
         if (logger.isTraceEnabled()) {
           logger.trace(
-              "UpdateEntryVersionMessage.operationOnRegion; ConcurrentCacheModificationException occured for key={}",
+              "UpdateEntryVersionMessage.operationOnRegion; ConcurrentCacheModificationException occurred for key={}",
               ev.getKey());
         }
         return true; // concurrent modification problems are not reported to senders

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -710,7 +710,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
         // is still usable:
         SystemFailure.checkFailure();
         this.cache.getLoggerI18n()
-            .error(LocalizedStrings.MemoryMonitor_EXCEPTION_OCCURED_WHEN_NOTIFYING_LISTENERS, t);
+            .error(LocalizedStrings.MemoryMonitor_EXCEPTION_OCCURRED_WHEN_NOTIFYING_LISTENERS, t);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/OffHeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/OffHeapMemoryMonitor.java
@@ -485,7 +485,7 @@ public class OffHeapMemoryMonitor implements MemoryMonitor, MemoryUsageListener 
         // ignore
       } catch (Throwable t) {
         logger.error(LocalizedMessage
-            .create(LocalizedStrings.MemoryMonitor_EXCEPTION_OCCURED_WHEN_NOTIFYING_LISTENERS), t);
+            .create(LocalizedStrings.MemoryMonitor_EXCEPTION_OCCURRED_WHEN_NOTIFYING_LISTENERS), t);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AbstractExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AbstractExecution.java
@@ -568,7 +568,7 @@ public abstract class AbstractExecution implements InternalExecution {
     FunctionStats stats = FunctionStats.getFunctionStats(fn.getId(), dm.getSystem());
 
     if (logger.isDebugEnabled()) {
-      logger.debug("Exception occured on local node while executing Function: {}", fn.getId(),
+      logger.debug("Exception occurred on local node while executing Function: {}", fn.getId(),
           functionException);
     }
     stats.endFunctionExecutionWithException(fn.hasResult());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionServiceStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionServiceStats.java
@@ -73,7 +73,7 @@ public class FunctionServiceStats {
       "functionExecutionsHasResultRunning";
 
   /**
-   * Total number of Exceptions Occuredwhile executing function Name of the functionExecution
+   * Total number of Exceptions Occurredwhile executing function Name of the functionExecution
    * exceptions statistic
    */
   private static final String FUNCTION_EXECUTION_EXCEPTIONS = "functionExecutionsExceptions";
@@ -148,7 +148,7 @@ public class FunctionServiceStats {
                 "A gauge indicating the number of currently active execute() calls for functions where hasResult() returns true.",
                 "operations"),
             f.createIntCounter(FUNCTION_EXECUTION_EXCEPTIONS,
-                "Total number of Exceptions Occured while executing function", "operations"),
+                "Total number of Exceptions Occurred while executing function", "operations"),
 
         });
     // Initialize id fields
@@ -318,7 +318,7 @@ public class FunctionServiceStats {
   }
 
   /**
-   * Returns the current value of the "Total number of Exceptions Occured while executing function"
+   * Returns the current value of the "Total number of Exceptions Occurred while executing function"
    * stat.
    * 
    * @return the current value of the "functionExecutionHasResultRunning" stat

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionStats.java
@@ -79,7 +79,7 @@ public class FunctionStats {
   private static final String RESULTS_RECEIVED = "resultsReceived";
 
   /**
-   * Total number of Exceptions Occured while executing function Name of the functionExecution
+   * Total number of Exceptions Occurred while executing function Name of the functionExecution
    * exceptions statistic
    */
   private static final String FUNCTION_EXECUTION_EXCEPTIONS = "functionExecutionsExceptions";
@@ -168,7 +168,7 @@ public class FunctionStats {
                 "operations"),
 
             f.createIntCounter(FUNCTION_EXECUTION_EXCEPTIONS,
-                "Total number of Exceptions Occured while executing function", "operations"),
+                "Total number of Exceptions Occurred while executing function", "operations"),
 
         // f
         // .createLongCounter(
@@ -359,7 +359,7 @@ public class FunctionStats {
   }
 
   /**
-   * Returns the current value of the "Total number of Exceptions Occured while executing function"
+   * Returns the current value of the "Total number of Exceptions Occurred while executing function"
    * stat.
    * 
    * @return the current value of the "functionExecutionHasResultRunning" stat

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender.java
@@ -308,7 +308,7 @@ public class ServerToClientFunctionResultSender implements ResultSender {
             sendHeader();
           }
           String exceptionMessage = exception.getMessage() != null ? exception.getMessage()
-              : "Exception occured during function execution";
+              : "Exception occurred during function execution";
           logger.warn(LocalizedMessage.create(
               LocalizedStrings.ExecuteRegionFunction_EXCEPTION_ON_SERVER_WHILE_EXECUTIONG_FUNCTION_0,
               this.fn), exception);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -1353,7 +1353,7 @@ public class HARegionQueue implements RegionQueue {
           // ignore and log
           logger.error(
               LocalizedMessage.create(
-                  LocalizedStrings.HARegionQueue_EXCEPTION_OCCURED_WHILE_TRYING_TO_SET_THE_LAST_DISPATCHED_ID),
+                  LocalizedStrings.HARegionQueue_EXCEPTION_OCCURRED_WHILE_TRYING_TO_SET_THE_LAST_DISPATCHED_ID),
               e);
         }
       }
@@ -2807,7 +2807,7 @@ public class HARegionQueue implements RegionQueue {
               }
               logger.warn(
                   LocalizedMessage.create(
-                      LocalizedStrings.HARegionQueue_INTERRUPTEDEXCEPTION_OCCURED_IN_QUEUEREMOVALTHREAD_WHILE_WAITING),
+                      LocalizedStrings.HARegionQueue_INTERRUPTEDEXCEPTION_OCCURRED_IN_QUEUEREMOVALTHREAD_WHILE_WAITING),
                   e);
               break; // desperation...we must be trying to shut down...?
             } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -2477,7 +2477,7 @@ public class CacheClientProxy implements ClientSession {
      */
     @Override
     public void run() {
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       this._isStopped = false;
 
       if (logger.isDebugEnabled()) {
@@ -2597,7 +2597,7 @@ public class CacheClientProxy implements ClientSession {
               pauseOrUnregisterProxy(e);
             } // _isStopped
           } // synchronized
-          exceptionOccured = true;
+          exceptionOccurred = true;
         } // IOException
         catch (InterruptedException e) {
           // If the thread is paused, ignore the InterruptedException and
@@ -2621,16 +2621,16 @@ public class CacheClientProxy implements ClientSession {
           if (logger.isDebugEnabled()) {
             logger.debug("{}: shutting down due to cancellation", this);
           }
-          exceptionOccured = true; // message queue is defunct, don't try to read it.
+          exceptionOccurred = true; // message queue is defunct, don't try to read it.
           break;
         } catch (RegionDestroyedException e) {
           if (logger.isDebugEnabled()) {
             logger.debug("{}: shutting down due to loss of message queue", this);
           }
-          exceptionOccured = true; // message queue is defunct, don't try to read it.
+          exceptionOccurred = true; // message queue is defunct, don't try to read it.
           break;
         } catch (Exception e) {
-          // An exception occured while processing a message. Since it
+          // An exception occurred while processing a message. Since it
           // is not an IOException, the client may still be alive, so
           // continue processing.
           if (!isStopped()) {
@@ -2644,7 +2644,7 @@ public class CacheClientProxy implements ClientSession {
 
       // Processing gets here if isStopped=true. What is this code below doing?
       List list = null;
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         try {
           // Clear the interrupt status if any,
           Thread.interrupted();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
@@ -859,7 +859,7 @@ public class GatewayReceiverCommand extends BaseCommand {
     // errorMsg.addStringPart(be.toString());
     errorMsg.send(servConn);
     for (Exception e : exceptions) {
-      ((GatewayReceiverStats) servConn.getCacheServerStats()).incExceptionsOccured();
+      ((GatewayReceiverStats) servConn.getCacheServerStats()).incExceptionsOccurred();
     }
     for (Exception be : exceptions) {
       if (logger.isWarnEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -880,7 +880,7 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
               filter.afterAcknowledgement((GatewaySenderEventImpl) o);
             } catch (Exception e) {
               logger.fatal(LocalizedMessage.create(
-                  LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+                  LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
                   new Object[] {filter.toString(), o}), e);
             }
           }
@@ -965,7 +965,7 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
             filter.afterAcknowledgement(event);
           } catch (Exception e) {
             logger.fatal(LocalizedMessage.create(
-                LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+                LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
                 new Object[] {filter.toString(), event}), e);
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -54,7 +54,7 @@ public class GatewayReceiverStats extends CacheServerStats {
   private static final String UNKNOWN_OPERATIONS_RECEIVED = "unknowsOperationsReceived";
 
   /** Name of the unprocessed events added by primary statistic */
-  private static final String EXCEPTIONS_OCCURED = "exceptionsOccured";
+  private static final String EXCEPTIONS_OCCURRED = "exceptionsOccurred";
 
   // /** Id of the events queued statistic */
   // private int failoverBatchesReceivedId;
@@ -84,7 +84,7 @@ public class GatewayReceiverStats extends CacheServerStats {
   private int unknowsOperationsReceivedId;
 
   /** Id of the unprocessed events added by primary statistic */
-  private int exceptionsOccuredId;
+  private int exceptionsOccurredId;
 
   // ///////////////////// Constructors ///////////////////////
 
@@ -109,8 +109,8 @@ public class GatewayReceiverStats extends CacheServerStats {
             "total number of destroy operations received by this GatewayReceiver", "operations"),
         f.createIntCounter(UNKNOWN_OPERATIONS_RECEIVED,
             "total number of unknown operations received by this GatewayReceiver", "operations"),
-        f.createIntCounter(EXCEPTIONS_OCCURED,
-            "number of exceptions occured while porcessing the batches", "operations")};
+        f.createIntCounter(EXCEPTIONS_OCCURRED,
+            "number of exceptions occurred while porcessing the batches", "operations")};
     return new GatewayReceiverStats(f, ownerName, typeName, descriptors);
 
   }
@@ -128,7 +128,7 @@ public class GatewayReceiverStats extends CacheServerStats {
     updateRequestId = statType.nameToId(UPDATE_REQUESTS);
     destroyRequestId = statType.nameToId(DESTROY_REQUESTS);
     unknowsOperationsReceivedId = statType.nameToId(UNKNOWN_OPERATIONS_RECEIVED);
-    exceptionsOccuredId = statType.nameToId(EXCEPTIONS_OCCURED);
+    exceptionsOccurredId = statType.nameToId(EXCEPTIONS_OCCURRED);
   }
 
   // /////////////////// Instance Methods /////////////////////
@@ -233,14 +233,14 @@ public class GatewayReceiverStats extends CacheServerStats {
   }
 
   /**
-   * Increments the number of exceptions occured by 1.
+   * Increments the number of exceptions occurred by 1.
    */
-  public void incExceptionsOccured() {
-    this.stats.incInt(exceptionsOccuredId, 1);
+  public void incExceptionsOccurred() {
+    this.stats.incInt(exceptionsOccurredId, 1);
   }
 
-  public int getExceptionsOccured() {
-    return this.stats.getInt(exceptionsOccuredId);
+  public int getExceptionsOccurred() {
+    return this.stats.getInt(exceptionsOccurredId);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueBatchRemovalMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueBatchRemovalMessage.java
@@ -97,7 +97,7 @@ public class ParallelQueueBatchRemovalMessage extends PartitionMessage {
                   }
                 } catch (Exception e) {
                   logger.fatal(LocalizedMessage.create(
-                      LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+                      LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
                       new Object[] {filter.toString(), eventForFilter}), e);
                 }
               }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessage.java
@@ -174,7 +174,7 @@ public class ParallelQueueRemovalMessage extends PooledDistributionMessage {
         }
       } catch (Exception e) {
         logger.fatal(LocalizedMessage.create(
-            LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+            LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
             new Object[] {filter.toString(), eventForFilter}), e);
       }
     }
@@ -247,7 +247,7 @@ public class ParallelQueueRemovalMessage extends PooledDistributionMessage {
         }
       } catch (Exception e) {
         logger.fatal(LocalizedMessage.create(
-            LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+            LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
             new Object[] {filter.toString(), eventForFilter}), e);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/BatchDestroyOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/BatchDestroyOperation.java
@@ -115,7 +115,7 @@ public class BatchDestroyOperation extends DistributedCacheOperation {
                 }
               } catch (Exception e) {
                 logger.fatal(LocalizedMessage.create(
-                    LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
+                    LocalizedStrings.GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1,
                     new Object[] {filter.toString(), eventForFilter}), e);
               }
             }

--- a/geode-core/src/main/java/org/apache/geode/internal/datasource/FacetsJCAConnectionManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/datasource/FacetsJCAConnectionManagerImpl.java
@@ -181,7 +181,7 @@ public class FacetsJCAConnectionManagerImpl
         // mannPoolCache.destroyPooledConnection(conn);
       } catch (Exception ex) {
         String exception =
-            "FacetsJCAConnectionManagerImpl::connectionErrorOccured: Exception occured due to "
+            "FacetsJCAConnectionManagerImpl::connectionErrorOccurred: Exception occurred due to "
                 + ex.getMessage();
         if (logger.isDebugEnabled()) {
           logger.debug(exception, ex);
@@ -206,7 +206,7 @@ public class FacetsJCAConnectionManagerImpl
         }
       } catch (Exception se) {
         String exception =
-            "FacetsJCAConnectionManagerImpl::connectionClosed: Exception occured due to "
+            "FacetsJCAConnectionManagerImpl::connectionClosed: Exception occurred due to "
                 + se.getMessage();
         if (logger.isDebugEnabled()) {
           logger.debug(exception, se);

--- a/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireConnPooledDataSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireConnPooledDataSource.java
@@ -157,7 +157,7 @@ public class GemFireConnPooledDataSource extends AbstractDataSource
         provider.returnAndExpireConnection(conn);
       } catch (Exception ex) {
         String exception =
-            "GemFireConnPooledDataSource::connectionErrorOccured:error in returning and expiring connection due to "
+            "GemFireConnPooledDataSource::connectionErrorOccurred:error in returning and expiring connection due to "
                 + ex;
         if (logger.isDebugEnabled()) {
           logger.debug(exception, ex);

--- a/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireTransactionDataSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireTransactionDataSource.java
@@ -166,7 +166,7 @@ public class GemFireTransactionDataSource extends AbstractDataSource
         provider.returnConnection(conn);
       } catch (Exception e) {
         String exception =
-            "GemFireTransactionDataSource::connectionClosed: Exception occured due to " + e;
+            "GemFireTransactionDataSource::connectionClosed: Exception occurred due to " + e;
         if (logger.isDebugEnabled()) {
           logger.debug(exception, e);
         }
@@ -187,7 +187,8 @@ public class GemFireTransactionDataSource extends AbstractDataSource
         provider.returnAndExpireConnection(conn);
       } catch (Exception ex) {
         String exception =
-            "GemFireTransactionDataSource::connectionErrorOccured: Exception occured due to " + ex;
+            "GemFireTransactionDataSource::connectionErrorOccurred: Exception occurred due to "
+                + ex;
         if (logger.isDebugEnabled()) {
           logger.debug(exception, ex);
         }
@@ -214,7 +215,7 @@ public class GemFireTransactionDataSource extends AbstractDataSource
       }
     } catch (Exception ex) {
       Exception e = new Exception(
-          LocalizedStrings.GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEREGISTERTRANXCONNECTION_EXCEPTION_IN_REGISTERING_THE_XARESOURCE_WITH_THE_TRANSACTIONEXCEPTION_OCCURED_0
+          LocalizedStrings.GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEREGISTERTRANXCONNECTION_EXCEPTION_IN_REGISTERING_THE_XARESOURCE_WITH_THE_TRANSACTIONEXCEPTION_OCCURRED_0
               .toLocalizedString(ex));
       e.initCause(ex);
       throw e;

--- a/geode-core/src/main/java/org/apache/geode/internal/datasource/JCAConnectionManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/datasource/JCAConnectionManagerImpl.java
@@ -159,7 +159,7 @@ public class JCAConnectionManagerImpl implements ConnectionManager, ConnectionEv
         // mannPoolCache.destroyPooledConnection(conn);
       } catch (Exception ex) {
         String exception =
-            "JCAConnectionManagerImpl::connectionErrorOccured: Exception occured due to " + ex;
+            "JCAConnectionManagerImpl::connectionErrorOccurred: Exception occurred due to " + ex;
         if (logger.isDebugEnabled()) {
           logger.debug(exception, ex);
         }
@@ -186,7 +186,7 @@ public class JCAConnectionManagerImpl implements ConnectionManager, ConnectionEv
         }
       } catch (Exception se) {
         String exception =
-            "JCAConnectionManagerImpl::connectionClosed: Exception occured due to " + se;
+            "JCAConnectionManagerImpl::connectionClosed: Exception occurred due to " + se;
         if (logger.isDebugEnabled()) {
           logger.debug(exception, se);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -522,11 +522,11 @@ public class LocalizedStrings {
       new StringId(1294, "ContextImpl::lookup::Error while looking up {0}");
   public static final StringId CqAttributesFactory_EXCEPTION_CLOSING_CQ_LISTENER_ERROR_0 =
       new StringId(1295, "Exception closing CQ Listener Error: {0}");
-  public static final StringId CqAttributesFactory_EXCEPTION_OCCURED_WHILE_CLOSING_CQ_LISTENER_ERROR_0 =
+  public static final StringId CqAttributesFactory_EXCEPTION_OCCURRED_WHILE_CLOSING_CQ_LISTENER_ERROR_0 =
       new StringId(1296, "Exception occurred while closing CQ Listener Error: {0}");
-  public static final StringId CqAttributesFactory_RUNTIME_EXCEPTION_OCCURED_CLOSING_CQ_LISTENER_ERROR_0 =
+  public static final StringId CqAttributesFactory_RUNTIME_EXCEPTION_OCCURRED_CLOSING_CQ_LISTENER_ERROR_0 =
       new StringId(1297, "Runtime Exception occurred closing CQ Listener Error: {0}");
-  public static final StringId CqAttributesFactory_RUNTIME_EXCEPTION_OCCURED_WHILE_CLOSING_CQ_LISTENER_ERROR_0 =
+  public static final StringId CqAttributesFactory_RUNTIME_EXCEPTION_OCCURRED_WHILE_CLOSING_CQ_LISTENER_ERROR_0 =
       new StringId(1298, "Runtime Exception occurred while closing CQ Listener Error: {0}");
   public static final StringId CqQueryImpl_FAILED_TO_STORE_CONTINUOUS_QUERY_IN_THE_REPOSITORY_CQNAME_0_1 =
       new StringId(1299, "Failed to store Continuous Query in the repository. CqName: {0} {1}");
@@ -1037,7 +1037,7 @@ public class LocalizedStrings {
   public static final StringId GlobalTransaction_GLOBALTRANSACTION_CONSTRUCTOR_ERROR_WHILE_TRYING_TO_CREATE_XID_DUE_TO_0 =
       new StringId(1645,
           "GlobalTransaction::Constructor::Error while trying to create Xid due to {0}");
-  public static final StringId GlobalTransaction_GLOBATRANSACTION_EXPIREGTX_ERROR_OCCURED_WHILE_REMOVING_TRANSACTIONAL_MAPPINGS_0 =
+  public static final StringId GlobalTransaction_GLOBATRANSACTION_EXPIREGTX_ERROR_OCCURRED_WHILE_REMOVING_TRANSACTIONAL_MAPPINGS_0 =
       new StringId(1646,
           "GlobaTransaction::expireGTX:Error occurred while removing transactional mappings {0}");
   public static final StringId GlobalTransaction_TRANSACTION_0_HAS_TIMED_OUT =
@@ -1054,7 +1054,7 @@ public class LocalizedStrings {
   public static final StringId HARegionQueue_DISPATCHEDANDCURRENTEVENTSEXPIREORUPDATE_UNEXPECTEDLY_ENCOUNTERED_EXCEPTION_WHILE_UPDATING_EXPIRY_ID_FOR_THREADIDENTIFIER_0 =
       new StringId(1651,
           "DispatchedAndCurrentEvents::expireOrUpdate: Unexpectedly encountered exception while updating expiry ID for ThreadIdentifier={0}");
-  public static final StringId HARegionQueue_EXCEPTION_OCCURED_WHILE_TRYING_TO_SET_THE_LAST_DISPATCHED_ID =
+  public static final StringId HARegionQueue_EXCEPTION_OCCURRED_WHILE_TRYING_TO_SET_THE_LAST_DISPATCHED_ID =
       new StringId(1652, "Exception occurred while trying to set the last dispatched id");
   public static final StringId HARegionQueue_HAREGIONQUEUECREATECACHELISTNEREXCEPTION_IN_THE_EXPIRY_THREAD =
       new StringId(1653, "HAREgionQueue::createCacheListner::Exception in the expiry thread");
@@ -1063,7 +1063,7 @@ public class LocalizedStrings {
       new StringId(1655, "HARegionQueue and its derived class do not support this operation ");
   public static final StringId ConnectionTable_THE_DISTRIBUTED_SYSTEM_IS_SHUTTING_DOWN =
       new StringId(1656, "The distributed system is shutting down");
-  public static final StringId HARegionQueue_INTERRUPTEDEXCEPTION_OCCURED_IN_QUEUEREMOVALTHREAD_WHILE_WAITING =
+  public static final StringId HARegionQueue_INTERRUPTEDEXCEPTION_OCCURRED_IN_QUEUEREMOVALTHREAD_WHILE_WAITING =
       new StringId(1657, "InterruptedException occurred in QueueRemovalThread  while waiting ");
   public static final StringId HealthMonitorImpl_UNEXPECTED_STOP_OF_HEALTH_MONITOR =
       new StringId(1658, "Unexpected stop of health monitor");
@@ -1101,9 +1101,9 @@ public class LocalizedStrings {
 
   public static final StringId InternalDistributedSystem_DISCONNECT_LISTENER_STILL_RUNNING__0 =
       new StringId(1685, "Disconnect listener still running: {0}");
-  public static final StringId InternalDistributedSystem_EXCEPTION_OCCURED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT =
+  public static final StringId InternalDistributedSystem_EXCEPTION_OCCURRED_WHILE_TRYING_TO_CONNECT_THE_SYSTEM_DURING_RECONNECT =
       new StringId(1686, "Exception occurred while trying to connect the system during reconnect");
-  public static final StringId InternalDistributedSystem_EXCEPTION_OCCURED_WHILE_TRYING_TO_CREATE_THE_CACHE_DURING_RECONNECT =
+  public static final StringId InternalDistributedSystem_EXCEPTION_OCCURRED_WHILE_TRYING_TO_CREATE_THE_CACHE_DURING_RECONNECT =
       new StringId(1687, "Exception occurred while trying to create the cache during reconnect");
   public static final StringId InternalDistributedSystem_INTERRUPTED_WHILE_PROCESSING_DISCONNECT_LISTENER =
       new StringId(1688, "Interrupted while processing disconnect listener");
@@ -1918,7 +1918,7 @@ public class LocalizedStrings {
   public static final StringId AbstractDistributionConfig_COULD_NOT_SET_0_RECHARGETHRESHOLD_TO_1_BECAUSE_ITS_VALUE_CAN_NOT_BE_LESS_THAN_2 =
       new StringId(2167,
           "Could not set \"{0}.rechargeThreshold\" to \"{1}\" because its value can not be less than \"{2}\"");
-  public static final StringId UNCAUGHT_EXCEPTION_IN_THREAD_0_THIS_MESSAGE_CAN_BE_DISREGARDED_IF_IT_OCCURED_DURING_AN_APPLICATION_SERVER_SHUTDOWN_THE_EXCEPTION_MESSAGE_WAS_1 =
+  public static final StringId UNCAUGHT_EXCEPTION_IN_THREAD_0_THIS_MESSAGE_CAN_BE_DISREGARDED_IF_IT_OCCURRED_DURING_AN_APPLICATION_SERVER_SHUTDOWN_THE_EXCEPTION_MESSAGE_WAS_1 =
       new StringId(2168,
           "Uncaught exception in thread {0} this message can be disregarded if it occurred during an Application Server shutdown. The Exception message was: {1}");
 
@@ -2855,7 +2855,7 @@ public class LocalizedStrings {
   public static final StringId GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEGETCONNECTIONNO_VALID_CONNECTION_AVAILABLE =
       new StringId(2707,
           "GemFireTransactionDataSource::getConnection::No valid Connection available");
-  public static final StringId GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEREGISTERTRANXCONNECTION_EXCEPTION_IN_REGISTERING_THE_XARESOURCE_WITH_THE_TRANSACTIONEXCEPTION_OCCURED_0 =
+  public static final StringId GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEREGISTERTRANXCONNECTION_EXCEPTION_IN_REGISTERING_THE_XARESOURCE_WITH_THE_TRANSACTIONEXCEPTION_OCCURRED_0 =
       new StringId(2708,
           "GemFireTransactionDataSource-registerTranxConnection(). Exception in registering the XAResource with the Transaction.Exception occurred= {0}");
   public static final StringId GemFireTransactionDataSource_GEMFIRETRANSACTIONDATASOURCEXADATASOURCE_CLASS_OBJECT_IS_NULL_OR_CONFIGUREDDATASOURCEPROPERTIES_OBJECT_IS_NULL =
@@ -3042,7 +3042,7 @@ public class LocalizedStrings {
       new StringId(2847, "Class  {0}  could not be instantiated.");
   public static final StringId LocalRegion_CLASS_0_NOT_FOUND_IN_CLASSPATH =
       new StringId(2848, "Class  {0}  not found in classpath.");
-  public static final StringId LocalRegion_EXCEPTION_OCCURED_WHILE_RE_CREATING_INDEX_DATA_ON_CLEARED_REGION =
+  public static final StringId LocalRegion_EXCEPTION_OCCURRED_WHILE_RE_CREATING_INDEX_DATA_ON_CLEARED_REGION =
       new StringId(2849, "Exception occurred while re creating index data on cleared region.");
   public static final StringId LocalRegion_FAILED_ENLISTEMENT_WITH_TRANSACTION_0 =
       new StringId(2850, "Failed enlistement with transaction \"{0}\"");
@@ -3459,7 +3459,7 @@ public class LocalizedStrings {
 
   public static final StringId PartitionedRegion_TIME_OUT_LOOKING_FOR_TARGET_NODE_FOR_DESTROY_WAITED_0_MS =
       new StringId(3093, "Time out looking for target node for destroy; waited  {0}  ms");
-  public static final StringId PartitionedRegion_UNEXPECTED_QUERY_EXCEPTION_OCCURED_DURING_QUERY_EXECUTION_0 =
+  public static final StringId PartitionedRegion_UNEXPECTED_QUERY_EXCEPTION_OCCURRED_DURING_QUERY_EXECUTION_0 =
       new StringId(3094, "Unexpected query exception occurred during query execution  {0}");
   public static final StringId PooledExecutorWithDMStats_EXECUTOR_HAS_BEEN_SHUTDOWN =
       new StringId(3095, "executor has been shutdown");
@@ -4442,14 +4442,14 @@ public class LocalizedStrings {
   public static final StringId GlobalTransaction_GLOBALTRANSACTION_ENLISTRESOURCE_CANNOT_ENLIST_A_RESOURCE_TO_A_TRANSACTION_WHICH_IS_NOT_ACTIVE =
       new StringId(3717,
           "GlobalTransaction::enlistResource::Cannot enlist a resource to a transaction which is not active");
-  public static final StringId GlobalTransaction_GLOBALTRANSACTION_ENLISTRESOURCE_EXCEPTION_OCCURED_IN_TRYING_TO_SET_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1 =
+  public static final StringId GlobalTransaction_GLOBALTRANSACTION_ENLISTRESOURCE_EXCEPTION_OCCURRED_IN_TRYING_TO_SET_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1 =
       new StringId(3718,
           "GlobalTransaction::enlistResource:Exception occurred in trying to set XAResource timeout due to {0} Error Code = {1}");
   public static final StringId GlobalTransaction_ERROR_WHILE_DELISTING_XARESOURCE_0_1 =
       new StringId(3719, "error while delisting XAResource {0} {1}");
   public static final StringId GlobalTransaction_GLOBATRANSACTION_RESUME_RESUME_NOT_SUCCESFUL_DUE_TO_0 =
       new StringId(3720, "GlobaTransaction::resume:Resume not succesful due to {0}");
-  public static final StringId GlobalTransaction_EXCEPTION_OCCURED_WHILE_TRYING_TO_SET_THE_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1 =
+  public static final StringId GlobalTransaction_EXCEPTION_OCCURRED_WHILE_TRYING_TO_SET_THE_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1 =
       new StringId(3721,
           "Exception occurred while trying to set the XAResource TimeOut due to {0} Error code = {1}");
   public static final StringId SmHelper_NATIVE_CODE_UNAVAILABLE =
@@ -5275,7 +5275,7 @@ public class LocalizedStrings {
       new StringId(4159, "AuthorizeRequest: Client[{0}] is setting authorization callback to {1}.");
   public static final StringId AuthorizeRequest_NOT_AUTHORIZED_TO_PERFORM_GET_OPERATION_ON_REGION_0 =
       new StringId(4160, "Not authorized to perform GET operation on region [{0}]");
-  public static final StringId CqEventImpl_EXCEPTION_OCCURED_WHILE_APPLYING_QUERY_ON_A_CACHE_EVENT =
+  public static final StringId CqEventImpl_EXCEPTION_OCCURRED_WHILE_APPLYING_QUERY_ON_A_CACHE_EVENT =
       new StringId(4161, "Exception occurred while applying query on a cache event.");
   public static final StringId AuthorizeRequest_NOT_AUTHORIZED_TO_PERFORM_PUT_OPERATION_ON_REGION_0 =
       new StringId(4162, "Not authorized to perform PUT operation on region {0}");
@@ -5672,7 +5672,7 @@ public class LocalizedStrings {
           "recursiveDestroyRegion: postDestroyRegion failed due to cache closure. region = {0}");
   public static final StringId LocalRegion_RECURSIVEDESTROYREGION_PROBLEM_IN_CACHEWRITEBEFOREREGIONDESTROY =
       new StringId(4402, "recursiveDestroyRegion: problem in cacheWriteBeforeRegionDestroy");
-  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_REGION_WILL_BE_CLOSED =
+  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_REGION_WILL_BE_CLOSED =
       new StringId(4403,
           "A DiskAccessException has occurred while writing to the disk for region {0}. The region will be closed.");
   public static final StringId PoolImpl_DESTROYING_CONNECTION_POOL_0 =
@@ -6129,7 +6129,7 @@ public class LocalizedStrings {
       new StringId(4679, "InstantiatorRecoveryTask - Error ClassNotFoundException: {0}");
   public static final StringId ResourceAdvisor_MEMBER_CAUGHT_EXCEPTION_PROCESSING_PROFILE =
       new StringId(4682, "This member caught exception processing profile {0} {1}");
-  public static final StringId MemoryMonitor_EXCEPTION_OCCURED_WHEN_NOTIFYING_LISTENERS =
+  public static final StringId MemoryMonitor_EXCEPTION_OCCURRED_WHEN_NOTIFYING_LISTENERS =
       new StringId(4683, "Exception occurred when notifying listeners ");
   public static final StringId CacheXmlParser_A_0_IS_NOT_DATA_SERIALIZABLE = new StringId(4684,
       "The class {0}, presented for instantiator registration is not an instance of DataSerializable and cannot be registered.");
@@ -6519,7 +6519,7 @@ public class LocalizedStrings {
       new StringId(4903, "Received cluster configuration from the locator");
   public static final StringId GemFireCache_SHARED_CONFIGURATION_NOT_AVAILABLE =
       new StringId(4904, "cluster configuration service not available");
-  public static final StringId GemFireCache_EXCEPTION_OCCURED_WHILE_DEPLOYING_JARS_FROM_SHARED_CONDFIGURATION =
+  public static final StringId GemFireCache_EXCEPTION_OCCURRED_WHILE_DEPLOYING_JARS_FROM_SHARED_CONDFIGURATION =
       new StringId(4905,
           "Exception while deploying the jars received as a part of cluster Configuration");
   public static final StringId GemFireCache_NO_LOCATORS_FOUND_WITH_SHARED_CONFIGURATION =
@@ -6783,7 +6783,7 @@ public class LocalizedStrings {
       new StringId(5090, "-disable-default-server  Do not add a default <cache-server>");
   public static final StringId Oplog_REMOVING_INCOMPLETE_KRF =
       new StringId(5091, "Removing incomplete krf {0} for oplog {1}, disk store \"{2}\"");
-  public static final StringId PlaceHolderDiskRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_RECOVERING_FROM_DISK =
+  public static final StringId PlaceHolderDiskRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_RECOVERING_FROM_DISK =
       new StringId(5092,
           "A DiskAccessException has occurred while recovering values asynchronously from disk for region {0}.");
   public static final StringId PartitionedRegion_FOR_REGION_0_TotalBucketNum_1_SHOULD_NOT_BE_CHANGED_Previous_Configured_2 =
@@ -6876,7 +6876,7 @@ public class LocalizedStrings {
   public static final StringId BucketPersistenceAdvisor_ERROR_RECOVERYING_SECONDARY_BUCKET_0 =
       new StringId(5137, "Unable to recover secondary bucket from disk for region {0} bucket {1}");
   public static final StringId FunctionService_EXCEPTION_ON_LOCAL_NODE =
-      new StringId(5138, "Exception occured on local node while executing Function:");
+      new StringId(5138, "Exception occurred on local node while executing Function:");
   public static final StringId AbstractIndex_WRONG_COMPARETO_IMPLEMENTATION_IN_INDEXED_OBJECT_0 =
       new StringId(5139, "Indexed object''s class {0} compareTo function is errorneous.");
   public static final StringId DefaultQuery_API_ONLY_FOR_PR =
@@ -7207,9 +7207,9 @@ public class LocalizedStrings {
   public static final StringId Region_REGION_0_HAS_1_ASYNC_EVENT_QUEUE_IDS_ANOTHER_CACHE_HAS_THE_SAME_REGION_WITH_2_ASYNC_EVENT_QUEUE_IDS_FOR_REGION_ACROSS_ALL_MEMBERS_IN_DS_ASYNC_EVENT_QUEUE_IDS_SHOULD_BE_SAME =
       new StringId(5304,
           "Region {0} has {1} AsyncEvent queue IDs. Another cache has same region with {2} AsyncEvent queue IDs. For region across all members, AsyncEvent queue IDs should be same.");
-  public static final StringId GatewayEventFilter_EXCEPTION_OCCURED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1 =
+  public static final StringId GatewayEventFilter_EXCEPTION_OCCURRED_WHILE_HANDLING_CALL_TO_0_AFTER_ACKNOWLEDGEMENT_FOR_EVENT_1 =
       new StringId(5305,
-          "Exception occured while handling call to {0}.afterAcknowledgement for event {1}:");
+          "Exception occurred while handling call to {0}.afterAcknowledgement for event {1}:");
   public static final StringId GatewayReceiverImpl_USING_LOCAL_HOST =
       new StringId(5399, "No bind-address or hostname-for-sender is specified, Using local host ");
   public static final StringId GatewayReceiverImpl_COULD_NOT_GET_HOST_NAME =
@@ -7376,13 +7376,13 @@ public class LocalizedStrings {
           "enforce-unique-host and redundancy-zone properties have no effect for a LonerDistributedSystem.");
   public static final StringId AttributesFactory_UNABLE_TO_CREATE_DISK_STORE_DIRECTORY_0 =
       new StringId(5607, "Unable to create directory : {0}");
-  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_CACHE_WILL_BE_CLOSED =
+  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_REGION_0_THE_CACHE_WILL_BE_CLOSED =
       new StringId(5608,
           "A DiskAccessException has occurred while writing to the disk for region {0}. The cache will be closed.");
-  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURED_WHILE_WRITING_TO_THE_DISK_FOR_DISKSTORE_0_THE_CACHE_WILL_BE_CLOSED =
+  public static final StringId LocalRegion_A_DISKACCESSEXCEPTION_HAS_OCCURRED_WHILE_WRITING_TO_THE_DISK_FOR_DISKSTORE_0_THE_CACHE_WILL_BE_CLOSED =
       new StringId(5609,
           "A DiskAccessException has occurred while writing to the disk for disk store {0}. The cache will be closed.");
-  public static final StringId LocalRegion_AN_EXCEPTION_OCCURED_WHILE_CLOSING_THE_CACHE =
+  public static final StringId LocalRegion_AN_EXCEPTION_OCCURRED_WHILE_CLOSING_THE_CACHE =
       new StringId(5610, "An Exception occurred while closing the cache.");
 
   public static final StringId DiskWriteAttributesFactory_DISK_USAGE_WARNING_INVALID_0 =
@@ -7480,7 +7480,7 @@ public class LocalizedStrings {
   public static final StringId Gateway_OBSOLETE_SYSTEM_POPERTY = new StringId(5711,
       "Obsolete java system property named {0} was set to control {1}. This property is no longer supported. Please use the GemFire API instead.");
   public static final StringId GatewayReceiver_EXCEPTION_WHILE_STARTING_GATEWAY_RECEIVER =
-      new StringId(5712, "Exception occured while starting gateway receiver");
+      new StringId(5712, "Exception occurred while starting gateway receiver");
   public static final StringId GatewayReceiver_IS_NOT_RUNNING =
       new StringId(5713, "Gateway Receiver is not running");
   public static final StringId GatewayReceiver_IS_ALREADY_RUNNING =

--- a/geode-core/src/main/java/org/apache/geode/internal/jta/GlobalTransaction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/jta/GlobalTransaction.java
@@ -358,7 +358,7 @@ public class GlobalTransaction {
             }
           } catch (XAException xe) {
             String exception =
-                LocalizedStrings.GlobalTransaction_GLOBALTRANSACTION_ENLISTRESOURCE_EXCEPTION_OCCURED_IN_TRYING_TO_SET_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1
+                LocalizedStrings.GlobalTransaction_GLOBALTRANSACTION_ENLISTRESOURCE_EXCEPTION_OCCURRED_IN_TRYING_TO_SET_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1
                     .toLocalizedString(new Object[] {xe, Integer.valueOf(xe.errorCode)});
             LogWriterI18n writer = TransactionUtils.getLogWriterI18n();
             if (VERBOSE)
@@ -601,7 +601,7 @@ public class GlobalTransaction {
     } catch (Exception e) {
       if (writer.severeEnabled())
         writer.severe(
-            LocalizedStrings.GlobalTransaction_GLOBATRANSACTION_EXPIREGTX_ERROR_OCCURED_WHILE_REMOVING_TRANSACTIONAL_MAPPINGS_0,
+            LocalizedStrings.GlobalTransaction_GLOBATRANSACTION_EXPIREGTX_ERROR_OCCURRED_WHILE_REMOVING_TRANSACTIONAL_MAPPINGS_0,
             e, e);
     }
   }
@@ -628,7 +628,7 @@ public class GlobalTransaction {
             resetXATimeOut = xar.setTransactionTimeout(seconds);
           } catch (XAException e) {
             String exception =
-                LocalizedStrings.GlobalTransaction_EXCEPTION_OCCURED_WHILE_TRYING_TO_SET_THE_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1
+                LocalizedStrings.GlobalTransaction_EXCEPTION_OCCURRED_WHILE_TRYING_TO_SET_THE_XARESOURCE_TIMEOUT_DUE_TO_0_ERROR_CODE_1
                     .toLocalizedString(new Object[] {e, Integer.valueOf(e.errorCode)});
             LogWriterI18n writer = TransactionUtils.getLogWriterI18n();
             if (VERBOSE)

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingThreadGroup.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingThreadGroup.java
@@ -267,7 +267,7 @@ public class LoggingThreadGroup extends ThreadGroup {
       if ((ex instanceof NoClassDefFoundError)
           && (threadName.equals(InternalDistributedSystem.SHUTDOWN_HOOK_NAME))) {
         final StringId msg =
-            LocalizedStrings.UNCAUGHT_EXCEPTION_IN_THREAD_0_THIS_MESSAGE_CAN_BE_DISREGARDED_IF_IT_OCCURED_DURING_AN_APPLICATION_SERVER_SHUTDOWN_THE_EXCEPTION_MESSAGE_WAS_1;
+            LocalizedStrings.UNCAUGHT_EXCEPTION_IN_THREAD_0_THIS_MESSAGE_CAN_BE_DISREGARDED_IF_IT_OCCURRED_DURING_AN_APPLICATION_SERVER_SHUTDOWN_THE_EXCEPTION_MESSAGE_WAS_1;
         final Object[] msgArgs = new Object[] {t, ex.getLocalizedMessage()};
         stderr.info(msg, msgArgs);
         if (this.logger != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgDestreamer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgDestreamer.java
@@ -168,7 +168,7 @@ public class MsgDestreamer {
   /**
    * Waits for the deserialization to complete and returns the deserialized message.
    * 
-   * @throws IOException A problem occured while deserializing the message.
+   * @throws IOException A problem occurred while deserializing the message.
    * @throws ClassNotFoundException The class of an object read from <code>in</code> could not be
    *         found
    */

--- a/geode-core/src/main/java/org/apache/geode/management/JVMMetrics.java
+++ b/geode-core/src/main/java/org/apache/geode/management/JVMMetrics.java
@@ -81,7 +81,7 @@ public class JVMMetrics implements Serializable {
   }
 
   /**
-   * Returns the number of times garbage collection has occured.
+   * Returns the number of times garbage collection has occurred.
    */
   public long getGcCount() {
     return gcCount;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/StatsKey.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/StatsKey.java
@@ -291,7 +291,7 @@ public class StatsKey {
   public static final String UPDATE_REQUESTS = "updateRequest";
   public static final String DESTROY_REQUESTS = "destroyRequest";
   public static final String UNKNOWN_OPERATIONS_RECEIVED = "unknowsOperationsReceived";
-  public static final String EXCEPTIONS_OCCURED = "exceptionsOccured";
+  public static final String EXCEPTIONS_OCCURRED = "exceptionsOccurred";
   public static final String BATCH_PROCESS_TIME = "processBatchTime";
   public static final String TOTAL_BATCHES = "processBatchRequests";
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShellCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShellCommands.java
@@ -963,7 +963,7 @@ public class ShellCommands implements CommandMarker {
     } catch (Exception e) {
       LogWrapper.getInstance().info(CliUtil.stackTraceAsString(e));
       return ResultBuilder
-          .createGemFireErrorResult("Exception occured while clearing history " + e.getMessage());
+          .createGemFireErrorResult("Exception occurred while clearing history " + e.getMessage());
     }
     return ResultBuilder.createInfoResult(CliStrings.HISTORY__MSG__CLEARED_HISTORY);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -742,7 +742,7 @@ public class CliStrings {
   public static final String CREATE_INDEX__FAILURE__MSG =
       "Failed to create index \"{0}\" due to following reasons";
   public static final String CREATE_INDEX__ERROR__MSG =
-      "Exception \"{0}\" occured on following members";
+      "Exception \"{0}\" occurred on following members";
   public static final String CREATE_INDEX__NAME__CONFLICT =
       "Index \"{0}\" already exists.  " + "Create failed due to duplicate name.";
   public static final String CREATE_INDEX__INDEX__EXISTS =
@@ -1324,7 +1324,7 @@ public class CliStrings {
   public static final String EXECUTE_FUNCTION__MSG__DOES_NOT_HAVE_FUNCTION_0_REGISTERED =
       "Function : {0} is not registered on member.";
   public static final String EXECUTE_FUNCTION__MSG__ERROR_IN_EXECUTING_ON_MEMBER_1_DETAILS_2 =
-      "While executing function : {0} on member : {1} error occured : {2}";
+      "While executing function : {0} on member : {1} error occurred : {2}";
   public static final String EXECUTE_FUNCTION__MSG__RESULT_COLLECTOR_0_NOT_FOUND_ERROR_1 =
       "ResultCollector : {0} not found. Error : {1}";
   public static final String EXECUTE_FUNCTION__MSG__MXBEAN_0_FOR_NOT_FOUND =
@@ -1334,7 +1334,7 @@ public class CliStrings {
   public static final String EXECUTE_FUNCTION__MSG__DS_HAS_NO_MEMBERS =
       "Distributed system has no members";
   public static final String EXECUTE_FUNCTION__MSG__ERROR_IN_EXECUTING_0_ON_REGION_1_DETAILS_2 =
-      "While executing function : {0} on region : {1} error occured : {2}";
+      "While executing function : {0} on region : {1} error occurred : {2}";
   public static final String EXECUTE_FUNCTION__MSG__ERROR_IN_RETRIEVING_EXECUTOR =
       "Could not retrieve executor";
   public static final String EXECUTE_FUNCTION__MSG__GROUPS_0_HAS_NO_MEMBERS =
@@ -1344,7 +1344,7 @@ public class CliStrings {
   public static final String EXECUTE_FUNCTION__MSG__COULD_NOT_RETRIEVE_ARGUMENTS =
       "Could not retrieve arguments";
   public static final String EXECUTE_FUNCTION__MSG__ERROR_IN_EXECUTING_0_ON_MEMBER_1_ON_REGION_2_DETAILS_3 =
-      "While executing function : {0} on member : {1} one region : {2} error occured : {3}";
+      "While executing function : {0} on member : {1} one region : {2} error occurred : {3}";
   public static final String EXECUTE_FUNCTION__MSG__MEMBER_SHOULD_NOT_HAVE_FILTER_FOR_EXECUTION =
       "Filters for executing on \"member\"/\"mebers of group\" is not supported.";
 
@@ -1467,9 +1467,9 @@ public class CliStrings {
       "Abort the command if already exists at locator directory";
   public static final String EXPORT_STACKTRACE__MEMBER__NOT__FOUND = "Member not found";
   public static final String EXPORT_STACKTRACE__SUCCESS = "stack-trace(s) exported to file: {0}";
-  public static final String EXPORT_STACKTRACE__ERROR = "Error occured while showing stack-traces";
+  public static final String EXPORT_STACKTRACE__ERROR = "Error occurred while showing stack-traces";
   public static final String EXPORT_STACKTRACE__ERROR__FILE__PRESENT =
-      "Error occured while exporting stack-traces, file {0} already present";
+      "Error occurred while exporting stack-traces, file {0} already present";
   public static final String EXPORT_STACKTRACE__HOST = "On host : ";
   public static final String EXPORT_STACKTRACE_WARN_USER =
       "If file {0} already present at locator directory it will be overwritten, do you want to continue?";
@@ -1620,7 +1620,7 @@ public class CliStrings {
   public static final String DESCRIBE_CLIENT_COULD_NOT_RETRIEVE_STATS_FOR_CLIENT_0_REASON_1 =
       "Could not retrieve stats for client : {0}. Reason : {1}";
   public static final String DESCRIBE_CLIENT_ERROR_FETCHING_STATS_0 =
-      "Error occured while fetching stats. Reason : {0}";
+      "Error occurred while fetching stats. Reason : {0}";
   public static final String DESCRIBE_CLIENT_NO_MEMBERS = "DS has no members";
   public static final String DESCRIBE_CLIENT_COLUMN_PRIMARY_SERVERS = "Primary Servers";
   public static final String DESCRIBE_CLIENT_COLUMN_SECONDARY_SERVERS = "Secondary Servers";
@@ -1890,9 +1890,9 @@ public class CliStrings {
   public static final String REBALANCE__MSG__NO_REBALANCING_REGIONS_ON_DS =
       "Distributed system has no regions that can be rebalanced";
   public static final String REBALANCE__MSG__EXCEPTION_IN_REBALANCE_FOR_MEMBER_0_Exception =
-      "Excpetion occured while rebalancing on member : {0} . Exception is ";
+      "Excpetion occurred while rebalancing on member : {0} . Exception is ";
   public static final String REBALANCE__MSG__EXCEPTION_IN_REBALANCE_FOR_MEMBER_0_Exception_1 =
-      "Excpetion occured while rebalancing on member : {0} . Exception is : {1}";
+      "Excpetion occurred while rebalancing on member : {0} . Exception is : {1}";
   public static final String REBALANCE__MSG__ERROR_IN_RETRIEVING_MBEAN =
       "Could not retrieve MBean for region : {0}";
   public static final String REBALANCE__MSG__NO_EXECUTION_FOR_REGION_0_ON_MEMBERS_1 =
@@ -1907,7 +1907,7 @@ public class CliStrings {
   public static final String REBALANCE__MSG__REGION_NOT_ASSOCIATED_WITH_MORE_THAN_ONE_MEMBER =
       "No regions associated with more than 1 members";
   public static final String REBALANCE__MSG__EXCEPTION_OCCRED_WHILE_REBALANCING_0 =
-      "Exception occured while rebelancing. Reason : {0}";
+      "Exception occurred while rebelancing. Reason : {0}";
 
   /* remove command */
   public static final String REMOVE = "remove";
@@ -2089,7 +2089,7 @@ public class CliStrings {
       "To shutdown locators specify this option as true. Default is false";
   public static final String SHUTDOWN__MSG__CANNOT_EXECUTE = "Cannot execute";
   public static final String SHUTDOWN__MSG__ERROR =
-      "Exception occured while shutdown. Reason : {0}";
+      "Exception occurred while shutdown. Reason : {0}";
   public static final String SHUTDOWN__MSG__MANAGER_NOT_FOUND = "Could not locate Manager.";
   public static final String SHUTDOWN__MSG__WARN_USER =
       "As a lot of data in memory will be lost, including possibly events in queues, do you really want to shutdown the entire distributed system?";
@@ -2870,7 +2870,7 @@ public class CliStrings {
   public static final String UPGRADE_OFFLINE_DISK_STORE__MSG__CANNOT_ACCESS_DISKSTORE_0_FROM_1_CHECK_GFSH_LOGS =
       COMPACT_OFFLINE_DISK_STORE__MSG__CANNOT_ACCESS_DISKSTORE_0_FROM_1_CHECK_GFSH_LOGS;
   public static final String UPGRADE_OFFLINE_DISK_STORE__MSG__ERROR_WHILE_COMPACTING_DISKSTORE_0_WITH_1_REASON_2 =
-      "Error occured while upgrading disk store={0} {1}. Reason: {2}";
+      "Error occurred while upgrading disk store={0} {1}. Reason: {2}";
 
   /* 'validate disk-store' command */
   public static final String VALIDATE_DISK_STORE = "validate offline-disk-store";

--- a/geode-core/src/test/java/batterytest/greplogs/ExpectedStrings.java
+++ b/geode-core/src/test/java/batterytest/greplogs/ExpectedStrings.java
@@ -113,7 +113,7 @@ public class ExpectedStrings {
       expected.add(Pattern.compile("SQLException: Database 'newDB1' not found"));
       expected.add(Pattern.compile("IGNORE_EXCEPTION_test"));
       expected.add(Pattern.compile("Unsupported at this time"));
-      expected.add(Pattern.compile("DiskAccessException occured as expected"));
+      expected.add(Pattern.compile("DiskAccessException occurred as expected"));
       expected.add(Pattern.compile("Oplog::createOplog:Exception in preblowing the file"));
     } else if (type.equals("dunit")) {
       expected.add(Pattern.compile("INCOMPATIBLE_ROOT"));

--- a/geode-core/src/test/java/org/apache/geode/JtaNoninvolvementJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/JtaNoninvolvementJUnitTest.java
@@ -119,7 +119,7 @@ public class JtaNoninvolvementJUnitTest {
         createCache(false);
       }
       final CountDownLatch l = new CountDownLatch(1);
-      final AtomicBoolean exceptionOccured = new AtomicBoolean(false);
+      final AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
       ut = (UserTransaction) cache.getJNDIContext().lookup("java:/UserTransaction");
       ut.begin();
       txRegion.put("key", "value");
@@ -128,17 +128,17 @@ public class JtaNoninvolvementJUnitTest {
         @Override
         public void run() {
           if (txRegion.get("key") != null) {
-            exceptionOccured.set(true);
+            exceptionOccurred.set(true);
           }
           if (nonTxRegion.get("key") != null) {
-            exceptionOccured.set(true);
+            exceptionOccurred.set(true);
           }
           l.countDown();
         }
       });
       t.start();
       l.await();
-      assertFalse(exceptionOccured.get());
+      assertFalse(exceptionOccurred.get());
     } finally {
       if (ut != null) {
         ut.commit();

--- a/geode-core/src/test/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -792,10 +792,10 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     ThreadUtils.join(inv3, 30 * 1000);
 
     if (inv2.exceptionOccurred()) {
-      org.apache.geode.test.dunit.Assert.fail("Error occured in vm2", inv2.getException());
+      org.apache.geode.test.dunit.Assert.fail("Error occurred in vm2", inv2.getException());
     }
     if (inv3.exceptionOccurred()) {
-      org.apache.geode.test.dunit.Assert.fail("Error occured in vm3", inv3.getException());
+      org.apache.geode.test.dunit.Assert.fail("Error occurred in vm3", inv3.getException());
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
@@ -260,7 +260,7 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
           try {
             date = sdf.parse(dateString);
           } catch (ParseException e) {
-            Assert.fail("Exception Occured while parseing date", e);
+            Assert.fail("Exception Occurred while parseing date", e);
           }
           String value = month.toString() + 10;
           region.put(date, value);
@@ -281,7 +281,7 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
           try {
             date = sdf.parse(dateString);
           } catch (ParseException e) {
-            Assert.fail("Exception Occured while parseing date", e);
+            Assert.fail("Exception Occurred while parseing date", e);
           }
           DistributedMember key1Pri = PartitionRegionHelper.getPrimaryMemberForKey(region, date);
           assertNotNull(key1Pri);

--- a/geode-core/src/test/java/org/apache/geode/cache/query/QueryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/QueryJUnitTest.java
@@ -373,7 +373,7 @@ public class QueryJUnitTest {
       try {
         q.execute(params);
       } catch (Exception e) {
-        throw new AssertionError("exception occured while executing query", e);
+        throw new AssertionError("exception occurred while executing query", e);
       }
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/IndexCreationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/IndexCreationJUnitTest.java
@@ -176,7 +176,7 @@ public class IndexCreationJUnitTest {
     // Task ID: ICM17
     QueryService qs;
     qs = CacheUtils.getQueryService();
-    // boolean exceptionoccured = true;
+    // boolean exceptionoccurred = true;
     qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "status", "/portfolios, positions");
     qs.createIndex("secIdIndex", IndexType.FUNCTIONAL, "b.secId",
         "/portfolios pf, pf.positions.values b");

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/MiscJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/MiscJUnitTest.java
@@ -397,7 +397,7 @@ public class MiscJUnitTest {
       rgn.put("name" + i, pf);
     }
     final Object lock = new Object();
-    final boolean[] expectionOccured = new boolean[] {false};
+    final boolean[] expectionOccurred = new boolean[] {false};
     final boolean[] keepGoing = new boolean[] {true};
 
     Thread indexCreatorDestroyer = new Thread(new Runnable() {
@@ -429,7 +429,7 @@ public class MiscJUnitTest {
             region.getCache().getLogger().error(e);
             e.printStackTrace();
             synchronized (lock) {
-              expectionOccured[0] = true;
+              expectionOccurred[0] = true;
               keepGoing[0] = false;
               continueRunning = false;
             }
@@ -459,7 +459,7 @@ public class MiscJUnitTest {
               e.printStackTrace();
               region.getCache().getLogger().error(e);
               synchronized (lock) {
-                expectionOccured[0] = true;
+                expectionOccurred[0] = true;
                 keepGoing[0] = false;
                 continueRunning = false;
               }
@@ -470,7 +470,7 @@ public class MiscJUnitTest {
       });
     }
     synchronized (lock) {
-      assertFalse(expectionOccured[0]);
+      assertFalse(expectionOccurred[0]);
     }
 
     for (int i = 0; i < THREAD_COUNT; ++i) {
@@ -486,7 +486,7 @@ public class MiscJUnitTest {
 
     indexCreatorDestroyer.join();
     synchronized (lock) {
-      assertFalse(expectionOccured[0]);
+      assertFalse(expectionOccurred[0]);
     }
 
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/IndexManagerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/IndexManagerJUnitTest.java
@@ -91,7 +91,7 @@ public class IndexManagerJUnitTest {
     assertFalse(IndexManager.setIndexBufferTime(0, 9));
     assertFalse(IndexManager.setIndexBufferTime(1, 10));
 
-    // Now let's assume a new update has occured where the time is larger (enough to roll off the
+    // Now let's assume a new update has occurred where the time is larger (enough to roll off the
     // large delta)
     // but the delta is smaller
     assertTrue(IndexManager.setIndexBufferTime(30, 30));

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/AsynchIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/AsynchIndexMaintenanceJUnitTest.java
@@ -49,7 +49,7 @@ public class AsynchIndexMaintenanceJUnitTest {
   private Region region;
 
   private boolean indexUsed = false;
-  private volatile boolean exceptionOccured = false;
+  private volatile boolean exceptionOccurred = false;
 
   private Set idSet;
 
@@ -233,7 +233,7 @@ public class AsynchIndexMaintenanceJUnitTest {
             }
           } catch (Exception e) {
             CacheUtils.getLogger().error(e);
-            exceptionOccured = true;
+            exceptionOccurred = true;
           }
         }
       });
@@ -247,9 +247,9 @@ public class AsynchIndexMaintenanceJUnitTest {
       }
     } catch (Exception e) {
       CacheUtils.getLogger().error(e);
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    assertFalse(exceptionOccured);
+    assertFalse(exceptionOccurred);
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/HashIndexSetJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/HashIndexSetJUnitTest.java
@@ -139,7 +139,7 @@ public class HashIndexSetJUnitTest {
     his.hashIndexSetProperties.removedTokens = his.hashIndexSetProperties.maxSize;
     addPortfoliosToHashIndexSet(portfoliosMap, his);
 
-    // compaction should have occured, removed tokens should now be gone
+    // compaction should have occurred, removed tokens should now be gone
     assertEquals(0, his.hashIndexSetProperties.removedTokens);
     assertEquals(numEntries, his.size());
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryCacheClosedJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryCacheClosedJUnitTest.java
@@ -212,10 +212,10 @@ public class PRQueryCacheClosedJUnitTest {
       ThreadUtils.join(t1, 30 * 1000);
       ThreadUtils.join(t2, 30 * 1000);
       logger.info(
-          "PRQueryCacheClosedJUnitTest#testQueryOnSingleDataStoreWithCacheClose: checking for any Unexpected Exception's occured");
+          "PRQueryCacheClosedJUnitTest#testQueryOnSingleDataStoreWithCacheClose: checking for any Unexpected Exception's occurred");
 
       assertFalse(
-          "PRQueryCacheClosedJUnitTest#testQueryOnSingleDataStoreWithCacheClose: Exception occured in Query-thread: "
+          "PRQueryCacheClosedJUnitTest#testQueryOnSingleDataStoreWithCacheClose: Exception occurred in Query-thread: "
               + errorBuf,
           encounteredException);
     } catch (Exception e) {

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryRegionClosedJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryRegionClosedJUnitTest.java
@@ -204,10 +204,10 @@ public class PRQueryRegionClosedJUnitTest {
       t2.join(30000);
       assertFalse(t2.isAlive());
       logger.info(
-          "PRQueryRegionClosedJUnitTest#testQueryingWithRegionClose: checking for any Unexpected Exception's occured");
+          "PRQueryRegionClosedJUnitTest#testQueryingWithRegionClose: checking for any Unexpected Exception's occurred");
 
       assertFalse(
-          "PRQueryRegionClosedJUnitTest#testQueryingWithRegionClose: Exception occured in Query-thread",
+          "PRQueryRegionClosedJUnitTest#testQueryingWithRegionClose: Exception occurred in Query-thread",
           encounteredException);
     } catch (Exception e) {
       e.printStackTrace();

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryRegionDestroyedJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryRegionDestroyedJUnitTest.java
@@ -202,10 +202,10 @@ public class PRQueryRegionDestroyedJUnitTest {
       ThreadUtils.join(t1, 30 * 1000);
       ThreadUtils.join(t2, 30 * 1000);
       logger.info(
-          "PRQueryRegionDestroyedJUnitTest#testQueryOnSingleDataStore: checking for any Unexpected Exception's occured");
+          "PRQueryRegionDestroyedJUnitTest#testQueryOnSingleDataStore: checking for any Unexpected Exception's occurred");
 
       assertFalse(
-          "PRQueryRegionDestroyedJUnitTest#testQueryOnSingleDataStore: Exception occured in Query-thread",
+          "PRQueryRegionDestroyedJUnitTest#testQueryOnSingleDataStore: Exception occurred in Query-thread",
           encounteredException);
     } catch (Exception e) {
       e.printStackTrace();

--- a/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
@@ -641,7 +641,7 @@ public class DiskRegionDUnitTest extends JUnit4CacheTestCase {
             fail("The values should have been evicted to disk, for key: " + "Key-" + i);
           }
         } catch (EntryNotFoundException e) {
-          fail("Entry not found not expected but occured ");
+          fail("Entry not found not expected but occurred ");
         }
       }
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
@@ -63,7 +63,7 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
 
   transient private static CountDownLatch clearLatch = new CountDownLatch(1);
 
-  static Boolean clearOccured = false;
+  static Boolean clearOccurred = false;
 
   public Bug37377DUnitTest() {
     super();
@@ -291,11 +291,11 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
     public boolean initialImageInit(final LocalRegion r, final long lastModifiedTime,
         final Object newValue, final boolean create, final boolean wasRecovered,
         final boolean versionTagAccepted) throws RegionClearedException {
-      synchronized (clearOccured) {
-        if (!clearOccured) {
+      synchronized (clearOccurred) {
+        if (!clearOccurred) {
           // Force other member to perform a clear during our GII
           invokeRemoteClearAndWait(otherVM, thisVM);
-          clearOccured = true;
+          clearOccurred = true;
         }
       }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentFlushingAndRegionOperationsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentFlushingAndRegionOperationsJUnitTest.java
@@ -61,7 +61,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
       assertEquals("Value2", region.get("Key"));
       assertEquals("Value2", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("Entry not found although was supposed to be there");
     }
   }
@@ -91,7 +91,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
     try {
       assertEquals("Value1", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("Entry not found although was supposed to be there");
     }
   }
@@ -110,8 +110,8 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
           try {
             region.destroy("Key");
           } catch (Exception e) {
-            logWriter.error("Exception occured", e);
-            fail("Exception occured when it was not supposed to occur");
+            logWriter.error("Exception occurred", e);
+            fail("Exception occurred when it was not supposed to occur");
           }
         }
         alreadyComeHere = true;
@@ -163,8 +163,8 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
               Thread.currentThread().interrupt();
             }
           } catch (Exception e) {
-            logWriter.error("Exception occured", e);
-            fail("Exception occured when it was not supposed to occur");
+            logWriter.error("Exception occurred", e);
+            fail("Exception occurred when it was not supposed to occur");
           }
         }
         alreadyComeHere = true;
@@ -179,7 +179,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
           region.wait();
         }
       } catch (InterruptedException e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail("interrupted");
       }
     }
@@ -207,8 +207,8 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
               Thread.currentThread().interrupt();
             }
           } catch (Exception e) {
-            logWriter.error("Exception occured", e);
-            fail("Exception occured when it was not supposed to occur");
+            logWriter.error("Exception occurred", e);
+            fail("Exception occurred when it was not supposed to occur");
           }
         }
         alreadyComeHere = true;
@@ -223,7 +223,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
           region.wait();
         }
       } catch (InterruptedException e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail("interrupted");
       }
     }
@@ -290,7 +290,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
       // region.getCache().getLogger().info("getting value2");
       assertEquals("Value2", region.get("Key"));
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("Entry not found although was supposed to be there");
     }
 
@@ -299,7 +299,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
     try {
       assertEquals("Value2", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("Entry not found although was supposed to be there");
     }
 
@@ -322,7 +322,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
     try {
       assertEquals("Value1", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("Entry not found although was supposed to be there");
     }
   }
@@ -337,7 +337,7 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
 
             region.destroy("Key");
           } catch (Exception e1) {
-            logWriter.error("Exception occured", e1);
+            logWriter.error("Exception occurred", e1);
             fail("encounter exception when not expected " + e1);
           }
         }
@@ -544,11 +544,11 @@ public class ConcurrentFlushingAndRegionOperationsJUnitTest extends DiskRegionTe
           hasBeenNotified = true;
         }
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         testFailed = true;
         failureCause =
-            "Exception occured when it was not supposed to occur, due to " + e + "in Close::run";
-        fail("Exception occured when it was not supposed to occur, due to " + e);
+            "Exception occurred when it was not supposed to occur, due to " + e + "in Close::run";
+        fail("Exception occurred when it was not supposed to occur, due to " + e);
       }
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentRegionOperationsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentRegionOperationsJUnitTest.java
@@ -70,15 +70,15 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
    */
   protected int TIME_TO_RUN = 1000;
 
-  private boolean exceptionOccuredInPuts = false;
+  private boolean exceptionOccurredInPuts = false;
 
-  private boolean exceptionOccuredInGets = false;
+  private boolean exceptionOccurredInGets = false;
 
-  private boolean exceptionOccuredInDestroys = false;
+  private boolean exceptionOccurredInDestroys = false;
 
-  private boolean exceptionOccuredInClears = false;
+  private boolean exceptionOccurredInClears = false;
 
-  protected boolean exceptionOccuredInForceRolls = false;
+  protected boolean exceptionOccurredInForceRolls = false;
 
   // if this test is to run for a longer time, make this true
   private static final boolean longTest = false;
@@ -330,13 +330,13 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
       try {
         region.get("" + 1);
       } catch (Exception e) {
-        logWriter.severe("Exception occured  ", e);
+        logWriter.severe("Exception occurred  ", e);
         fail(
             "Failed to retrieve value from disk as the Oplog has been rolled but entry still references the Oplog.");
       }
 
     } catch (Exception e) {
-      logWriter.severe("Exception occured  ", e);
+      logWriter.severe("Exception occurred  ", e);
       fail("Test failed because  of unexpected exception");
     }
 
@@ -518,23 +518,23 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
     }
     r1.close();
 
-    if (exceptionOccuredInDestroys) {
-      fail("Exception occured while destroying");
+    if (exceptionOccurredInDestroys) {
+      fail("Exception occurred while destroying");
     }
-    if (exceptionOccuredInClears) {
-      fail("Exception occured while clearing");
-    }
-
-    if (exceptionOccuredInForceRolls) {
-      fail("Exception occured while force Rolling");
+    if (exceptionOccurredInClears) {
+      fail("Exception occurred while clearing");
     }
 
-    if (exceptionOccuredInGets) {
-      fail("Exception occured while doing gets");
+    if (exceptionOccurredInForceRolls) {
+      fail("Exception occurred while force Rolling");
     }
 
-    if (exceptionOccuredInPuts) {
-      fail("Exception occured while doing puts");
+    if (exceptionOccurredInGets) {
+      fail("Exception occurred while doing gets");
+    }
+
+    if (exceptionOccurredInPuts) {
+      fail("Exception occurred while doing puts");
     }
 
     return region2;
@@ -590,8 +590,8 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
           expected = region2.put(integer1, integer2);
         }
       } catch (Exception e) {
-        exceptionOccuredInPuts = true;
-        logWriter.severe("Exception occured in puts ", e);
+        exceptionOccurredInPuts = true;
+        logWriter.severe("Exception occurred in puts ", e);
         fail(" failed during put due to " + e);
       }
     } finally {
@@ -627,8 +627,8 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
           expected = region2.get(integer1);
         }
       } catch (Exception e) {
-        exceptionOccuredInGets = true;
-        logWriter.severe("Exception occured in get ", e);
+        exceptionOccurredInGets = true;
+        logWriter.severe("Exception occurred in get ", e);
         throw new AssertionError(" failed during get due to ", e);
       }
     } finally {
@@ -642,8 +642,8 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
   }
 
   void destroy() {
-    Exception exceptionOccured1 = null;
-    Exception exceptionOccured2 = null;
+    Exception exceptionOccurred1 = null;
+    Exception exceptionOccurred2 = null;
     int randomInt1 = random.nextInt() % 10;
     if (randomInt1 < 0) {
       randomInt1 = randomInt1 * (-1);
@@ -660,20 +660,20 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
       try {
         v = region1.destroy(integer1);
       } catch (Exception e) {
-        exceptionOccured1 = e;
+        exceptionOccurred1 = e;
       }
       if (this.validate) {
         try {
           expected = region2.destroy(integer1);
         } catch (Exception e) {
-          exceptionOccured2 = e;
+          exceptionOccurred2 = e;
         }
 
-        if ((exceptionOccured1 != null) ^ (exceptionOccured2 != null)) {
-          exceptionOccuredInDestroys = true;
-          logWriter.severe("Exception occured in destroy ex1=" + exceptionOccured1 + " ex2="
-              + exceptionOccured2);
-          fail("Exception occured in destroy");
+        if ((exceptionOccurred1 != null) ^ (exceptionOccurred2 != null)) {
+          exceptionOccurredInDestroys = true;
+          logWriter.severe("Exception occurred in destroy ex1=" + exceptionOccurred1 + " ex2="
+              + exceptionOccurred2);
+          fail("Exception occurred in destroy");
         }
       }
     } finally {
@@ -696,15 +696,15 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
     try {
       region1.clear();
     } catch (Exception e) {
-      exceptionOccuredInClears = true;
-      logWriter.severe("Exception occured in clear=", e);
-      throw new AssertionError("Exception occured in clear", e);
+      exceptionOccurredInClears = true;
+      logWriter.severe("Exception occurred in clear=", e);
+      throw new AssertionError("Exception occurred in clear", e);
     }
   }
 
   /**
    * Bug Test for bug # 35139. This bug was occuring because a clear & region destroy operation
-   * occured near concurrently. The region destroy operation notified the roller thread to stop &
+   * occurred near concurrently. The region destroy operation notified the roller thread to stop &
    * then it joined with the roller . But by that time clear operation created a new instance of
    * roller thread ( because a clear operation stop/starts the roller) & the destroy operation
    * actually joined with the new thread ( different from the one on which notification was issued
@@ -824,9 +824,9 @@ public class ConcurrentRegionOperationsJUnitTest extends DiskRegionTestingBase {
       try {
         region1.forceRolling();
       } catch (Exception e) {
-        exceptionOccuredInForceRolls = true;
-        logWriter.severe("Exception occured in forceRolling ", e);
-        throw new AssertionError(" Exception occured here", e);
+        exceptionOccurredInForceRolls = true;
+        logWriter.severe("Exception occurred in forceRolling ", e);
+        throw new AssertionError(" Exception occurred here", e);
       }
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentRollingAndRegionOperationsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ConcurrentRollingAndRegionOperationsJUnitTest.java
@@ -79,7 +79,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
     try {
       assertEquals("Value2", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       throw new AssertionError("Entry not found although was supposed to be there", e);
     }
   }
@@ -114,7 +114,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
       assertEquals("Value1", getValueOnDisk(region));
       assertEquals("Value1", getValueInHTree(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       throw new AssertionError("Entry not found although was supposed to be there", e);
     }
   }
@@ -144,7 +144,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
     try {
       region.destroy("Key");
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       throw new AssertionError("failed while trying to destroy due to ", e);
     }
     boolean entryNotFound = false;
@@ -239,7 +239,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
     try {
       assertEquals("Value2", getValueOnDisk(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       throw new AssertionError("Entry not found although was supposed to be there", e);
     }
   }
@@ -271,7 +271,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
       assertEquals("Value1", getValueOnDisk(region));
       assertEquals("Value1", getValueInHTree(region));
     } catch (EntryNotFoundException e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       throw new AssertionError("Entry not found although was supposed to be there", e);
     }
   }
@@ -301,7 +301,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
     try {
       region.destroy("Key");
     } catch (Exception e1) {
-      logWriter.error("Exception occured", e1);
+      logWriter.error("Exception occurred", e1);
       throw new AssertionError("encounter exception when not expected ", e1);
     }
     boolean entryNotFound = false;
@@ -663,7 +663,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
                 Thread.sleep(2000);
               } catch (InterruptedException e) {
                 testFailed = true;
-                failureCause = "Exception occured when it was not supposed to occur, Exception is "
+                failureCause = "Exception occurred when it was not supposed to occur, Exception is "
                     + e + "in concurrentPutAndRoll";
                 throw new AssertionError("exception not expected here", e);
               }
@@ -679,7 +679,7 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
             }
           } catch (InterruptedException e) {
             testFailed = true;
-            failureCause = "Exception occured when it was not supposed to occur, Exception is " + e
+            failureCause = "Exception occurred when it was not supposed to occur, Exception is " + e
                 + "in concurrentPutAndRoll";
             throw new AssertionError("exception not expected here", e);
           }
@@ -819,8 +819,8 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
           th.start();
           Thread.sleep(3000);
         } catch (Exception e) {
-          logWriter.error("Exception occured", e);
-          throw new AssertionError("Exception occured when it was not supposed to occur", e);
+          logWriter.error("Exception occurred", e);
+          throw new AssertionError("Exception occurred when it was not supposed to occur", e);
         }
       }
     });
@@ -856,8 +856,8 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
           th.start();
           Thread.sleep(3000);
         } catch (Exception e) {
-          logWriter.error("Exception occured", e);
-          throw new AssertionError("Exception occured when it was not supposed to occur", e);
+          logWriter.error("Exception occurred", e);
+          throw new AssertionError("Exception occurred when it was not supposed to occur", e);
         }
       }
     });
@@ -898,10 +898,11 @@ public class ConcurrentRollingAndRegionOperationsJUnitTest extends DiskRegionTes
           hasBeenNotified = true;
         }
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         testFailed = true;
-        failureCause = "Exception occured when it was not supposed to occur, due to " + e;
-        throw new AssertionError("Exception occured when it was not supposed to occur, due to ", e);
+        failureCause = "Exception occurred when it was not supposed to occur, due to " + e;
+        throw new AssertionError("Exception occurred when it was not supposed to occur, due to ",
+            e);
       }
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -322,8 +322,8 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
     VM0.invoke(() -> DeltaPropagationDUnitTest.createDelta());
     VM0.invoke(() -> DeltaPropagationDUnitTest.createAnEntry());
     Thread.sleep(5000); // TODO: Find a better 'n reliable alternative
-    // assert overflow occured on client vm
-    verifyOverflowOccured(1L, 2);
+    // assert overflow occurred on client vm
+    verifyOverflowOccurred(1L, 2);
     VM0.invoke(() -> DeltaPropagationDUnitTest.updateDelta());
 
     waitForLastKey();
@@ -359,8 +359,8 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
     VM0.invoke(() -> DeltaPropagationDUnitTest.createDelta());
     VM0.invoke(() -> DeltaPropagationDUnitTest.createAnEntry());
     Thread.sleep(5000); // TODO: Find a better 'n reliable alternative
-    // assert overflow occured on client vm
-    verifyOverflowOccured(1L, 1);
+    // assert overflow occurred on client vm
+    verifyOverflowOccurred(1L, 1);
     VM0.invoke(() -> DeltaPropagationDUnitTest.updateDelta());
 
     waitForLastKey();
@@ -1037,7 +1037,7 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
     }
   }
 
-  public static void verifyOverflowOccured(long evictions, int regionsize) {
+  public static void verifyOverflowOccurred(long evictions, int regionsize) {
     EnableLRU cc =
         ((VMLRURegionMap) ((LocalRegion) cache.getRegion(regionName)).entries)._getCCHelper();
     Assert.assertTrue(cc.getStats().getEvictions() == evictions,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskLruRegRecoveryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskLruRegRecoveryJUnitTest.java
@@ -45,7 +45,7 @@ public class DiskLruRegRecoveryJUnitTest extends DiskRegionTestingBase {
           valuesInVm++;
         }
       } catch (EntryNotFoundException e) {
-        fail("Entry not found not expected but occured ");
+        fail("Entry not found not expected but occurred ");
       }
     }
     return valuesInVm;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegOplogSwtchingAndRollerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegOplogSwtchingAndRollerJUnitTest.java
@@ -861,7 +861,7 @@ public class DiskRegOplogSwtchingAndRollerJUnitTest extends DiskRegionTestingBas
    */
   @Test
   public void testDiskFullExcep() {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     int[] diskDirSize1 = new int[4];
     diskDirSize1[0] = 1048576;
     diskDirSize1[1] = 1048576;
@@ -894,9 +894,9 @@ public class DiskRegOplogSwtchingAndRollerJUnitTest extends DiskRegionTestingBas
       }
     } catch (DiskAccessException e) {
       logWriter.error("exception not expected", e);
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    if (exceptionOccured) {
+    if (exceptionOccurred) {
       fail("FAILED::DiskAccessException is Not expected here !!");
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegRecoveryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegRecoveryJUnitTest.java
@@ -542,7 +542,7 @@ public class DiskRegRecoveryJUnitTest extends DiskRegionTestingBase {
             serilizedValuesInVm++;
           }
         } catch (EntryNotFoundException e) {
-          fail("Entry not found not expected but occured ");
+          fail("Entry not found not expected but occurred ");
         }
       }
       // Test to see if values are in serialized form, when disk recovery is performed.
@@ -594,7 +594,7 @@ public class DiskRegRecoveryJUnitTest extends DiskRegionTestingBase {
         try {
           ((LocalRegion) region).getValueInVM(new Integer(i));
         } catch (EntryNotFoundException e) {
-          fail("Entry not found not expected but occured ");
+          fail("Entry not found not expected but occurred ");
         }
       }
 
@@ -603,7 +603,7 @@ public class DiskRegRecoveryJUnitTest extends DiskRegionTestingBase {
         try {
           Assert.assertTrue(((LocalRegion) region).getValueInVM(new Integer(i)) == null);
         } catch (EntryNotFoundException e) {
-          fail("Entry not found not expected but occured ");
+          fail("Entry not found not expected but occurred ");
         }
       }
       for (int i = 0; i < 1000; i++) {
@@ -611,7 +611,7 @@ public class DiskRegRecoveryJUnitTest extends DiskRegionTestingBase {
           Assert.assertTrue(
               ((LocalRegion) region).getValueOnDisk(new Integer(i)).equals(new Integer(i)));
         } catch (EntryNotFoundException e) {
-          fail("Entry not found not expected but occured ");
+          fail("Entry not found not expected but occurred ");
         }
       }
       // region.close();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionIllegalCacheXMLvaluesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionIllegalCacheXMLvaluesJUnitTest.java
@@ -40,7 +40,7 @@ public class DiskRegionIllegalCacheXMLvaluesJUnitTest {
   public void createRegion(String path) {
     DistributedSystem ds = null;
     try {
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       File dir = new File("testingDirectoryForXML");
       dir.mkdir();
       dir.deleteOnExit();
@@ -52,11 +52,11 @@ public class DiskRegionIllegalCacheXMLvaluesJUnitTest {
 
         CacheFactory.create(ds);
       } catch (IllegalArgumentException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         System.out.println(
             "ExpectedStrings: Received expected IllegalArgumentException:" + ex.getMessage());
       } catch (CacheXmlException ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         System.out
             .println("ExpectedStrings: Received expected CacheXmlException:" + ex.getMessage());
       } catch (Exception e) {
@@ -64,7 +64,7 @@ public class DiskRegionIllegalCacheXMLvaluesJUnitTest {
         fail("test failed due to " + e);
       }
 
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail(" exception did not occur although was expected");
       }
     } finally {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
@@ -57,7 +57,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
   private static volatile boolean hasNotified = false;
   private static volatile boolean putsHaveStarted = false;
 
-  private volatile boolean exceptionOccured = false;
+  private volatile boolean exceptionOccurred = false;
   private volatile boolean finished = false;
 
   private DiskRegionProperties diskProps = new DiskRegionProperties();
@@ -98,7 +98,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
 
   @Override
   protected final void postSetUp() throws Exception {
-    this.exceptionOccured = false;
+    this.exceptionOccurred = false;
     DiskStoreImpl.SET_IGNORE_PREALLOCATE = true;
   }
 
@@ -139,17 +139,17 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
 
     assertTrue(region.get("1") == null);
 
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Object result = ((LocalRegion) region).getValueOnDisk("1");
       if (result == null || result.equals(Token.TOMBSTONE)) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
     } catch (EntryNotFoundException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
 
-    if (!exceptionOccured) {
+    if (!exceptionOccurred) {
       fail("exception did not occur although was supposed to occur");
     }
 
@@ -831,7 +831,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         region.put("" + i, value);
       }
     } catch (DiskAccessException e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("FAILED::", e);
     }
 
@@ -841,7 +841,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       region.put("OK", value);
     } catch (DiskAccessException e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("FAILED::", e);
     }
 
@@ -884,7 +884,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         region.put("" + i, value);
       }
     } catch (DiskAccessException e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("FAILED::", e);
     }
 
@@ -940,7 +940,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         region.put("" + i, value);
       }
     } catch (DiskAccessException e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("FAILED::", e);
     }
 
@@ -950,7 +950,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       region.put("OK", value);
     } catch (DiskAccessException e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("FAILED::", e);
     }
 
@@ -986,7 +986,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     int[] diskSizes1 = ((LocalRegion) region).getDiskDirSizes();
 
     assertEquals(2048, diskSizes1[0]);
-    this.exceptionOccured = false;
+    this.exceptionOccurred = false;
     dskAccessExpHelperMethod(region, true/* synch mode */);
 
     // region.close(); // closes disk file which will flush all buffers
@@ -1020,7 +1020,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     int[] diskSizes1 = ((LocalRegion) region).getDiskDirSizes();
     assertEquals(diskDirSize1.length, 1);
     assertTrue("diskSizes != 2048 ", diskSizes1[0] == 2048);
-    this.exceptionOccured = false;
+    this.exceptionOccurred = false;
     this.dskAccessExpHelperMethod(region, false/* asynch mode */);
 
     // region.close(); // closes disk file which will flush all buffers
@@ -1040,7 +1040,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
             region.put("" + (synchMode ? 1 : i), value);
           }
         } catch (DiskAccessException e) {
-          logWriter.error("Exception occured but not expected", e);
+          logWriter.error("Exception occurred but not expected", e);
           testFailed = true;
           failureCause = "FAILED::" + e.toString();
           throw new AssertionError("FAILED::", e);
@@ -1072,24 +1072,25 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         // the space. Still the put operation must succeed.
         logWriter.info("Available disk space=" + availSpace + " MINIMUM STIPULATED SPACE="
             + DiskStoreImpl.MINIMUM_DIR_SIZE);
-        exceptionOccured = false/* availSpace >= DiskStoreImpl.MINIMUM_DIR_SIZE */; // @todo I see
-                                                                                    // this test
-                                                                                    // failing here
-                                                                                    // but I don't
-                                                                                    // know what it
-                                                                                    // means. My
-                                                                                    // availSpace is
-                                                                                    // 1052
-        if (exceptionOccured) {
+        exceptionOccurred = false/* availSpace >= DiskStoreImpl.MINIMUM_DIR_SIZE */; // @todo I see
+                                                                                     // this test
+                                                                                     // failing here
+                                                                                     // but I don't
+                                                                                     // know what it
+                                                                                     // means. My
+                                                                                     // availSpace
+                                                                                     // is
+                                                                                     // 1052
+        if (exceptionOccurred) {
           fail("FAILED::Available space should be less than Minimum Directory size("
               + DiskStoreImpl.MINIMUM_DIR_SIZE
               + ") as the operation would have violated the max directory size requirement availSpace="
               + availSpace);
         } else {
-          exceptionOccured = false /* availSpace >= 0 */; // @todo I see this test failing here but
-                                                          // I don't know what it means. My
-                                                          // availSpace is 1052
-          if (exceptionOccured) {
+          exceptionOccurred = false /* availSpace >= 0 */; // @todo I see this test failing here but
+                                                           // I don't know what it means. My
+                                                           // availSpace is 1052
+          if (exceptionOccurred) {
             fail(
                 "FAILED::Available space should be less than 0 as the operation would have violated the max directory size requirement availSpace="
                     + availSpace);
@@ -1107,7 +1108,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     assertFalse(failureCause, testFailed);
     assertFalse(
         "Expected situation of max directory size violation happening and available space less than zero did not happen  ",
-        exceptionOccured); // CC jade1d failure
+        exceptionOccurred); // CC jade1d failure
 
   }
 
@@ -1257,7 +1258,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       getInvalidEnt = region.get("key1");
     } catch (Exception e) {
-      logWriter.error("Exception occured but not expected", e);
+      logWriter.error("Exception occurred but not expected", e);
       throw new AssertionError("Failed while getting invalid entry:", e);
 
     }
@@ -1537,11 +1538,11 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
       cache.getLogger().info("waiting for clear to finish");
       ThreadUtils.join(th, 30 * 1000);
     } catch (Exception ie) {
-      DiskRegionJUnitTest.this.exceptionOccured = true;
+      DiskRegionJUnitTest.this.exceptionOccurred = true;
       DiskRegionJUnitTest.this.failureCause = ie.toString();
     }
 
-    assertFalse(this.failureCause, this.exceptionOccured);
+    assertFalse(this.failureCause, this.exceptionOccurred);
     NewLRUClockHand lruList = ((VMLRURegionMap) ((LocalRegion) region).entries)._getLruList();
     assertEquals(region.size(), 0);
     lruList.audit();
@@ -1581,7 +1582,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         // DistributedTestCase.join(th, 7 * 1000, null);
         // }
         // catch (Exception e) {
-        // DiskRegionJUnitTest.this.exceptionOccured = true;
+        // DiskRegionJUnitTest.this.exceptionOccurred = true;
         // DiskRegionJUnitTest.this.failureCause = e.toString();
         // }
       }
@@ -1589,7 +1590,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       region.clear();
       ThreadUtils.join(th, 30 * 1000);
-      assertFalse(this.failureCause, this.exceptionOccured);
+      assertFalse(this.failureCause, this.exceptionOccurred);
       // We expect 1 entry to exist, because the clear was triggered before
       // the update
       assertEquals(1, region.size());
@@ -1632,7 +1633,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         // DistributedTestCase.join(th, 10 * 1000, null);
         // }
         // catch (Exception e) {
-        // DiskRegionJUnitTest.this.exceptionOccured = true;
+        // DiskRegionJUnitTest.this.exceptionOccurred = true;
         // DiskRegionJUnitTest.this.failureCause = e.toString();
         // }
       }
@@ -1640,7 +1641,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       region.clear();
       ThreadUtils.join(th, 30 * 1000);
-      assertFalse(this.failureCause, this.exceptionOccured);
+      assertFalse(this.failureCause, this.exceptionOccurred);
       // We expect 1 entry to exist, because the clear was triggered before
       // the update
       assertEquals(1, region.size());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterface2JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterface2JUnitTest.java
@@ -49,7 +49,7 @@ import org.apache.geode.test.junit.categories.IntegrationTest;
 @Category(IntegrationTest.class)
 public class MapInterface2JUnitTest {
 
-  protected boolean afterClearCallbackOccured = false;
+  protected boolean afterClearCallbackOccurred = false;
   boolean mainThreadProceed = false;
 
   @Before
@@ -115,7 +115,7 @@ public class MapInterface2JUnitTest {
       public void afterRegionClear(RegionEvent event) {
         synchronized (MapInterface2JUnitTest.this) {
           event.getRegion().getCache().getLogger().info("afterRegionClear call back " + event);
-          afterClearCallbackOccured = true;
+          afterClearCallbackOccurred = true;
           MapInterface2JUnitTest.this.notify();
         }
       }
@@ -132,14 +132,14 @@ public class MapInterface2JUnitTest {
     }
     try {
       synchronized (this) {
-        if (!this.afterClearCallbackOccured) {
+        if (!this.afterClearCallbackOccurred) {
           this.wait(10000);
         }
       }
     } catch (InterruptedException ie) {
       fail(ie.toString());
     }
-    if (!this.afterClearCallbackOccured) {
+    if (!this.afterClearCallbackOccurred) {
       fail("afterClear Callback not issued");
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterfaceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterfaceJUnitTest.java
@@ -76,13 +76,13 @@ public class MapInterfaceJUnitTest {
     } catch (Exception e) {
       throw new AssertionError(" failed in creating region due to ", e);
     }
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       region.localClear();
     } catch (UnsupportedOperationException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    if (!exceptionOccured) {
+    if (!exceptionOccurred) {
       fail(" exception did not occur when it was supposed to occur");
     }
     region.close();
@@ -130,13 +130,13 @@ public class MapInterfaceJUnitTest {
     } catch (Exception e) {
       throw new AssertionError(" failed in creating region due to ", e);
     }
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       region.localClear();
     } catch (UnsupportedOperationException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    if (!exceptionOccured) {
+    if (!exceptionOccurred) {
       fail(" exception did not occur when it was supposed to occur");
     }
     region.close();
@@ -195,13 +195,13 @@ public class MapInterfaceJUnitTest {
     } catch (Exception e) {
       throw new AssertionError(" failed in creating region due to ", e);
     }
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       region.localClear();
     } catch (UnsupportedOperationException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    if (!exceptionOccured) {
+    if (!exceptionOccurred) {
       fail(" exception did not occur when it was supposed to occur");
     }
     region.close();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OplogJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OplogJUnitTest.java
@@ -86,7 +86,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
 
   protected long delta;
 
-  protected boolean flushOccuredAtleastOnce = false;
+  protected boolean flushOccurredAtleastOnce = false;
 
   volatile protected boolean assertDone = false;
 
@@ -406,7 +406,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     try {
       region.destroy(new Integer(0));
     } catch (EntryNotFoundException e1) {
-      logWriter.error("Exception occured", e1);
+      logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
@@ -420,7 +420,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     try {
       region.destroy(new Integer(0));
     } catch (EntryNotFoundException e1) {
-      logWriter.error("Exception occured", e1);
+      logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
@@ -434,7 +434,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     try {
       region.destroy(new Integer(0));
     } catch (EntryNotFoundException e1) {
-      logWriter.error("Exception occured", e1);
+      logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
@@ -608,7 +608,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       assertTrue(dr.getNoBuffer(entry.getDiskId()) == Token.INVALID);
 
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail(e.toString());
     }
     closeDown();
@@ -759,7 +759,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // Thread.sleep(4000);
   // }
   // catch (InterruptedException ie) {
-  // logWriter.error("Exception occured", ie);
+  // logWriter.error("Exception occurred", ie);
   // failureCause = "No guarantee of vaildity of result hence failing. Exception = "
   // + ie;
   // testFailed = true;
@@ -808,7 +808,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // Thread.sleep(5000);
   // }
   // catch (InterruptedException ie) {
-  // logWriter.error("Exception occured", ie);
+  // logWriter.error("Exception occurred", ie);
   // failureCause = "No guarantee of vaildity of result hence failing. Exception = "
   // + ie;
   // testFailed = true;
@@ -901,7 +901,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // CacheObserverHolder.setInstance(old);
   // }
   // catch (Exception e) {
-  // logWriter.error("Exception occured", e);
+  // logWriter.error("Exception occurred", e);
   // fail(e.toString());
   // }
   // assertFalse(failureCause, testFailed);
@@ -1491,7 +1491,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // {
 
   // synchronized (OplogJUnitTest.this) {
-  // flushOccuredAtleastOnce = true;
+  // flushOccurredAtleastOnce = true;
   // OplogJUnitTest.this.notify();
   // }
 
@@ -1524,9 +1524,9 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // "The number of operations did not cause asynch writer to run atleast once , the expected file
   // size = "
   // + expectedSize, expectedSize > 1000);
-  // if (!flushOccuredAtleastOnce) {
+  // if (!flushOccurredAtleastOnce) {
   // synchronized (this) {
-  // if (!flushOccuredAtleastOnce) {
+  // if (!flushOccurredAtleastOnce) {
   // try {
   // this.wait(20000);
   // }
@@ -1536,7 +1536,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // }
   // }
   // }
-  // if (!flushOccuredAtleastOnce) {
+  // if (!flushOccurredAtleastOnce) {
   // fail("In the wait duration , flush did not occur even once. Try increasing the wait time");
   // }
   // long actualFileSize = 0L;
@@ -1695,7 +1695,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       assertEquals(val_11, Token.LOCAL_INVALID);
 
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       // fail("The test failed due to exception = " + e);
       throw e;
     } finally {
@@ -1725,7 +1725,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       byte[] val_1 = ((byte[]) ((LocalRegion) region).getValueOnDiskOrBuffer("1"));
       assertEquals(val_1.length, 0);
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("The test failed due to exception = " + e);
     }
     closeDown();
@@ -1753,7 +1753,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       byte[] val_1 = ((byte[]) ((LocalRegion) region).getValueOnDiskOrBuffer("1"));
       assertEquals(val_1.length, 0);
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail("The test failed due to exception = " + e);
     }
     closeDown();
@@ -1870,7 +1870,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     try {
       region.put("key1", val);
     } catch (DiskAccessException dae) {
-      logWriter.error("Exception occured", dae);
+      logWriter.error("Exception occurred", dae);
       fail(
           "Test failed as DiskAccessException was encountered where as the operation should ideally have proceeded without issue . exception = "
               + dae);
@@ -3091,13 +3091,13 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     int sizeOfRegion = region.size();
     region.close();
     // this variable will set to false in the src code itself
-    // NewLBHTreeDiskRegion.setJdbmexceptionOccuredToTrueForTesting = true;
+    // NewLBHTreeDiskRegion.setJdbmexceptionOccurredToTrueForTesting = true;
     try {
       region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, null, Scope.LOCAL);
     } catch (Exception e) {
       fail("failed in recreating region due to" + e);
     } finally {
-      // NewLBHTreeDiskRegion.setJdbmexceptionOccuredToTrueForTesting = false;
+      // NewLBHTreeDiskRegion.setJdbmexceptionOccurredToTrueForTesting = false;
     }
     if (sizeOfRegion != region.size()) {
       fail(" Expected region size to be " + sizeOfRegion + " after recovery but it is "
@@ -3240,7 +3240,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
     final DiskRegion dr = ((LocalRegion) region).getDiskRegion();
     final Object lock = new Object();
-    final boolean[] exceptionOccured = new boolean[] {true};
+    final boolean[] exceptionOccurred = new boolean[] {true};
     final boolean[] okToExit = new boolean[] {false};
     final boolean[] switchExpected = new boolean[] {false};
 
@@ -3301,9 +3301,9 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
             if (after != oplog_2_size) {
               cache.getLogger().info(
                   "test failed before=" + before + " after=" + after + " oplogsSize=" + oplogsSize);
-              exceptionOccured[0] = true;
+              exceptionOccurred[0] = true;
             } else {
-              exceptionOccured[0] = false;
+              exceptionOccurred[0] = false;
             }
             LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
             lock.notify();
@@ -3341,7 +3341,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
           lock.wait(9000);
           assertTrue(okToExit[0]);
         }
-        assertFalse(exceptionOccured[0]);
+        assertFalse(exceptionOccurred[0]);
       }
 
       region.close();
@@ -3373,7 +3373,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // diskProps);
   // final DiskRegion dr = ((LocalRegion)region).getDiskRegion();
   // final Object lock = new Object();
-  // final boolean [] exceptionOccured = new boolean[] {true};
+  // final boolean [] exceptionOccurred = new boolean[] {true};
   // final boolean [] okToExit = new boolean[] {false};
 
   // CacheObserver old = CacheObserverHolder
@@ -3391,7 +3391,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // synchronized(lock) {
   // okToExit[0] = true;
   // long after = dr.getNextDir().getDirStatsDiskSpaceUsage();;
-  // exceptionOccured[0] = false;
+  // exceptionOccurred[0] = false;
   // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
   // lock.notify();
   // }
@@ -3410,7 +3410,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   // lock.wait(9000);
   // assertTrue(okToExit[0]);
   // }
-  // assertFalse(exceptionOccured[0]);
+  // assertFalse(exceptionOccurred[0]);
   // }
   // while (region.forceCompaction() != null) {
   // // wait until no more oplogs to compact

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionDestroyDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionDestroyDUnitTest.java
@@ -115,7 +115,7 @@ public class PartitionedRegionDestroyDUnitTest extends PartitionedRegionDUnitTes
 
         } catch (RegionDestroyedException e) {
           // getLogWriter().info (
-          // "RegionDestroyedException occured for Region = " + PR_PREFIX + j);
+          // "RegionDestroyedException occurred for Region = " + PR_PREFIX + j);
         }
         getCache().getLogger().info(
             "<ExpectedException action=remove>" + expectedExistsException + "</ExpectedException>");
@@ -158,7 +158,7 @@ public class PartitionedRegionDestroyDUnitTest extends PartitionedRegionDUnitTes
           }
         } catch (RegionDestroyedException e) {
           LogWriterUtils.getLogWriter()
-              .info("RegionDestroyedException occured for Region = " + PR_PREFIX + j);
+              .info("RegionDestroyedException occurred for Region = " + PR_PREFIX + j);
         }
         getCache().getLogger()
             .info("<ExpectedException action=remove>" + expectedException + "</ExpectedException>");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentPartitionedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentPartitionedRegionJUnitTest.java
@@ -322,7 +322,7 @@ public class PersistentPartitionedRegionJUnitTest {
           valuesInVm++;
         }
       } catch (EntryNotFoundException e) {
-        fail("Entry not found not expected but occured ");
+        fail("Entry not found not expected but occurred ");
       }
     }
     return valuesInVm;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
@@ -61,7 +61,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowandPersist due to " + e);
       }
       region.close();
@@ -73,7 +73,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowOnly due to " + e);
       }
       region.close();
@@ -85,7 +85,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowandPersist due to " + e);
       }
       region.close();
@@ -96,7 +96,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
     try {
       region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
     } catch (Exception e) {
-      logWriter.error("Exception occured", e);
+      logWriter.error("Exception occurred", e);
       fail(" Exception in createOverflowandPersist due to " + e);
     }
 
@@ -146,7 +146,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowandPersist due to " + e);
       }
       region.destroyRegion();
@@ -162,7 +162,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowOnly due to " + e);
       }
       region.destroyRegion();
@@ -178,7 +178,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       try {
         region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
       } catch (Exception e) {
-        logWriter.error("Exception occured", e);
+        logWriter.error("Exception occurred", e);
         fail(" Exception in createOverflowandPersist due to " + e);
       }
       region.destroyRegion();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
@@ -430,7 +430,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
      * DataPolicy.REPLICATE ));
      * 
      * DistributedTestCase.join(async[0], 50 * 1000, getLogWriter()); if (async[0].getException() !=
-     * null) { fail("UnExpected Exception Occured : ", async[0].getException()); } List l =
+     * null) { fail("UnExpected Exception Occurred : ", async[0].getException()); } List l =
      * (List)async[0].getReturnValue();
      */
     List l = (List) empty
@@ -468,7 +468,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
     ThreadUtils.join(async[0], 50 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(5001, l.size());
@@ -594,7 +594,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
     emptyServer1.invoke(() -> DistributedRegionFunctionExecutionDUnitTest.closeCacheHA());
     ThreadUtils.join(async[0], 4 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(5001, l.size());
@@ -952,7 +952,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
       executeInlineFunction();
       ds.disconnect();
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
@@ -1071,7 +1071,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
           noOfExecutionsCompleted_Inline++;
 
         } catch (Exception e) {
-          LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+          LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
           e.printStackTrace();
           Assert.fail("Test failed", e);
         }
@@ -1144,7 +1144,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   }
 
   /**
-   * Test the exception occured while invoking the function execution on all members of DS
+   * Test the exception occurred while invoking the function execution on all members of DS
    * 
    * Function throws the Exception, The check is added to for the no of function execution execption
    * in datatostore1
@@ -1220,7 +1220,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         } catch (Exception expected) {
           return Boolean.TRUE;
         }
-        fail("No exception Occured");
+        fail("No exception Occurred");
         return Boolean.FALSE;
       }
     });

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutionDUnitTest.java
@@ -410,7 +410,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
       }
       ds.disconnect();
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }
@@ -464,7 +464,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
         assertEquals(obj, "Success");
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }
@@ -501,7 +501,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
         assertTrue(obj instanceof MyFunctionExecutionException);
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }
@@ -599,7 +599,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
         assertEquals(obj, "Success");
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }
@@ -618,7 +618,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
       rc.getResult();
       fail("Test Failed");
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + expected.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + expected.getMessage());
       // boolean check = expected.getMessage().equals("Cannot return any result, as
       // Function.hasResult() is false");
       assertTrue(expected.getMessage()

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
@@ -110,7 +110,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -142,7 +142,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
@@ -350,7 +350,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
 
@@ -383,7 +383,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -1096,7 +1096,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occured : " + expected.getMessage());
+      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
@@ -317,7 +317,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
 
@@ -361,7 +361,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -1067,7 +1067,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occured : " + expected.getMessage());
+      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
@@ -362,7 +362,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
 
@@ -394,7 +394,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -1114,7 +1114,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occured : " + expected.getMessage());
+      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
@@ -928,7 +928,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
     ThreadUtils.join(async[0], 60 * 1000);
 
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -1022,7 +1022,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
     ThreadUtils.join(async[0], 60 * 1000);
 
     if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occured : ", async[0].getException());
+      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
     }
     List l = (List) async[0].getReturnValue();
     assertEquals(2, l.size());
@@ -1475,7 +1475,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         } catch (Exception expected) {
           // No data should cause exec to throw
-          LogWriterUtils.getLogWriter().warning("Exception Occured : " + expected.getMessage());
+          LogWriterUtils.getLogWriter().warning("Exception Occurred : " + expected.getMessage());
           // boolean expectedStr = expected.getMessage().startsWith("No target
           // node was found for routingKey");
           // assertTrue("Unexpected exception: " + expected, expectedStr);
@@ -2856,7 +2856,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
       rc.getResult();
       ds.disconnect();
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception Occured : " + e.getMessage());
+      LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
       e.printStackTrace();
       Assert.fail("Test failed", e);
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRPerformanceTestDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRPerformanceTestDUnitTest.java
@@ -252,7 +252,7 @@ public class PRPerformanceTestDUnitTest extends PartitionedRegionDUnitTestCase {
             ResultCollector rc = dataSet.execute(function.getId());
             list = (ArrayList) rc.getResult();
           } catch (Exception ex) {
-            LogWriterUtils.getLogWriter().info("Exception Occured :" + ex.getMessage());
+            LogWriterUtils.getLogWriter().info("Exception Occurred :" + ex.getMessage());
             Assert.fail("Test failed", ex);
           }
           Object val = list.get(0);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
@@ -40,7 +40,7 @@ public class BlockingHARegionJUnitTest {
   private static Cache cache = null;
 
   /** boolean to record an exception occurence in another thread **/
-  private static volatile boolean exceptionOccured = false;
+  private static volatile boolean exceptionOccurred = false;
   /** StringBuffer to store the exception **/
   private static StringBuffer exceptionString = new StringBuffer();
   /** boolen to quit the for loop **/
@@ -63,7 +63,7 @@ public class BlockingHARegionJUnitTest {
    */
   @Test
   public void testBoundedPuts() throws Exception {
-    exceptionOccured = false;
+    exceptionOccurred = false;
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
     HARegionQueue hrq = HARegionQueue.getHARegionQueueInstance("BlockingHARegionJUnitTest_Region",
@@ -78,7 +78,7 @@ public class BlockingHARegionJUnitTest {
     ThreadUtils.join(thread1, 30 * 1000);
     ThreadUtils.join(thread2, 30 * 1000);
 
-    if (exceptionOccured) {
+    if (exceptionOccurred) {
       fail(" Test failed due to " + exceptionString);
     }
 
@@ -95,7 +95,7 @@ public class BlockingHARegionJUnitTest {
    */
   @Test
   public void testPutBeingBlocked() throws Exception {
-    exceptionOccured = false;
+    exceptionOccurred = false;
     quitForLoop = false;
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
@@ -144,7 +144,7 @@ public class BlockingHARegionJUnitTest {
 
     ThreadUtils.join(thread1, 30 * 1000); // for completeness
     ThreadUtils.join(thread2, 30 * 1000);
-    if (exceptionOccured) {
+    if (exceptionOccurred) {
       fail(" Test failed due to " + exceptionString);
     }
     cache.close();
@@ -160,7 +160,7 @@ public class BlockingHARegionJUnitTest {
    */
   @Test
   public void testConcurrentPutsNotExceedingLimit() throws Exception {
-    exceptionOccured = false;
+    exceptionOccurred = false;
     quitForLoop = false;
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
@@ -228,7 +228,7 @@ public class BlockingHARegionJUnitTest {
   @Ignore("TODO: test is disabled")
   @Test
   public void testConcurrentPutsTakesNotExceedingLimit() throws Exception {
-    exceptionOccured = false;
+    exceptionOccurred = false;
     quitForLoop = false;
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
@@ -315,7 +315,7 @@ public class BlockingHARegionJUnitTest {
   @Test
   public void testHARQMaxCapacity_Bug37627() throws Exception {
     try {
-      exceptionOccured = false;
+      exceptionOccurred = false;
       quitForLoop = false;
       HARegionQueueAttributes harqa = new HARegionQueueAttributes();
       harqa.setBlockingQueueCapacity(1);
@@ -335,13 +335,13 @@ public class BlockingHARegionJUnitTest {
             hrq.put(new ConflatableObject("key3", "value1", id2, false, "region1"));
           } catch (Exception e) {
             exceptionString.append("First Put in region queue failed");
-            exceptionOccured = true;
+            exceptionOccurred = true;
           }
         }
       };
       t1.start();
       ThreadUtils.join(t1, 20 * 1000);
-      if (exceptionOccured) {
+      if (exceptionOccurred) {
         fail(" Test failed due to " + exceptionString);
       }
     } finally {
@@ -388,8 +388,8 @@ public class BlockingHARegionJUnitTest {
             break;
           }
         } catch (Exception e) {
-          exceptionOccured = true;
-          exceptionString.append(" Exception occured due to " + e);
+          exceptionOccurred = true;
+          exceptionString.append(" Exception occurred due to " + e);
         }
       }
     }
@@ -414,8 +414,8 @@ public class BlockingHARegionJUnitTest {
         try {
           assertNotNull(this.regionQueue.take());
         } catch (Exception e) {
-          exceptionOccured = true;
-          exceptionString.append(" Exception occured due to " + e);
+          exceptionOccurred = true;
+          exceptionString.append(" Exception occurred due to " + e);
         }
       }
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/BlockingHARegionQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/BlockingHARegionQueueJUnitTest.java
@@ -136,7 +136,7 @@ public class BlockingHARegionQueueJUnitTest extends HARegionQueueJUnitTest {
     assertNotNull(conf);
     hrq.remove();
     Awaitility.await().atMost(1, TimeUnit.MINUTES).until(() -> !t1.isAlive());
-    assertFalse("Exception occured in put-thread", encounteredException);
+    assertFalse("Exception occurred in put-thread", encounteredException);
 
   }
 
@@ -174,6 +174,6 @@ public class BlockingHARegionQueueJUnitTest extends HARegionQueueJUnitTest {
     waitAtLeast(1000, start, () -> {
       assertFalse("Put-thread blocked unexpectedly", t1.isAlive());
     });
-    assertFalse("Exception occured in put-thread", encounteredException);
+    assertFalse("Exception occurred in put-thread", encounteredException);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/Bug36853EventsExpiryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/Bug36853EventsExpiryDUnitTest.java
@@ -220,7 +220,7 @@ public class Bug36853EventsExpiryDUnitTest extends JUnit4CacheTestCase {
   }
 
   /**
-   * Waits for the listener to receive all events and validates that no exception occured in client
+   * Waits for the listener to receive all events and validates that no exception occurred in client
    */
   private static void validateEventCountAtClient() throws Exception {
     if (!proceedForValidation) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/EventIdOptimizationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/EventIdOptimizationDUnitTest.java
@@ -401,7 +401,7 @@ public class EventIdOptimizationDUnitTest extends JUnit4DistributedTestCase {
   }
 
   /**
-   * Waits for the listener to receive all events and validates that no exception occured in client
+   * Waits for the listener to receive all events and validates that no exception occurred in client
    */
   public static void verifyEventIdsOnClient2() {
     if (!proceedForValidation) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
@@ -300,7 +300,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
         hrq.getRegion().localDestroy(iterator.next());
       }
     } catch (Exception e) {
-      fail("Exception occured while trying to destroy region", e);
+      fail("Exception occurred while trying to destroy region", e);
     }
 
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -582,7 +582,7 @@ public class HARegionQueueJUnitTest {
           !(regionqueue.getEventsMapForTesting().size() == 0));
 
     } catch (Exception e) {
-      throw new AssertionError("Exception occured in test due to ", e);
+      throw new AssertionError("Exception occurred in test due to ", e);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
@@ -74,7 +74,7 @@ public class HARegionQueueStartStopJUnitTest {
   @Test
   public void testStartStop() {
     try {
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       Cache cache = createCache();
       createHARegionQueue("test", cache);
       Assert.assertTrue(HARegionQueue.getDispatchedMessagesMapForTesting() != null);
@@ -82,9 +82,9 @@ public class HARegionQueueStartStopJUnitTest {
       try {
         HARegionQueue.getDispatchedMessagesMapForTesting();
       } catch (NullPointerException e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail("Expected exception to occur but did not occur");
       }
       HARegionQueue.startHAServices((GemFireCacheImpl) cache);
@@ -93,9 +93,9 @@ public class HARegionQueueStartStopJUnitTest {
       try {
         HARegionQueue.getDispatchedMessagesMapForTesting();
       } catch (NullPointerException e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail("Expected exception to occur but did not occur");
       }
 
@@ -104,9 +104,9 @@ public class HARegionQueueStartStopJUnitTest {
       try {
         HARegionQueue.getDispatchedMessagesMapForTesting();
       } catch (NullPointerException e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail("Expected exception to occur but did not occur");
       }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HAInterestPart2DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HAInterestPart2DUnitTest.java
@@ -355,7 +355,7 @@ public class HAInterestPart2DUnitTest extends HAInterestTestCase {
     setClientServerObserverForBeforeInterestRecoveryFailure();
     primary.invoke(() -> HAInterestTestCase.startServer());
     waitForBeforeInterestRecoveryCallBack();
-    if (exceptionOccured) {
+    if (exceptionOccurred) {
       fail("The DSM could not ensure that server 1 is started & serevr 2 is stopped");
     }
     final Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HAInterestTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/HAInterestTestCase.java
@@ -94,7 +94,7 @@ public class HAInterestTestCase extends JUnit4DistributedTestCase {
   protected static VM server2 = null;
   protected static VM server3 = null;
 
-  protected volatile static boolean exceptionOccured = false;
+  protected volatile static boolean exceptionOccurred = false;
 
   @Override
   public final void postSetUp() throws Exception {
@@ -107,7 +107,7 @@ public class HAInterestTestCase extends JUnit4DistributedTestCase {
     PORT1 = ((Integer) server1.invoke(() -> HAInterestTestCase.createServerCache())).intValue();
     PORT2 = ((Integer) server2.invoke(() -> HAInterestTestCase.createServerCache())).intValue();
     PORT3 = ((Integer) server3.invoke(() -> HAInterestTestCase.createServerCache())).intValue();
-    exceptionOccured = false;
+    exceptionOccurred = false;
     IgnoredException.addIgnoredException("java.net.ConnectException: Connection refused: connect");
   }
 
@@ -317,7 +317,7 @@ public class HAInterestTestCase extends JUnit4DistributedTestCase {
           try {
             ThreadUtils.join(t, 30 * 1000);
           } catch (Exception ignore) {
-            exceptionOccured = true;
+            exceptionOccurred = true;
           }
           HAInterestTestCase.isBeforeInterestRecoveryCallbackCalled = true;
           HAInterestTestCase.class.notify();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/InterestListDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/InterestListDUnitTest.java
@@ -273,7 +273,7 @@ public class InterestListDUnitTest extends JUnit4DistributedTestCase {
   /**
    * one server two clients create Entries in all the vms server directly puts some values then both
    * clients connect to the server c1 register(k1,k2,k3) and c2 register (k4,k5) then verify that
-   * updates has occured as a result of interest registration.
+   * updates has occurred as a result of interest registration.
    */
   @Test
   public void testInitializationOfRegionFromInterestList() throws Exception {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/NewRegionAttributesDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/NewRegionAttributesDUnitTest.java
@@ -273,74 +273,74 @@ public class NewRegionAttributesDUnitTest extends JUnit4DistributedTestCase {
     for (int i = 0; i < totalKeys; i++) {
       keylist.add("key-" + i);
     }
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     // test registerInterest(key)
     try {
       region1.registerInterest("DummyKey1");
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("UnsupportedOperationException was not thrown as expected for registerInterest(key)");
     }
 
     // test registerInterest(key,policy)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.registerInterest("DummyKey2", policy);
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for  registerInterest(key,policy)");
     }
 
     // test registerInterest(keylist)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.registerInterest(keylist);
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for registerInterest(keylist)");
     }
 
     // test registerInterest(keylist,policy)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.registerInterest(keylist, policy);
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for registerInterest(keylist,policy)");
     }
 
     // test registerInterestRegex(expr)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.registerInterestRegex("ke?");
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for registerInterestRegex(expr)");
     }
 
     // test registerInterestRegex(expr,policy)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.registerInterestRegex("ke?", InterestResultPolicy.KEYS_VALUES);
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for registerInterestRegex(expr,policy)");
     }
@@ -363,37 +363,37 @@ public class NewRegionAttributesDUnitTest extends JUnit4DistributedTestCase {
     }
 
     // test unregisterInterest(key)
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       region1.unregisterInterest("DummyKey1");
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for unregisterInterest(key)");
     }
 
     // test unregisterInterest(keylist)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.unregisterInterest(keylist);
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for unregisterInterest(keylist)");
     }
 
     // test unregisterInterestRegex(expr)
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.unregisterInterestRegex("kp?");
     } catch (UnsupportedOperationException expected) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail(
             "UnsupportedOperationException was not thrown as expected for unregisterInterestRegex(expr)");
     }
@@ -409,27 +409,27 @@ public class NewRegionAttributesDUnitTest extends JUnit4DistributedTestCase {
    */
   public static void getInterestForRegion() {
     Region region1 = cache.getRegion(Region.SEPARATOR + REGION_NAME);
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     // test getInterestList()
     try {
       region1.getInterestList();
     } catch (UnsupportedOperationException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("UnsupportedOperationException was not thrown as expected for getInterestList()");
     }
 
     // test getInterestListRegex()
 
-    exceptionOccured = false;
+    exceptionOccurred = false;
     try {
       region1.getInterestListRegex();
     } catch (UnsupportedOperationException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     } finally {
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("UnsupportedOperationException was not thrown as expected for getInterestListRegex()");
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/CleanUpJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/CleanUpJUnitTest.java
@@ -73,7 +73,7 @@ public class CleanUpJUnitTest {
         fail(
             "DataSourceFactoryTest-testGetSimpleDataSource() Error in creating the GemFireBasicDataSource");
     } catch (Exception e) {
-      fail("Exception occured in testGetSimpleDataSource due to " + e);
+      fail("Exception occurred in testGetSimpleDataSource due to " + e);
       e.printStackTrace();
     }
   }
@@ -104,7 +104,7 @@ public class CleanUpJUnitTest {
         fail("Clean-up on expiration not done");
       }
     } catch (Exception e) {
-      fail("Exception occured in testBlockingTimeOut due to " + e);
+      fail("Exception occurred in testBlockingTimeOut due to " + e);
       e.printStackTrace();
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/ConnectionPoolCacheImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/ConnectionPoolCacheImplJUnitTest.java
@@ -67,7 +67,7 @@ public class ConnectionPoolCacheImplJUnitTest {
       ds1 = DistributedSystem.connect(props);
       cache = CacheFactory.create(ds1);
     } catch (Exception e) {
-      fail("Exception occured in creation of ds and cache due to " + e);
+      fail("Exception occurred in creation of ds and cache due to " + e);
       e.printStackTrace();
     }
   }
@@ -97,7 +97,7 @@ public class ConnectionPoolCacheImplJUnitTest {
       ThreadB = new Thread(clientB, "ThreadB");
       ThreadA.start();
     } catch (Exception e) {
-      fail("Exception occured in testConnectionPoolFunctions due to " + e);
+      fail("Exception occurred in testConnectionPoolFunctions due to " + e);
       e.printStackTrace();
     }
   }
@@ -128,7 +128,7 @@ public class ConnectionPoolCacheImplJUnitTest {
           // System.out.println(" Got connection " + numConn + "from "+
           // threadName);
         } catch (Exception ex) {
-          fail("Exception occured in trying to getPooledConnectionfromPool due to " + ex);
+          fail("Exception occurred in trying to getPooledConnectionfromPool due to " + ex);
           ex.printStackTrace();
         }
       }
@@ -157,7 +157,7 @@ public class ConnectionPoolCacheImplJUnitTest {
           // System.out.println(" Returned connection " + display + "from "+
           // threadName);
         } catch (Exception ex) {
-          fail("Exception occured in trying to returnPooledConnectiontoPool due to " + ex);
+          fail("Exception occurred in trying to returnPooledConnectiontoPool due to " + ex);
           ex.printStackTrace();
         }
       }
@@ -185,7 +185,7 @@ public class ConnectionPoolCacheImplJUnitTest {
           // System.out.println(" ********** Got connection " + numConn2+ "from
           // " + threadName);
         } catch (Exception ex) {
-          fail("Exception occured in trying to getPooledConnectionFromPool due to " + ex);
+          fail("Exception occurred in trying to getPooledConnectionFromPool due to " + ex);
           ex.printStackTrace();
         }
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/ConnectionPoolingJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/ConnectionPoolingJUnitTest.java
@@ -273,7 +273,7 @@ public class ConnectionPoolingJUnitTest {
           // conn.close();
           logger.debug(" Returned connection " + display + "from " + threadName);
         } catch (Exception ex) {
-          fail("Exception occured in trying to returnPooledConnectiontoPool due to " + ex);
+          fail("Exception occurred in trying to returnPooledConnectiontoPool due to " + ex);
           ex.printStackTrace();
         }
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/jta/GlobalTransactionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/jta/GlobalTransactionJUnitTest.java
@@ -92,7 +92,7 @@ public class GlobalTransactionJUnitTest {
   @Test
   public void testEnlistResource() throws Exception {
     try {
-      boolean exceptionoccured = false;
+      boolean exceptionoccurred = false;
       utx.begin();
       try {
         Context ctx = cache.getJNDIContext();
@@ -100,10 +100,10 @@ public class GlobalTransactionJUnitTest {
             (GemFireTransactionDataSource) ctx.lookup("java:/XAPooledDataSource");
         ds.getConnection();
       } catch (SQLException e) {
-        exceptionoccured = true;
+        exceptionoccurred = true;
       }
-      if (exceptionoccured)
-        fail("SQLException occured while trying to enlist resource");
+      if (exceptionoccurred)
+        fail("SQLException occurred while trying to enlist resource");
       utx.rollback();
     } catch (Exception e) {
       try {
@@ -119,17 +119,17 @@ public class GlobalTransactionJUnitTest {
   @Test
   public void testRegisterSynchronization() throws Exception {
     try {
-      boolean exceptionoccured = false;
+      boolean exceptionoccurred = false;
       utx.begin();
       try {
         Transaction txn = tm.getTransaction();
         Synchronization sync = new SyncImpl();
         txn.registerSynchronization(sync);
       } catch (RollbackException e) {
-        exceptionoccured = true;
+        exceptionoccurred = true;
       }
-      if (exceptionoccured)
-        fail("exception occured while trying to register synchronization ");
+      if (exceptionoccurred)
+        fail("exception occurred while trying to register synchronization ");
       utx.rollback();
     } catch (Exception e) {
       try {
@@ -145,7 +145,7 @@ public class GlobalTransactionJUnitTest {
   @Test
   public void testEnlistResourceAfterRollBack() throws Exception {
     try {
-      boolean exceptionoccured = false;
+      boolean exceptionoccurred = false;
       utx.begin();
       utx.setRollbackOnly();
       Context ctx = cache.getJNDIContext();
@@ -154,10 +154,10 @@ public class GlobalTransactionJUnitTest {
             (GemFireTransactionDataSource) ctx.lookup("java:/XAPooledDataSource");
         ds.getConnection();
       } catch (SQLException e) {
-        exceptionoccured = true;
+        exceptionoccurred = true;
       }
-      if (!exceptionoccured)
-        fail("SQLException not occured although the transaction was marked for rollback");
+      if (!exceptionoccurred)
+        fail("SQLException not occurred although the transaction was marked for rollback");
       utx.rollback();
     } catch (Exception e) {
       try {
@@ -173,7 +173,7 @@ public class GlobalTransactionJUnitTest {
   @Test
   public void testRegisterSynchronizationAfterRollBack() throws Exception {
     try {
-      boolean exceptionoccured = false;
+      boolean exceptionoccurred = false;
       utx.begin();
       utx.setRollbackOnly();
       Context ctx = cache.getJNDIContext();
@@ -182,10 +182,10 @@ public class GlobalTransactionJUnitTest {
         Synchronization sync = new SyncImpl();
         txn.registerSynchronization(sync);
       } catch (RollbackException e) {
-        exceptionoccured = true;
+        exceptionoccurred = true;
       }
-      if (!exceptionoccured)
-        fail("RollbackException not occured although the transaction was marked for rollback");
+      if (!exceptionoccurred)
+        fail("RollbackException not occurred although the transaction was marked for rollback");
       utx.rollback();
     } catch (Exception e) {
       try {

--- a/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/ExceptionsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/ExceptionsDUnitTest.java
@@ -205,7 +205,7 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest1() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Context ctx = cache.getJNDIContext();
       DataSource ds1 = null;
@@ -221,9 +221,9 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception did not occur on commit although was supposed" + "occur");
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().fine("Exception caught in runTest1 due to : " + e);
@@ -232,8 +232,8 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest2() throws Exception {
-    boolean exceptionOccured1 = false;
-    boolean exceptionOccured2 = false;
+    boolean exceptionOccurred1 = false;
+    boolean exceptionOccurred2 = false;
     try {
       Context ctx = cache.getJNDIContext();
       DataSource ds1 = null;
@@ -252,16 +252,16 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
         ds1.getConnection();
         Thread.sleep(8000);
       } catch (SQLException e) {
-        exceptionOccured1 = true;
+        exceptionOccurred1 = true;
       }
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured2 = true;
+        exceptionOccurred2 = true;
       }
-      if (!exceptionOccured1)
+      if (!exceptionOccurred1)
         fail("Exception (Login-Time-Out)did not occur although was supposed" + "to occur");
-      if (exceptionOccured2)
+      if (exceptionOccurred2)
         fail("Exception did occur on commit, although was not supposed" + "to occur");
     } catch (Exception e) {
       fail("failed in runTest2 due to " + e);
@@ -269,7 +269,7 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest3() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Context ctx = cache.getJNDIContext();
       DataSource ds1 = null;
@@ -285,9 +285,9 @@ public class ExceptionsDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception (Transaction-Time-Out)did not occur although was supposed" + "to occur");
     } catch (Exception e) {
       fail("failed in runTest3 due to " + e);

--- a/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/TransactionTimeOutDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/TransactionTimeOutDUnitTest.java
@@ -194,7 +194,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest1() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -204,9 +204,9 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception did not occur although was supposed to occur");
     } catch (Exception e) {
       fail("failed in naming lookup: ", e);
@@ -214,7 +214,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest2() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -224,9 +224,9 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception did not occur although was supposed to occur");
     } catch (Exception e) {
       fail("failed in naming lookup: ", e);
@@ -248,7 +248,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest4() {
-    boolean exceptionOccured = true;
+    boolean exceptionOccurred = true;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -259,9 +259,9 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = false;
+        exceptionOccurred = false;
       }
-      if (exceptionOccured) {
+      if (exceptionOccurred) {
         fail("TimeOut did not rollback the transaction");
       }
     } catch (Exception e) {
@@ -270,7 +270,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest5() {
-    boolean exceptionOccured = true;
+    boolean exceptionOccurred = true;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -284,9 +284,9 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = false;
+        exceptionOccurred = false;
       }
-      if (exceptionOccured) {
+      if (exceptionOccurred) {
         fail("TimeOut did not rollback the transaction");
       }
     } catch (Exception e) {
@@ -295,7 +295,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest6() {
-    boolean exceptionOccured = true;
+    boolean exceptionOccurred = true;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -305,9 +305,9 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = false;
+        exceptionOccurred = false;
       }
-      if (exceptionOccured) {
+      if (exceptionOccurred) {
         fail("TimeOut did not rollback the transaction");
       }
     } catch (Exception e) {
@@ -316,7 +316,7 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest7() {
-    // boolean exceptionOccured = true;
+    // boolean exceptionOccurred = true;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -362,13 +362,13 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       sm.close();
       conn.close();
     } catch (Exception e) {
-      fail("Exception occured in test Commit due to ", e);
+      fail("Exception occurred in test Commit due to ", e);
     }
   }
 
   public static void runTest9() {
     try {
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       Context ctx = cache.getJNDIContext();
       DataSource ds2 = (DataSource) ctx.lookup("java:/SimpleDataSource");
       ds2.getConnection();
@@ -396,19 +396,19 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail("exception did not occur on commit although transaction timed out");
       }
     } catch (Exception e) {
-      fail("Exception occured in test Commit due to ", e);
+      fail("Exception occurred in test Commit due to ", e);
     }
   }
 
   public static void runTest10() {
     try {
-      boolean exceptionOccured = false;
+      boolean exceptionOccurred = false;
       Context ctx = cache.getJNDIContext();
       DataSource ds2 = (DataSource) ctx.lookup("java:/SimpleDataSource");
       ds2.getConnection();
@@ -436,13 +436,13 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.rollback();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured) {
+      if (!exceptionOccurred) {
         fail("exception did not occur on rollback although transaction timed out");
       }
     } catch (Exception e) {
-      fail("Exception occured in test Commit due to ", e);
+      fail("Exception occurred in test Commit due to ", e);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/TxnTimeOutDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/jta/dunit/TxnTimeOutDUnitTest.java
@@ -171,7 +171,7 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
 
 
     } catch (Exception e) {
-      fail("exception occured in testMultiThreaded due to " + e);
+      fail("exception occurred in testMultiThreaded due to " + e);
       e.printStackTrace();
     }
   }
@@ -196,7 +196,7 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest1() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       getSystemStatic().getLogWriter().fine("<ExpectedException action=add> +"
           + "DistributedSystemDisconnectedException" + "</ExpectedException>");
@@ -208,9 +208,9 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception did not occur although was supposed to occur");
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().fine("Exception caught " + e);
@@ -222,7 +222,7 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void runTest2() throws Exception {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     try {
       Context ctx = cache.getJNDIContext();
       UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -232,9 +232,9 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
       try {
         utx.commit();
       } catch (Exception e) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
       }
-      if (!exceptionOccured)
+      if (!exceptionOccurred)
         fail("Exception did not occur although was supposed to occur");
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().fine("Exception caught " + e);
@@ -244,7 +244,7 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
 
   public static void runTest3(Object o)
       throws SystemException, NotSupportedException, NamingException, InterruptedException {
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     int sleeptime = ((Integer) o).intValue();
     Context ctx = cache.getJNDIContext();
     UserTransaction utx = (UserTransaction) ctx.lookup("java:/UserTransaction");
@@ -254,9 +254,9 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
     try {
       utx.commit();
     } catch (Exception e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
-    if (!exceptionOccured) {
+    if (!exceptionOccurred) {
       fail("exception did not occur although was supposed to occur");
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
@@ -919,7 +919,7 @@ public class CacheJUnitTest {
     rs.next();
     String str1 = rs.getString(1);
     if (!str1.equals("name2"))
-      fail("Rollback not occured on XAConnection got in a cache loader");
+      fail("Rollback not occurred on XAConnection got in a cache loader");
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/security/ClientAuthorizationTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientAuthorizationTestCase.java
@@ -289,7 +289,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
     final int numOps = indices.length;
     System.out.println("Got doOp for op: " + op.toString() + ", numOps: " + numOps + ", indices: "
         + indicesToString(indices) + ", expect: " + expectedResult);
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
     boolean breakLoop = false;
 
     if (op.isGet() || op.isContainsKey() || op.isKeySet() || op.isQuery() || op.isExecuteCQ()) {
@@ -681,7 +681,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
         }
 
       } catch (Exception ex) {
-        exceptionOccured = true;
+        exceptionOccurred = true;
         if ((ex instanceof ServerConnectivityException
             || ex instanceof QueryInvocationTargetException || ex instanceof CqException)
             && (expectedResult == NOTAUTHZ_EXCEPTION)
@@ -698,7 +698,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
         }
       }
     }
-    if (!exceptionOccured && !operationOmitted && expectedResult != NO_EXCEPTION) {
+    if (!exceptionOccurred && !operationOmitted && expectedResult != NO_EXCEPTION) {
       fail("Expected an exception while performing operation: " + op + " flags = "
           + OpFlags.description(flags));
     }

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/internal/cq/CqEventImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/internal/cq/CqEventImpl.java
@@ -123,7 +123,7 @@ public class CqEventImpl implements CqEvent {
   public void setException() {
     // Needs to be changed.
     this.throwable = new Throwable(
-        LocalizedStrings.CqEventImpl_EXCEPTION_OCCURED_WHILE_APPLYING_QUERY_ON_A_CACHE_EVENT
+        LocalizedStrings.CqEventImpl_EXCEPTION_OCCURRED_WHILE_APPLYING_QUERY_ON_A_CACHE_EVENT
             .toLocalizedString());
   }
 

--- a/geode-docs/managing/troubleshooting/recovering_from_p2p_crashes.html.md.erb
+++ b/geode-docs/managing/troubleshooting/recovering_from_p2p_crashes.html.md.erb
@@ -170,7 +170,7 @@ Some general considerations for disk data recovery:
 Alert 1:
 
 ``` pre
-DiskAccessException has occured while writing to the disk for region <Region_Name>.
+DiskAccessException has occurred while writing to the disk for region <Region_Name>.
 Attempt will be made to destroy the region locally.
 ```
 

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
@@ -2351,7 +2351,7 @@ public class Cluster extends Thread {
     try {
       join();
     } catch (InterruptedException e) {
-      logger.info("InterruptedException occured while stoping cluster thread : ", e);
+      logger.info("InterruptedException occurred while stoping cluster thread : ", e);
     }
   }
 

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
@@ -1656,7 +1656,7 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
         return (Boolean) object;
       }
     } catch (Exception e) {
-      logger.info("Exception Occured: ", e);
+      logger.info("Exception Occurred: ", e);
       return Boolean.FALSE;
     }
   }

--- a/geode-pulse/src/main/webapp/scripts/lib/jquery-1.7.2.js
+++ b/geode-pulse/src/main/webapp/scripts/lib/jquery-1.7.2.js
@@ -8249,7 +8249,7 @@ if ( jQuery.support.ajax ) {
 							xml;
 
 						// Firefox throws exceptions when accessing properties
-						// of an xhr when a network error occured
+						// of an xhr when a network error occurred
 						// http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
 						try {
 

--- a/geode-pulse/src/main/webapp/scripts/pulsescript/common.js
+++ b/geode-pulse/src/main/webapp/scripts/pulsescript/common.js
@@ -1320,7 +1320,7 @@ function ajaxPost(pulseUrl, pulseData, pulseCallBackName) {
     // callback handler that will be called on error
     error : function(jqXHR, textStatus, errorThrown) {
       // log the error to the console
-      console.log("The following error occured: " + textStatus, errorThrown);
+      console.log("The following error occurred: " + textStatus, errorThrown);
       $('#connectionStatusDiv').show();
       $('#connectionErrorMsgDiv').html("Pulse server is not connected");
     },

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1242,9 +1242,9 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     assertTrue(stats instanceof GatewayReceiverStats);
     GatewayReceiverStats gatewayReceiverStats = (GatewayReceiverStats) stats;
     if (exceptionsOccurred == 0) {
-      assertEquals(exceptionsOccurred, gatewayReceiverStats.getExceptionsOccured());
+      assertEquals(exceptionsOccurred, gatewayReceiverStats.getExceptionsOccurred());
     } else {
-      assertTrue(gatewayReceiverStats.getExceptionsOccured() >= exceptionsOccurred);
+      assertTrue(gatewayReceiverStats.getExceptionsOccurred() >= exceptionsOccurred);
     }
   }
 


### PR DESCRIPTION
Most occurrences are in comments and string constants, but there are a nontrivial number of variable name changes as well.

Initial testing returns green across the board.