### PR TITLE
GEODE-2725: export logs now honors --dir when connected via JMX, with respect to the manager's filesystem.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogCommand.java
@@ -130,8 +130,7 @@ public class ExportLogCommand implements CommandMarker {
 
       Path tempDir = Files.createTempDirectory("exportedLogs");
       // make sure the directory is created, so that even if there is no files unzipped to this dir,
-      // we can
-      // still zip it and send an empty zip file back to the client
+      // we can still zip it and send an empty zip file back to the client
       Path exportedLogsDir = tempDir.resolve("exportedLogs");
       FileUtils.forceMkdir(exportedLogsDir.toFile());
 
@@ -142,9 +141,14 @@ public class ExportLogCommand implements CommandMarker {
         FileUtils.deleteQuietly(zipFile.toFile());
       }
 
-      Path workingDir = Paths.get(System.getProperty("user.dir"));
-      Path exportedLogsZipFile = workingDir
-          .resolve("exportedLogs_" + System.currentTimeMillis() + ".zip").toAbsolutePath();
+      Path dirPath;
+      if (StringUtils.isBlank(dirName)) {
+        dirPath = Paths.get(System.getProperty("user.dir"));
+      } else {
+        dirPath = Paths.get(dirName);
+      }
+      Path exportedLogsZipFile =
+          dirPath.resolve("exportedLogs_" + System.currentTimeMillis() + ".zip").toAbsolutePath();
 
       logger.info("Zipping into: " + exportedLogsZipFile.toString());
       ZipUtils.zipDirectory(exportedLogsDir, exportedLogsZipFile);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1391,7 +1391,7 @@ public class CliStrings {
   public static final String EXPORT_LOGS__HELP = "Export the log files for a member or members.";
   public static final String EXPORT_LOGS__DIR = "dir";
   public static final String EXPORT_LOGS__DIR__HELP =
-      "Local directory to which logs will be written. This is used only when you are exporting logs using an http connection. If not specified, logs are written to the location specified by the user.dir system property.";
+      "Directory to which logs will be written.  This respects the local filesystem when connected via HTTP and the manager's filesystem when connected via JMX.  If not specified, logs are written to the location specified by the user.dir system property.";
   public static final String EXPORT_LOGS__MEMBER = "member";
   public static final String EXPORT_LOGS__MEMBER__HELP =
       "Name/Id of the member whose log files will be exported.";

--- a/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
+++ b/geode-core/src/test/resources/org/apache/geode/management/internal/cli/commands/golden-help-offline.properties
@@ -1473,9 +1473,9 @@ SYNTAX\n\
 \ \ \ \ [--end-time=value] [--logs-only(=value)?] [--stats-only(=value)?]\n\
 PARAMETERS\n\
 \ \ \ \ dir\n\
-\ \ \ \ \ \ \ \ Local directory to which logs will be written. This is used only when you are exporting\n\
-\ \ \ \ \ \ \ \ logs using an http connection. If not specified, logs are written to the location specified\n\
-\ \ \ \ \ \ \ \ by the user.dir system property.\n\
+\ \ \ \ \ \ \ \ Directory to which logs will be written.  This respects the local filesystem when\n\
+\ \ \ \ \ \ \ \ connected via HTTP and the manager's filesystem when connected via JMX.  If not\n\
+\ \ \ \ \ \ \ \ specified, logs are written to the location specified by the user.dir system property.\n\
 \ \ \ \ \ \ \ \ Required: false\n\
 \ \ \ \ group\n\
 \ \ \ \ \ \ \ \ Group of members whose log files will be exported.\n\


### PR DESCRIPTION
Unchanged behavior of --dir when connected via HTTP.