### PR TITLE
GEODE-2725: export logs now honors --dir when connected via JMX, with respect to the manager filesystem.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
@@ -170,8 +170,7 @@ public class ExportLogsCommand implements CommandMarker {
 
       Path tempDir = Files.createTempDirectory("exportedLogs");
       // make sure the directory is created, so that even if there is no files unzipped to this dir,
-      // we can
-      // still zip it and send an empty zip file back to the client
+      // we can still zip it and send an empty zip file back to the client
       Path exportedLogsDir = tempDir.resolve("exportedLogs");
       FileUtils.forceMkdir(exportedLogsDir.toFile());
 
@@ -182,9 +181,14 @@ public class ExportLogsCommand implements CommandMarker {
         FileUtils.deleteQuietly(zipFile.toFile());
       }
 
-      Path workingDir = Paths.get(System.getProperty("user.dir"));
-      Path exportedLogsZipFile = workingDir
-          .resolve("exportedLogs_" + System.currentTimeMillis() + ".zip").toAbsolutePath();
+      Path dirPath;
+      if (StringUtils.isBlank(dirName)) {
+        dirPath = Paths.get(System.getProperty("user.dir"));
+      } else {
+        dirPath = Paths.get(dirName);
+      }
+      Path exportedLogsZipFile =
+          dirPath.resolve("exportedLogs_" + System.currentTimeMillis() + ".zip").toAbsolutePath();
 
       logger.info("Zipping into: " + exportedLogsZipFile.toString());
       ZipUtils.zipDirectory(exportedLogsDir, exportedLogsZipFile);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsInterceptor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsInterceptor.java
@@ -85,9 +85,9 @@ public class ExportLogsInterceptor extends AbstractCliAroundInterceptor {
       Path dirPath;
       String dirName = parseResult.getParamValueStrings().get("dir");
       if (StringUtils.isBlank(dirName)) {
-        dirPath = Paths.get(System.getProperty("user.dir"));
+        dirPath = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
       } else {
-        dirPath = Paths.get(dirName);
+        dirPath = Paths.get(dirName).toAbsolutePath();
       }
       String fileName = "exportedLogs_" + System.currentTimeMillis() + ".zip";
       File exportedLogFile = dirPath.resolve(fileName).toFile();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1391,7 +1391,7 @@ public class CliStrings {
   public static final String EXPORT_LOGS__HELP = "Export the log files for a member or members.";
   public static final String EXPORT_LOGS__DIR = "dir";
   public static final String EXPORT_LOGS__DIR__HELP =
-      "Directory to which logs will be written.  This refers to a local directory when exporting logs using an http connection, but refers to the filesystem of the manager when connected via JMX. If not specified, logs are written to the location specified by the user.dir system property.";
+      "Directory to which logs will be written.  This respects the local filesystem when connected via HTTP and the manager's filesystem when connected via JMX.  If not specified, logs are written to the location specified by the user.dir system property.";
   public static final String EXPORT_LOGS__MEMBER = "member";
   public static final String EXPORT_LOGS__MEMBER__HELP =
       "Name/Id of the member whose log files will be exported.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1391,7 +1391,7 @@ public class CliStrings {
   public static final String EXPORT_LOGS__HELP = "Export the log files for a member or members.";
   public static final String EXPORT_LOGS__DIR = "dir";
   public static final String EXPORT_LOGS__DIR__HELP =
-      "Directory to which logs will be written.  This respects the local filesystem when connected via HTTP and the manager's filesystem when connected via JMX.  If not specified, logs are written to the location specified by the user.dir system property.";
+      "Directory to which logs will be written.  This refers to a local directory when exporting logs using an http connection, but refers to the filesystem of the manager when connected via JMX. If not specified, logs are written to the location specified by the user.dir system property.";
   public static final String EXPORT_LOGS__MEMBER = "member";
   public static final String EXPORT_LOGS__MEMBER__HELP =
       "Name/Id of the member whose log files will be exported.";

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
@@ -118,7 +118,6 @@ public class ExportLogsDUnitTest {
     commandStringBuilder.addOption("start-time", dateTimeFormatter.format(yesterday));
     commandStringBuilder.addOption("end-time", dateTimeFormatter.format(tomorrow));
     commandStringBuilder.addOption("log-level", "debug");
-    commandStringBuilder.addOption("dir", "someDir");
 
     gfshConnector.executeAndVerifyCommand(commandStringBuilder.toString());
 
@@ -146,7 +145,6 @@ public class ExportLogsDUnitTest {
     commandStringBuilder.addOption("start-time", dateTimeFormatter.format(cutoffTime.minusDays(1)));
     commandStringBuilder.addOption("end-time", cutoffTimeString);
     commandStringBuilder.addOption("log-level", "debug");
-    commandStringBuilder.addOption("dir", "someDir");
 
     gfshConnector.executeAndVerifyCommand(commandStringBuilder.toString());
 

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/GfshShellConnectionRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/GfshShellConnectionRule.java
@@ -92,6 +92,17 @@ public class GfshShellConnectionRule extends DescribedExternalResource {
 
   }
 
+  // connect and connectAndVerify(Member, ...) required for ExportLogsCommand testing until
+  // LocalLocatorStarterRule has working directory functionality.
+  public void connect(Member locator, String... options) throws Exception {
+    connect(locator.getPort(), PortType.locator, options);
+  }
+
+  public void connectAndVerify(Member locator, String... options) throws Exception {
+    connect(locator.getPort(), PortType.locator, options);
+    assertThat(this.connected).isTrue();
+  }
+
   public void connect(MemberVM locator, String... options) throws Exception {
     connect(locator.getPort(), PortType.locator, options);
   }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOverHttpIntegrationTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOverHttpIntegrationTest.java
@@ -19,12 +19,18 @@ import org.apache.geode.test.dunit.rules.GfshShellConnectionRule;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.junit.experimental.categories.Category;
 
+import java.io.File;
+
 @Category(IntegrationTest.class)
 public class ExportLogsOverHttpIntegrationTest extends ExportLogsIntegrationTest {
 
   @Override
-  protected void connect() throws Exception {
+  public void connect() throws Exception {
     gfsh.connectAndVerify(locator.getHttpPort(), GfshShellConnectionRule.PortType.http);
+  }
+
+  public File getWorkingDirectory() throws Exception {
+    return new File(System.getProperty("user.dir"));
   }
 
 }


### PR DESCRIPTION
Removed --dir usage from ExportLogsDUnitTests:
startAndEndDateCanIncludeLogs and
testExportWithStartAndEndDateTimeFiltering; these tests expected logs
to appear in the locator working directory and the --dir option was
not actually being used.

Usage of LocalLocatorStarterRules reverted in
ExportLogsIntegrationTest as locator working directory access is
required.

-- Precheckin cleared green on Test, IntegrationTest, LegacyDUnitTest, and FlakyTest.  DistributedTest still running.