### PR TITLE
GEODE-2745: WaitUntilBucketRegionQueueFlushedCallable gets BucketRegi…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
@@ -464,21 +464,25 @@ public class BucketRegionQueue extends AbstractBucketRegionQueue {
     this.latestAcknowledgedKey.set(key);
   }
 
-  public boolean waitUntilFlushed(long timeout, TimeUnit unit) throws InterruptedException {
+  public long getLatestQueuedKey() {
+    return this.latestQueuedKey.get();
+  }
+
+  public boolean waitUntilFlushed(long latestQueuedKey, long timeout, TimeUnit unit)
+      throws InterruptedException {
     long then = System.currentTimeMillis();
     if (logger.isDebugEnabled()) {
-      logger.debug("BucketRegionQueue: waitUntilFlushed bucket=" + getId() + "; timeout=" + timeout
-          + "; unit=" + unit);
+      logger.debug("BucketRegionQueue: waitUntilFlushed bucket=" + getId() + "; latestQueuedKey="
+          + latestQueuedKey + "; timeout=" + timeout + "; unit=" + unit);
     }
     boolean result = false;
     // Wait until latestAcknowledgedKey > latestQueuedKey or the queue is empty
     if (this.initialized) {
-      long latestQueuedKeyToCheck = this.latestQueuedKey.get();
       long nanosRemaining = unit.toNanos(timeout);
       long endTime = System.nanoTime() + nanosRemaining;
       while (nanosRemaining > 0) {
         try {
-          if (latestAcknowledgedKey.get() > latestQueuedKeyToCheck || isEmpty()) {
+          if (latestAcknowledgedKey.get() > latestQueuedKey || isEmpty()) {
             result = true;
             break;
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/WaitUntilParallelGatewaySenderFlushedCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/WaitUntilParallelGatewaySenderFlushedCoordinator.java
@@ -100,6 +100,8 @@ public class WaitUntilParallelGatewaySenderFlushedCoordinator
 
     private BucketRegionQueue brq;
 
+    private long latestQueuedKey;
+
     private long timeout;
 
     private TimeUnit unit;
@@ -107,13 +109,14 @@ public class WaitUntilParallelGatewaySenderFlushedCoordinator
     public WaitUntilBucketRegionQueueFlushedCallable(BucketRegionQueue brq, long timeout,
         TimeUnit unit) {
       this.brq = brq;
+      this.latestQueuedKey = brq.getLatestQueuedKey();
       this.timeout = timeout;
       this.unit = unit;
     }
 
     @Override
     public Boolean call() throws Exception {
-      return this.brq.waitUntilFlushed(this.timeout, this.unit);
+      return this.brq.waitUntilFlushed(this.latestQueuedKey, this.timeout, this.unit);
     }
 
     @Override


### PR DESCRIPTION
GEODE-2745: waitUntilFlushed method waits longer than it should

- Added getter in BucketRegionQueue for latestQueuedKey
- WaitUntilBucketRegionQueueFlushedCallable constructor now gets/maintains the BucketRegionQueue.latestQueuedKey

@nabarunnag, @boglesby, @jhuynh1 