### PR TITLE
GEODE-2768: Lucene Queries executed before index is fully created sho…

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.lucene.LuceneIndexDestroyedException;
 import org.apache.geode.cache.lucene.LuceneIndexNotFoundException;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
+import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.internal.cache.PrimaryBucketException;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.logging.log4j.Logger;
@@ -132,6 +133,25 @@ public class LuceneQueryFunction implements Function, InternalEntity {
     try {
       index =
           (LuceneIndexImpl) service.getIndex(searchContext.getIndexName(), region.getFullPath());
+      if (index == null && service instanceof LuceneServiceImpl) {
+        if (((LuceneServiceImpl) service).getDefinedIndex(searchContext.getIndexName(),
+            region.getFullPath()) != null) {
+          // The node may be in the process of recovering, where we have the index defined but yet
+          // to be recovered
+          // If we retry fast enough, we could get a stack overflow based on the way function
+          // execution is currently written
+          // Instead we will add an artificial sleep to slow down the retry at this point
+          // Hopefully in the future, the function execution would retry without adding to the stack
+          // and this can be removed
+          try {
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          throw new InternalFunctionInvocationTargetException(
+              "Defined Lucene Index has not been created");
+        }
+      }
     } catch (CacheClosedException e) {
       throw new InternalFunctionInvocationTargetException(
           "Cache is closed when attempting to retrieve index:" + region.getFullPath(), e);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunctionJUnitTest.java
@@ -33,8 +33,10 @@ import org.apache.geode.cache.lucene.LuceneQueryException;
 import org.apache.geode.cache.lucene.LuceneQueryFactory;
 import org.apache.geode.cache.lucene.LuceneQueryProvider;
 import org.apache.geode.cache.lucene.internal.InternalLuceneService;
+import org.apache.geode.cache.lucene.internal.LuceneIndexCreationProfile;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
+import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.cache.lucene.internal.StringQueryProvider;
 import org.apache.geode.cache.lucene.internal.repository.IndexRepository;
 import org.apache.geode.cache.lucene.internal.repository.IndexResultCollector;
@@ -214,6 +216,22 @@ public class LuceneQueryFunctionJUnitTest {
   @Test(expected = LuceneIndexNotFoundException.class)
   public void whenServiceReturnsNullIndexDuringQueryExecutionFunctionExceptionShouldBeThrown()
       throws Exception {
+    when(mockContext.getDataSet()).thenReturn(mockRegion);
+    when(mockContext.getArguments()).thenReturn(searchArgs);
+
+    LuceneQueryFunction function = new LuceneQueryFunction();
+    when(mockService.getIndex(eq("indexName"), eq(regionPath))).thenReturn(null);
+    function.execute(mockContext);
+  }
+
+  @Test(expected = InternalFunctionInvocationTargetException.class)
+  public void whenServiceReturnsNullIndexButHasDefinedLuceneIndexDuringQueryExecutionInternalFunctionExceptionShouldBeThrown()
+      throws Exception {
+    LuceneServiceImpl mockServiceImpl = mock(LuceneServiceImpl.class);
+    when(mockCache.getService(any())).thenReturn(mockServiceImpl);
+    when(mockServiceImpl.getIndex(eq("indexName"), eq(regionPath))).thenReturn(null);
+    when(mockServiceImpl.getDefinedIndex(eq("indexName"), eq(regionPath)))
+        .thenReturn(mock(LuceneIndexCreationProfile.class));
     when(mockContext.getDataSet()).thenReturn(mockRegion);
     when(mockContext.getArguments()).thenReturn(searchArgs);
 


### PR DESCRIPTION
…uld be retried

  * Added a sleep to prevent rapid retries which lead to stack overflow
  * Sleep can be removed when Function Execution retry does not add to stack