### PR TITLE
GEODE-2775: Corrected setting of Pulse SSL Manager flag

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.tools.pulse;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_CIPHERS;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_ENABLED_COMPONENTS;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE_PASSWORD;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_PROTOCOLS;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE_PASSWORD;
+import static org.apache.geode.util.test.TestUtil.getResourcePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.geode.security.SecurableCommunicationChannels;
+import org.apache.geode.security.SimpleTestSecurityManager;
+import org.apache.geode.test.dunit.rules.HttpClientRule;
+import org.apache.geode.test.dunit.rules.LocatorStarterRule;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.util.Properties;
+
+
+@Category(IntegrationTest.class)
+public class PulseSecurityWithSSLTest {
+
+  private static File jks =
+      new File(getResourcePath(PulseSecurityWithSSLTest.class, "/ssl/trusted.keystore"));
+
+  @ClassRule
+  public static LocatorStarterRule locator = new LocatorStarterRule();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Properties securityProps = new Properties();
+    securityProps.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannels.JMX);
+    securityProps.setProperty(SSL_KEYSTORE, jks.getCanonicalPath());
+    securityProps.setProperty(SSL_KEYSTORE_PASSWORD, "password");
+    // securityProps.setProperty(SSL_KEYSTORE_TYPE, "JKS");
+    securityProps.setProperty(SSL_TRUSTSTORE, jks.getCanonicalPath());
+    securityProps.setProperty(SSL_TRUSTSTORE_PASSWORD, "password");
+    securityProps.setProperty(SSL_PROTOCOLS, "TLSv1.2");
+    securityProps.setProperty(SSL_CIPHERS, "any");
+
+    locator.withSecurityManager(SimpleTestSecurityManager.class).withProperties(securityProps)
+        .startLocator();
+  }
+
+  @Rule
+  public HttpClientRule client = new HttpClientRule(locator::getHttpPort);
+
+
+  @Test
+  public void loginWithIncorrectPassword() throws Exception {
+    HttpResponse response = client.loginToPulse("data", "wrongPassword");
+    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(302);
+    assertThat(response.getFirstHeader("Location").getValue())
+        .contains("/pulse/login.html?error=BAD_CREDS");
+
+    client.loginToPulseAndVerify("data", "data");
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
@@ -100,6 +100,7 @@ public class ManagementAgent {
    */
   private static final String PULSE_EMBEDDED_PROP = "pulse.embedded";
   private static final String PULSE_PORT_PROP = "pulse.port";
+  private static final String PULSE_USESSL_MANAGER = "pulse.useSSL.manager";
 
   public ManagementAgent(DistributionConfig config) {
     this.config = config;
@@ -268,6 +269,10 @@ public class ManagementAgent {
 
           System.setProperty(PULSE_EMBEDDED_PROP, "true");
           System.setProperty(PULSE_PORT_PROP, "" + config.getJmxManagerPort());
+
+          final SocketCreator socketCreator =
+              SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.JMX);
+          System.setProperty(PULSE_USESSL_MANAGER, socketCreator.useSSL() + "");
 
           this.httpServer = JettyHelper.startJetty(this.httpServer);
 
@@ -504,14 +509,9 @@ public class ManagementAgent {
       if (names.isEmpty()) {
         try {
           platformMBeanServer.registerMBean(acc, accessControlMBeanON);
-          logger.info("Registered AccessContorlMBean on " + accessControlMBeanON);
-        } catch (InstanceAlreadyExistsException e) {
-          throw new GemFireConfigException("Error while configuring accesscontrol for jmx resource",
-              e);
-        } catch (MBeanRegistrationException e) {
-          throw new GemFireConfigException("Error while configuring accesscontrol for jmx resource",
-              e);
-        } catch (NotCompliantMBeanException e) {
+          logger.info("Registered AccessControlMBean on " + accessControlMBeanON);
+        } catch (InstanceAlreadyExistsException | MBeanRegistrationException
+            | NotCompliantMBeanException e) {
           throw new GemFireConfigException("Error while configuring accesscontrol for jmx resource",
               e);
         }

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/PulseAppListener.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/PulseAppListener.java
@@ -169,6 +169,10 @@ public class PulseAppListener implements ServletContextListener {
 
     // set SSL info
     initializeSSL();
+    if (sysIsEmbedded) {
+      sysPulseUseSSLManager = Boolean
+          .parseBoolean(System.getProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_USESSL_MANAGER));
+    }
     repository.setUseSSLLocator(sysPulseUseSSLLocator);
     repository.setUseSSLManager(sysPulseUseSSLManager);
 


### PR DESCRIPTION
Flag now set from System properties instead of pulse.properties when running in embedded mode.

Precheckin returned fully green.