### PR TITLE
GEODE-2770 - Move the shutdown of the rest interface to the same plac…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2231,6 +2231,8 @@ public class GemFireCacheImpl
 
           stopRedisServer();
 
+          stopRestAgentServer();
+
           // no need to track PR instances since we won't create any more
           // cacheServers or gatewayHubs
           if (this.partitionedRegions != null) {
@@ -2458,7 +2460,6 @@ public class GemFireCacheImpl
         CacheLifecycleListener listener = (CacheLifecycleListener) iter.next();
         listener.cacheClosed(this);
       }
-      stopRestAgentServer();
       // Fix for #49856
       SequenceLoggerImpl.signalCacheClose();
       SystemFailure.signalCacheClose();


### PR DESCRIPTION
Moving the shutdown of the rest interface to the sample pace as other client APIs.   This will prevent a rest api client interaction from mutating the state of the system after key components are already shutdown.