### PR TITLE
GEODE-728 : Rename Execution.withArgs to Execution.setArguments

### DIFF
--- a/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
+++ b/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
@@ -132,7 +132,7 @@ public class ClientServerSessionCache extends AbstractSessionCache {
     RegionConfiguration configuration = createRegionConfiguration();
 
     // Send it to the server tier
-    Execution execution = FunctionService.onServer(this.cache).withArgs(configuration);
+    Execution execution = FunctionService.onServer(this.cache).setArguments(configuration);
     ResultCollector collector = execution.execute(CreateRegionFunction.ID);
 
     // Verify the region was successfully created on the servers

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
@@ -109,7 +109,7 @@ public class ClientServerSessionCache extends AbstractSessionCache {
     } else {
       // Execute the member touch function on all the server(s)
       Execution execution = FunctionService.onServers(getCache())
-          .withArgs(new Object[] {this.sessionRegion.getFullPath(), sessionIds});
+          .setArguments(new Object[] {this.sessionRegion.getFullPath(), sessionIds});
       try {
         ResultCollector collector =
             execution.execute(TouchReplicatedRegionEntriesFunction.ID, true, false, false);
@@ -202,7 +202,7 @@ public class ClientServerSessionCache extends AbstractSessionCache {
     RegionConfiguration configuration = createRegionConfiguration();
 
     // Send it to the server tier
-    Execution execution = FunctionService.onServer(this.cache).withArgs(configuration);
+    Execution execution = FunctionService.onServer(this.cache).setArguments(configuration);
     ResultCollector collector = execution.execute(CreateRegionFunction.ID);
 
     // Verify the region was successfully created on the servers

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/PeerToPeerSessionCache.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/PeerToPeerSessionCache.java
@@ -91,7 +91,7 @@ public class PeerToPeerSessionCache extends AbstractSessionCache {
     } else {
       // Execute the member touch function on all the server(s)
       Execution execution = FunctionService.onMembers(getCache().getDistributedSystem())
-          .withArgs(new Object[] {this.sessionRegion.getFullPath(), sessionIds});
+          .setArguments(new Object[] {this.sessionRegion.getFullPath(), sessionIds});
       collector = execution.execute(TouchReplicatedRegionEntriesFunction.ID, true, false, false);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/Execution.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/Execution.java
@@ -60,7 +60,20 @@ public interface Execution<IN, OUT, AGG> {
    * @param args user data passed to the function execution
    * @return an Execution with args
    * @throws IllegalArgumentException if the input parameter is null
+   * @since Geode 1.2
+   * 
+   */
+  public Execution<IN, OUT, AGG> setArguments(IN args);
+
+  /**
+   * Specifies the user data passed to the function when it is executed. The function can retrieve
+   * these arguments using {@link FunctionContext#getArguments()}
+   * 
+   * @param args user data passed to the function execution
+   * @return an Execution with args
+   * @throws IllegalArgumentException if the input parameter is null
    * @since GemFire 6.0
+   * @deprecated use {@link #setArguments(Object)} instead
    * 
    */
   public Execution<IN, OUT, AGG> withArgs(IN args);

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionContext.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionContext.java
@@ -35,7 +35,7 @@ package org.apache.geode.cache.execute;
 public interface FunctionContext<T1> {
   /**
    * Returns the arguments provided to this function execution. These are the arguments specified by
-   * the caller using {@link Execution#withArgs(Object)}
+   * the caller using {@link Execution#setArguments(Object)}
    * 
    * @return the arguments or null if there are no arguments
    * @since GemFire 6.0

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/ResultCollector.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/ResultCollector.java
@@ -37,7 +37,7 @@ import org.apache.geode.distributed.DistributedMember;
  *  Function multiGetFunction ;
  *  Object args ;
  *  ResultCollector rc = FunctionService.onRegion(region)
- *                                      .withArgs(args)
+ *                                      .setArguments(args)
  *                                      .withFilter(keySet)
  *                                      .withCollector(new MyCustomResultCollector())
  *                                      .execute(multiGetFunction.getId());

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/package.html
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/package.html
@@ -73,7 +73,7 @@ limitations under the License.
     Function multiGetFunction;
     Object args;
     ResultCollector rc = FunctionService.onRegion(region)
-                                        .withArgs(args)
+                                        .setArguments(args)
                                         .withFilter(keySet)
                                         .withCollector(new MyCustomResultCollector())
                                         .execute(multiGetFunction.getId());
@@ -96,7 +96,7 @@ limitations under the License.
     Function multiGetFunction;
     Object args;
     ResultCollector rc = FunctionService.onRegions(s)
-                                        .withArgs(args)
+                                        .setArguments(args)
                                         .withCollector(new MyCustomResultCollector())
                                         .execute(multiGetFunction.getId());
     // Application can get the handle of all the regions at the node it is executing on.
@@ -114,7 +114,7 @@ limitations under the License.
     Function memberSetupFunction;
     Object args;
     ResultCollector rc = FunctionService.onMembers(ds)
-                                        .withArgs(args)
+                                        .setArguments(args)
                                         .execute(memberSetupFunction.getId());
     //Application can do something else here before retrieving the result
     Object functionResult = rc.getResult();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -3347,20 +3347,20 @@ public class PartitionedRegion extends LocalRegion
       switch (execution.getFilter().size()) {
         case 0:
           if (logger.isDebugEnabled()) {
-            logger.debug("Executing Function: {} withArgs={} on all buckets.", function.getId(),
+            logger.debug("Executing Function: {} setArguments={} on all buckets.", function.getId(),
                 execution.getArguments());
           }
           return executeOnAllBuckets(function, execution, rc, false);
         case 1:
           if (logger.isDebugEnabled()) {
-            logger.debug("Executing Function: {} withArgs={} on single node.", function.getId(),
+            logger.debug("Executing Function: {} setArguments={} on single node.", function.getId(),
                 execution.getArguments());
           }
           return executeOnSingleNode(function, execution, rc, false, executeOnBucketSet);
         default:
           if (logger.isDebugEnabled()) {
-            logger.debug("Executing Function: {} withArgs={} on multiple nodes.", function.getId(),
-                execution.getArguments());
+            logger.debug("Executing Function: {} setArguments={} on multiple nodes.",
+                function.getId(), execution.getArguments());
           }
           return executeOnMultipleNodes(function, execution, rc, false, executeOnBucketSet);
       }
@@ -3576,7 +3576,7 @@ public class PartitionedRegion extends LocalRegion
     }
 
     if (logger.isDebugEnabled()) {
-      logger.debug("Executing Function: {} withArgs={} on {}", function.getId(),
+      logger.debug("Executing Function: {} setArguments={} on {}", function.getId(),
           execution.getArguments(), targetNode);
     }
     while (!execution.getFailedNodes().isEmpty()) {
@@ -6445,7 +6445,7 @@ public class PartitionedRegion extends LocalRegion
 
     ResultCollector rc = null;
     try {
-      rc = FunctionService.onRegion(this).withArgs((Serializable) value)
+      rc = FunctionService.onRegion(this).setArguments((Serializable) value)
           .execute(PRContainsValueFunction.class.getName());
       List<Boolean> results = ((List<Boolean>) rc.getResult());
       for (Boolean r : results) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
@@ -344,13 +344,20 @@ public class DistributedRegionFunctionExecutor extends AbstractExecution {
     return this.sender;
   }
 
-  public Execution withArgs(Object args) {
+
+
+  @Override
+  public Execution setArguments(Object args) {
     if (args == null) {
       throw new IllegalArgumentException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("Args"));
     }
     return new DistributedRegionFunctionExecutor(this, args);
+  }
+
+  public Execution withArgs(Object args) {
+    return setArguments(args);
   }
 
   public Execution withCollector(ResultCollector rs) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionContextImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionContextImpl.java
@@ -59,7 +59,7 @@ public class FunctionContextImpl implements FunctionContext {
 
   /**
    * Returns the arguments provided to this function execution. These are the arguments specified by
-   * caller using {@link Execution#withArgs(Object)}
+   * caller using {@link Execution#setArguments(Object)}
    * 
    * @return the arguments or null if there are no arguments
    */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
@@ -207,14 +207,19 @@ public class MemberFunctionExecutor extends AbstractExecution {
     }
   }
 
-  // Changing the object!!
-  public Execution withArgs(Object arguments) {
-    if (arguments == null) {
+  @Override
+  public Execution setArguments(Object args) {
+    if (args == null) {
       throw new IllegalArgumentException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("args"));
     }
-    return new MemberFunctionExecutor(this, arguments);
+    return new MemberFunctionExecutor(this, args);
+  }
+
+  // Changing the object!!
+  public Execution withArgs(Object args) {
+    return setArguments(args);
   }
 
   // Changing the object!!

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
@@ -142,13 +142,18 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
     return this.sender;
   }
 
-  public Execution withArgs(Object args) {
+  @Override
+  public Execution setArguments(Object args) {
     if (args == null) {
       throw new IllegalArgumentException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("args"));
     }
     return new MultiRegionFunctionExecutor(this, args);
+  }
+
+  public Execution withArgs(Object args) {
+    return setArguments(args);
   }
 
   public Execution withCollector(ResultCollector rc) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
@@ -278,13 +278,18 @@ public class PartitionedRegionFunctionExecutor extends AbstractExecution {
     return this.sender;
   }
 
-  public Execution withArgs(Object args) {
+  @Override
+  public Execution setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("args"));
     }
     return new PartitionedRegionFunctionExecutor(this, args);
+  }
+
+  public Execution withArgs(Object args) {
+    return setArguments(args);
   }
 
   public Execution withCollector(ResultCollector rs) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
@@ -250,13 +250,18 @@ public class ServerFunctionExecutor extends AbstractExecution {
             .toLocalizedString("buckets as filter"));
   }
 
-  public Execution withArgs(Object args) {
+  @Override
+  public Execution setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("args"));
     }
     return new ServerFunctionExecutor(this, args);
+  }
+
+  public Execution withArgs(Object args) {
+    return setArguments(args);
   }
 
   public Execution withCollector(ResultCollector rs) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
@@ -308,13 +308,18 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
         .append("]").toString();
   }
 
-  public Execution withArgs(Object params) {
-    if (params == null) {
+  @Override
+  public Execution setArguments(Object args) {
+    if (args == null) {
       throw new FunctionException(
           LocalizedStrings.ExecuteRegionFunction_THE_INPUT_0_FOR_THE_EXECUTE_FUNCTION_REQUEST_IS_NULL
               .toLocalizedString("args"));
     }
-    return new ServerRegionFunctionExecutor(this, params);
+    return new ServerRegionFunctionExecutor(this, args);
+  }
+
+  public Execution withArgs(Object params) {
+    return setArguments(args);
   }
 
   public Execution withCollector(ResultCollector rs) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
@@ -69,7 +69,7 @@ public class ClientExporter<K, V> implements Exporter<K, V> {
           : FunctionService.onServer(pool);
 
       ResultCollector<?, ?> rc =
-          exec.withArgs(args).withCollector(results).execute(new ProxyExportFunction<K, V>());
+          exec.setArguments(args).withCollector(results).execute(new ProxyExportFunction<K, V>());
 
       // Our custom result collector is writing the data, but this will
       // check for errors.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -180,7 +180,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
   private void snapshotInParallel(ParallelArgs<K, V> args, Function fn) throws IOException {
     try {
 
-      ResultCollector rc = FunctionService.onRegion(region).withArgs(args).execute(fn);
+      ResultCollector rc = FunctionService.onRegion(region).setArguments(args).execute(fn);
       List result = (List) rc.getResult();
       for (Object obj : result) {
         if (obj instanceof Exception) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/WindowedExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/WindowedExporter.java
@@ -77,8 +77,8 @@ public class WindowedExporter<K, V> implements Exporter<K, V> {
       // to keep the reference to the ResultsCollector returned from execute().
       // Normally discarding the reference can cause issues if GC causes the
       // weak ref in ProcessorKeeper21 to be collected!!
-      InternalExecution exec = (InternalExecution) FunctionService.onRegion(region).withArgs(args)
-          .withCollector(results);
+      InternalExecution exec = (InternalExecution) FunctionService.onRegion(region)
+          .setArguments(args).withCollector(results);
 
       // Ensure that our collector gets all exceptions so we can shut down the
       // queue properly.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
@@ -124,7 +124,7 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
     }
     Execution execution = new MemberFunctionExecutor(ds, members, resultSender);
     if (args != null) {
-      execution = execution.withArgs(args);
+      execution = execution.setArguments(args);
     }
     if (ignoreFailedMembers) {
       if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/MBeanProxyInvocationHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/MBeanProxyInvocationHandler.java
@@ -281,7 +281,7 @@ public class MBeanProxyInvocationHandler implements InvocationHandler {
     List<Object> result = null;
     try {
 
-      ResultCollector rc = FunctionService.onMember(member).withArgs(functionArgs)
+      ResultCollector rc = FunctionService.onMember(member).setArguments(functionArgs)
           .execute(ManagementConstants.MGMT_FUNCTION_ID);
       result = (List<Object>) rc.getResult();
       // Exceptions of ManagementFunctions

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -174,8 +174,8 @@ public class QueryDataFunction extends FunctionAdapter implements InternalEntity
             results = selectResults;
           }
         } else {
-          rcollector = FunctionService.onRegion(cache.getRegion(regionName)).withArgs(queryString)
-              .execute(loclQueryFunc);
+          rcollector = FunctionService.onRegion(cache.getRegion(regionName))
+              .setArguments(queryString).execute(loclQueryFunc);
           results = rcollector.getResult();
         }
       }
@@ -250,7 +250,7 @@ public class QueryDataFunction extends FunctionAdapter implements InternalEntity
     try {
       if (members.size() == 1) {
         DistributedMember member = members.iterator().next();
-        ResultCollector collector = FunctionService.onMember(member).withArgs(functionArgs)
+        ResultCollector collector = FunctionService.onMember(member).setArguments(functionArgs)
             .execute(ManagementConstants.QUERY_DATA_FUNCTION);
         List list = (List) collector.getResult();
         Object object = null;
@@ -280,7 +280,7 @@ public class QueryDataFunction extends FunctionAdapter implements InternalEntity
         }
 
       } else { // More than 1 Member
-        ResultCollector coll = FunctionService.onMembers(members).withArgs(functionArgs)
+        ResultCollector coll = FunctionService.onMembers(members).setArguments(functionArgs)
             .execute(ManagementConstants.QUERY_DATA_FUNCTION);
 
         List list = (List) coll.getResult();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
@@ -614,7 +614,7 @@ public class CliUtil {
     Execution execution = null;
 
     if (args != null) {
-      execution = FunctionService.onMembers(targetMembers).withArgs(args);
+      execution = FunctionService.onMembers(targetMembers).setArguments(args);
     } else {
       execution = FunctionService.onMembers(targetMembers);
     }
@@ -637,7 +637,7 @@ public class CliUtil {
     Execution execution = null;
 
     if (args != null) {
-      execution = FunctionService.onMember(targetMember).withArgs(args);
+      execution = FunctionService.onMember(targetMember).setArguments(args);
     } else {
       execution = FunctionService.onMember(targetMember);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DataCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DataCommands.java
@@ -1198,7 +1198,8 @@ public class DataCommands implements CommandMarker {
 
     if (members.size() == 1) {
       DistributedMember member = members.iterator().next();
-      ResultCollector collector = FunctionService.onMember(member).withArgs(request).execute(putfn);
+      ResultCollector collector =
+          FunctionService.onMember(member).setArguments(request).execute(putfn);
       List list = (List) collector.getResult();
       Object object = list.get(0);
       if (object instanceof Throwable) {
@@ -1213,7 +1214,7 @@ public class DataCommands implements CommandMarker {
       return result;
     } else {
       ResultCollector collector =
-          FunctionService.onMembers(members).withArgs(request).execute(putfn);
+          FunctionService.onMembers(members).setArguments(request).execute(putfn);
       List list = (List) collector.getResult();
       DataCommandResult result = null;
       for (int i = 0; i < list.size(); i++) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommands.java
@@ -911,7 +911,7 @@ public class DiskStoreCommands extends AbstractCommandsSupport {
                                                                         // MemberNotFoundException
 
     final ResultCollector<?, ?> resultCollector =
-        getMembersFunctionExecutor(Collections.singleton(member)).withArgs(diskStoreName)
+        getMembersFunctionExecutor(Collections.singleton(member)).setArguments(diskStoreName)
             .execute(new DescribeDiskStoreFunction());
 
     final Object result = ((List<?>) resultCollector.getResult()).get(0);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/FunctionCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/FunctionCommands.java
@@ -257,7 +257,7 @@ public class FunctionCommands implements CommandMarker {
               execution = execution.withFilter(filters);
             }
             if (arguments != null && arguments.length > 0) {
-              execution = execution.withArgs(arguments);
+              execution = execution.setArguments(arguments);
             }
 
             try {
@@ -389,7 +389,7 @@ public class FunctionCommands implements CommandMarker {
       }
       args[4] = onRegion;
 
-      Execution execution = FunctionService.onMember(member).withArgs(args);
+      Execution execution = FunctionService.onMember(member).setArguments(args);
       if (execution != null) {
         List<Object> results = (List<Object>) execution.execute(function).getResult();
         if (results != null) {
@@ -522,7 +522,7 @@ public class FunctionCommands implements CommandMarker {
     Object[] obj = new Object[1];
     obj[0] = functionId;
 
-    Execution execution = FunctionService.onMembers(DsMembers).withArgs(obj);
+    Execution execution = FunctionService.onMembers(DsMembers).setArguments(obj);
 
     if (execution == null) {
       cache.getLogger().error("executeUnregister execution is null");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/MiscellaneousCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/MiscellaneousCommands.java
@@ -1951,7 +1951,7 @@ public class MiscellaneousCommands implements CommandMarker {
       TabularResultData resultTable = section.addTable("ChangeLogLevel");
       resultTable = resultTable.setHeader("Summary");
 
-      Execution execution = FunctionService.onMembers(dsMembers).withArgs(functionArgs);
+      Execution execution = FunctionService.onMembers(dsMembers).setArguments(functionArgs);
       if (execution == null) {
         return ResultBuilder.createUserErrorResult(CliStrings.CHANGE_LOGLEVEL__MSG__CANNOT_EXECUTE);
       }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UserFunctionExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UserFunctionExecution.java
@@ -92,7 +92,7 @@ public class UserFunctionExecution implements Function, InternalEntity {
               }
 
               if (functionArgs != null && functionArgs.length > 0) {
-                execution = execution.withArgs(functionArgs);
+                execution = execution.setArguments(functionArgs);
               }
               if (filters != null && filters.size() > 0) {
                 execution = execution.withFilter(filters);

--- a/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
@@ -1126,7 +1126,7 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
               Execution e = FunctionService.onRegion(pr);
               try {
                 getCache().getLoggerI18n().fine(addExpectedFunctionExString);
-                e.withFilter(s).withArgs((Serializable) s).execute(function);
+                e.withFilter(s).setArguments((Serializable) s).execute(function);
                 getCache().getLoggerI18n().fine(removeExpectedFunctionExString);
                 fail("expected LowMemoryExcception was not thrown");
               } catch (LowMemoryException ex) {
@@ -1140,7 +1140,7 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
               s.add(sickKey2);
               Execution e = FunctionService.onRegion(pr);
               try {
-                e.withFilter(s).withArgs((Serializable) s).execute(function);
+                e.withFilter(s).setArguments((Serializable) s).execute(function);
                 fail("expected LowMemoryExcception was not thrown");
               } catch (LowMemoryException ex) {
                 // expected
@@ -1152,7 +1152,7 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
             Set s = new HashSet();
             s.add(healthyKey);
             Execution e = FunctionService.onRegion(pr);
-            e.withFilter(s).withArgs((Serializable) s).execute(function);
+            e.withFilter(s).setArguments((Serializable) s).execute(function);
           }
           if (sickKey1 != null && sickKey2 != null && healthyKey != null) {
             break;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
@@ -198,7 +198,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
 
             rcollector =
                 FunctionService.onRegion(CacheFactory.getAnyInstance().getRegion(repRegionName))
-                    .withArgs(queriesForRR[i]).execute(function);
+                    .setArguments(queriesForRR[i]).execute(function);
 
             // Should not come here, an exception is expected from above function call.
             fail("Function call did not fail for query with function context");
@@ -438,7 +438,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
 
             rcollector = FunctionService
                 .onRegion(CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1))
-                .withArgs(queries[i]).withFilter(filter).execute(function);
+                .setArguments(queries[i]).withFilter(filter).execute(function);
 
             // Should not come here, an exception is expected from above function call.
             fail("Function call did not fail for query with function context");
@@ -509,7 +509,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
 
             rcollector = FunctionService
                 .onRegion(CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1))
-                .withArgs(queries[i]).withFilter(filter).execute(function);
+                .setArguments(queries[i]).withFilter(filter).execute(function);
 
             // Should not come here, an exception is expected from above function call.
             fail("Function call did not fail for query with function context");
@@ -930,10 +930,10 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
     // Filter can not be set as null if withFilter() is called.
     if (filter != null) {
       rcollector = FunctionService.onRegion(CacheFactory.getAnyInstance().getRegion(regionName))
-          .withArgs(query).withFilter(filter).execute(func);
+          .setArguments(query).withFilter(filter).execute(func);
     } else {
       rcollector = FunctionService.onRegion(CacheFactory.getAnyInstance().getRegion(regionName))
-          .withArgs(query).execute(func);
+          .setArguments(query).execute(func);
     }
     Object result = rcollector.getResult();
     assertTrue(result instanceof ArrayList);
@@ -968,7 +968,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
 
     // Filter can not be set as null if withFilter() is called.
     rcollector = FunctionService.onServer(ClientCacheFactory.getAnyInstance())
-        .withArgs(new Object[] {query, filter}).execute(func);
+        .setArguments(new Object[] {query, filter}).execute(func);
     Object result = rcollector.getResult();
     assertTrue(result instanceof ArrayList);
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/PartitionedRegionEquiJoinIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/PartitionedRegionEquiJoinIntegrationTest.java
@@ -82,8 +82,8 @@ public class PartitionedRegionEquiJoinIntegrationTest extends EquiJoinIntegratio
 
   @Override
   protected Object[] executeQueries(String[] queries) {
-    ResultCollector collector =
-        FunctionService.onRegion(region1).withArgs(queries).execute(equijoinTestFunction.getId());
+    ResultCollector collector = FunctionService.onRegion(region1).setArguments(queries)
+        .execute(equijoinTestFunction.getId());
     Object result = collector.getResult();
     return (Object[]) ((ArrayList) result).get(0);
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
@@ -343,7 +343,7 @@ public class PRColocatedEquiJoinDUnitTest extends PartitionedRegionDUnitTestCase
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
+                .setArguments("Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
                     + " * from /" + name + " r1, /" + coloName + " r2 where " + queries[j])
                 .execute(func).getResult();
 
@@ -1603,7 +1603,7 @@ public class PRColocatedEquiJoinDUnitTest extends PartitionedRegionDUnitTestCase
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
+                .setArguments("Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
                     + " * from /" + name + " r1, /" + coloName + " r2 where " + queries[j])
                 .execute(func).getResult();
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitHelper.java
@@ -2024,8 +2024,9 @@ public class PRQueryDUnitHelper implements Serializable {
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("<trace> Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
-                    + " * from /" + name + " r1, /" + coloName + " r2 where " + queries[j])
+                .setArguments(
+                    "<trace> Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
+                        + " * from /" + name + " r1, /" + coloName + " r2 where " + queries[j])
                 .execute(func).getResult();
 
             r[j][0] = ((ArrayList) funcResult).get(0);
@@ -2138,9 +2139,9 @@ public class PRQueryDUnitHelper implements Serializable {
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("<trace> Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
-                    + " * from /" + name + " r1, /" + coloName
-                    + " r2, r2.positions.values pos2 where " + queries[j])
+                .setArguments("<trace> Select "
+                    + (queries[j].contains("ORDER BY") ? "DISTINCT" : "") + " * from /" + name
+                    + " r1, /" + coloName + " r2, r2.positions.values pos2 where " + queries[j])
                 .execute(func).getResult();
 
             r[j][0] = ((ArrayList) funcResult).get(0);
@@ -2251,9 +2252,9 @@ public class PRQueryDUnitHelper implements Serializable {
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("<trace> Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
-                    + " * from /" + name + " r1, /" + coloName
-                    + " r2, r2.positions.values pos2 where " + queries[j])
+                .setArguments("<trace> Select "
+                    + (queries[j].contains("ORDER BY") ? "DISTINCT" : "") + " * from /" + name
+                    + " r1, /" + coloName + " r2, r2.positions.values pos2 where " + queries[j])
                 .execute(func).getResult();
 
             r[j][0] = ((ArrayList) funcResult).get(0);
@@ -2365,9 +2366,9 @@ public class PRQueryDUnitHelper implements Serializable {
             Object funcResult = FunctionService
                 .onRegion((getCache().getRegion(name) instanceof PartitionedRegion)
                     ? getCache().getRegion(name) : getCache().getRegion(coloName))
-                .withArgs("<trace> Select " + (queries[j].contains("ORDER BY") ? "DISTINCT" : "")
-                    + " * from /" + name + " r1, r1.positions.values pos1, /" + coloName
-                    + " r2 where " + queries[j])
+                .setArguments("<trace> Select "
+                    + (queries[j].contains("ORDER BY") ? "DISTINCT" : "") + " * from /" + name
+                    + " r1, r1.positions.values pos1, /" + coloName + " r2 where " + queries[j])
                 .execute(func).getResult();
 
             r[j][0] = ((ArrayList) funcResult).get(0);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
@@ -3000,19 +3000,19 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         args.add(new CustId(0));
         args.add(new Customer("name0", "address0"));
         args.add(null);
-        List result = (List) FunctionService.onRegion(cust).withArgs(args).execute(new TXFunction())
-            .getResult();
+        List result = (List) FunctionService.onRegion(cust).setArguments(args)
+            .execute(new TXFunction()).getResult();
         TransactionId txId = (TransactionId) result.get(0);
         assertNotNull(txId);
         args = new ArrayList();
         args.add(new CustId(1));
         args.add(new Customer("name1", "address1"));
         args.add(txId);
-        result = (List) FunctionService.onRegion(cust).withArgs(args).execute(new TXFunction())
+        result = (List) FunctionService.onRegion(cust).setArguments(args).execute(new TXFunction())
             .getResult();
         TransactionId txId2 = (TransactionId) result.get(0);
         assertEquals(txId, txId2);
-        result = (List) FunctionService.onServer(getCache()).withArgs(txId)
+        result = (List) FunctionService.onServer(getCache()).setArguments(txId)
             .execute(new CommitFunction()).getResult();
         Boolean b = (Boolean) result.get(0);
         assertEquals(Boolean.TRUE, b);
@@ -3088,7 +3088,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
           args.add(new CustId(0));
           args.add(new Customer("name0", "address0"));
           args.add(null);
-          List result = (List) FunctionService.onRegion(cust).withArgs(args)
+          List result = (List) FunctionService.onRegion(cust).setArguments(args)
               .execute(new TXFunction()).getResult();
           TransactionId txId = (TransactionId) result.get(0);
           assertNotNull(txId);
@@ -3096,17 +3096,17 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
           args.add(new CustId(1));
           args.add(new Customer("name1", "address1"));
           args.add(txId);
-          result = (List) FunctionService.onRegion(cust).withArgs(args).execute(new TXFunction())
-              .getResult();
+          result = (List) FunctionService.onRegion(cust).setArguments(args)
+              .execute(new TXFunction()).getResult();
           TransactionId txId2 = (TransactionId) result.get(0);
           assertEquals(txId, txId2);
           // invoke ClientCommitFunction
           try {
             if (commit) {
-              FunctionService.onServer(getCache()).withArgs(new CustId(0))
+              FunctionService.onServer(getCache()).setArguments(new CustId(0))
                   .execute(new CommitFunction()).getResult();
             } else {
-              FunctionService.onServer(getCache()).withArgs(new CustId(0))
+              FunctionService.onServer(getCache()).setArguments(new CustId(0))
                   .execute(new RollbackFunction()).getResult();
             }
             fail("expected exception not thrown");
@@ -3115,10 +3115,10 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
           }
           List list = null;
           if (commit) {
-            list = (List) FunctionService.onServer(getCache()).withArgs(txId)
+            list = (List) FunctionService.onServer(getCache()).setArguments(txId)
                 .execute(new CommitFunction()).getResult();
           } else {
-            list = (List) FunctionService.onServer(getCache()).withArgs(txId)
+            list = (List) FunctionService.onServer(getCache()).setArguments(txId)
                 .execute(new RollbackFunction()).getResult();
           }
           assertEquals(Boolean.TRUE, list.get(0));
@@ -3179,22 +3179,22 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         args.add(new CustId(0));
         args.add(new Customer("name0", "address0"));
         args.add(null);
-        List result = (List) FunctionService.onRegion(cust).withArgs(args).execute(new TXFunction())
-            .getResult();
+        List result = (List) FunctionService.onRegion(cust).setArguments(args)
+            .execute(new TXFunction()).getResult();
         TransactionId txId = (TransactionId) result.get(0);
         assertNotNull(txId);
         args = new ArrayList();
         args.add(new CustId(1));
         args.add(new Customer("name1", "address1"));
         args.add(txId);
-        result = (List) FunctionService.onRegion(cust).withArgs(args).execute(new TXFunction())
+        result = (List) FunctionService.onRegion(cust).setArguments(args).execute(new TXFunction())
             .getResult();
         TransactionId txId2 = (TransactionId) result.get(0);
         assertEquals(txId, txId2);
         // invoke ClientCommitFunction
         try {
-          FunctionService.onServer(getCache()).withArgs(new CustId(0)).execute(new CommitFunction())
-              .getResult();
+          FunctionService.onServer(getCache()).setArguments(new CustId(0))
+              .execute(new CommitFunction()).getResult();
           fail("expected exception not thrown");
         } catch (FunctionException e) {
           assertTrue(e.getCause() instanceof ClassCastException);
@@ -3216,10 +3216,10 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         try {
           List list = null;
           if (commit) {
-            list = (List) FunctionService.onServer(getCache()).withArgs(txId)
+            list = (List) FunctionService.onServer(getCache()).setArguments(txId)
                 .execute(new CommitFunction()).getResult();
           } else {
-            list = (List) FunctionService.onServer(getCache()).withArgs(txId)
+            list = (List) FunctionService.onServer(getCache()).setArguments(txId)
                 .execute(new RollbackFunction()).getResult();
           }
           fail("expected exception not thrown");
@@ -3281,7 +3281,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     accessor.invoke(new SerializableCallable() {
       public Object call() throws Exception {
-        Execution exe = FunctionService.onMember(((TXId) txId).getMemberId()).withArgs(txId);
+        Execution exe = FunctionService.onMember(((TXId) txId).getMemberId()).setArguments(txId);
         List list = null;
         if (commit) {
           list = (List) exe.execute(new CommitFunction()).getResult();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
@@ -79,7 +79,7 @@ public class CommitFunction implements Function {
       txId = (TXId) context.getArguments();
     } catch (ClassCastException e) {
       logger.info(
-          "CommitFunction should be invoked with a TransactionId as an argument i.e. withArgs(txId).execute(function)");
+          "CommitFunction should be invoked with a TransactionId as an argument i.e. setArguments(txId).execute(function)");
       throw e;
     }
     DistributedMember member = txId.getMemberId();
@@ -101,7 +101,8 @@ public class CommitFunction implements Function {
       ArrayList args = new ArrayList();
       args.add(txId);
       args.add(NestedTransactionFunction.COMMIT);
-      Execution ex = FunctionService.onMember(cache.getDistributedSystem(), member).withArgs(args);
+      Execution ex =
+          FunctionService.onMember(cache.getDistributedSystem(), member).setArguments(args);
       if (isDebugEnabled) {
         logger.debug(
             "CommitFunction: for transaction: {} executing NestedTransactionFunction on member: {}",

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/FireAndForgetFunctionOnAllServersDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/FireAndForgetFunctionOnAllServersDUnitTest.java
@@ -100,7 +100,7 @@ public class FireAndForgetFunctionOnAllServersDUnitTest extends LocatorTestBase 
 
       String regionName = "R1";
       Execution dataSet = FunctionService.onServers(pool1);
-      dataSet.withArgs(regionName).execute(function);
+      dataSet.setArguments(regionName).execute(function);
 
       // Using Awatility, if the condition is not met during the timeout, a
       // ConditionTimeoutException will be thrown. This makes analyzing the failure much simpler
@@ -119,7 +119,7 @@ public class FireAndForgetFunctionOnAllServersDUnitTest extends LocatorTestBase 
       await().atMost(60, SECONDS)
           .until(() -> Assert.assertEquals(1, pool.getCurrentServers().size()));
       dataSet = FunctionService.onServers(pool1);
-      dataSet.withArgs(regionName).execute(function);
+      dataSet.setArguments(regionName).execute(function);
 
       await().atMost(60, SECONDS)
           .until(() -> Assert.assertEquals(2, pool.getCurrentServers().size()));
@@ -140,7 +140,7 @@ public class FireAndForgetFunctionOnAllServersDUnitTest extends LocatorTestBase 
       // Step 9. Execute the same function to put DistributedMemberID into above created replicated
       // region.
       dataSet = FunctionService.onServers(pool1);
-      dataSet.withArgs(regionName).execute(function);
+      dataSet.setArguments(regionName).execute(function);
 
       await().atMost(60, SECONDS)
           .until(() -> Assert.assertEquals(1, pool.getCurrentServers().size()));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/NestedTransactionFunction.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/NestedTransactionFunction.java
@@ -67,7 +67,7 @@ public class NestedTransactionFunction implements Function {
       action = (Integer) args.get(1);
     } catch (ClassCastException e) {
       logger.info(
-          "CommitFunction should be invoked with a TransactionId as an argument i.e. withArgs(txId).execute(function)");
+          "CommitFunction should be invoked with a TransactionId as an argument i.e. setArguments(txId).execute(function)");
       throw e;
     }
     CacheTransactionManager txMgr = cache.getCacheTransactionManager();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RollbackFunction.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RollbackFunction.java
@@ -78,7 +78,7 @@ public class RollbackFunction implements Function {
       txId = (TXId) context.getArguments();
     } catch (ClassCastException e) {
       logger.info(
-          "RollbackFunction should be invoked with a TransactionId as an argument i.e. withArgs(txId).execute(function)");
+          "RollbackFunction should be invoked with a TransactionId as an argument i.e. setArguments(txId).execute(function)");
       throw e;
     }
     DistributedMember member = txId.getMemberId();
@@ -100,7 +100,8 @@ public class RollbackFunction implements Function {
       ArrayList args = new ArrayList();
       args.add(txId);
       args.add(NestedTransactionFunction.ROLLBACK);
-      Execution ex = FunctionService.onMember(cache.getDistributedSystem(), member).withArgs(args);
+      Execution ex =
+          FunctionService.onMember(cache.getDistributedSystem(), member).setArguments(args);
       if (isDebugEnabled) {
         logger.debug(
             "RollbackFunction: for transaction: {} executing NestedTransactionFunction on member: {}",

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/Bug51193DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/Bug51193DUnitTest.java
@@ -145,11 +145,11 @@ public class Bug51193DUnitTest extends JUnit4DistributedTestCase {
     FunctionService.registerFunction(function);
     Execution dataSet = null;
     if ("region".equalsIgnoreCase(mode)) {
-      dataSet = FunctionService.onRegion(cache.getRegion(REGION_NAME)).withArgs(timeout);
+      dataSet = FunctionService.onRegion(cache.getRegion(REGION_NAME)).setArguments(timeout);
     } else if ("server".equalsIgnoreCase(mode)) {
-      dataSet = FunctionService.onServer(cache.getDefaultPool()).withArgs(timeout);
+      dataSet = FunctionService.onServer(cache.getDefaultPool()).setArguments(timeout);
     } else {
-      dataSet = FunctionService.onServers(cache).withArgs(timeout);
+      dataSet = FunctionService.onServers(cache).setArguments(timeout);
     }
     ResultCollector rs = dataSet.execute(function);
     assertTrue("Server did not read client_function_timeout from client.",

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
@@ -238,7 +238,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution member = FunctionService.onServers(pool);
     try {
-      ResultCollector rs = member.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      ResultCollector rs = member.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -465,7 +465,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
 
     // remove any existing attributes
     ((AbstractExecution) member).removeFunctionAttributes(TestFunction.TEST_FUNCTION1);
-    ResultCollector rs = member.withArgs(Boolean.TRUE).execute(TestFunction.TEST_FUNCTION1);
+    ResultCollector rs = member.setArguments(Boolean.TRUE).execute(TestFunction.TEST_FUNCTION1);
     assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
     byte[] functionAttributes =
         ((AbstractExecution) member).getFunctionAttributes(TestFunction.TEST_FUNCTION1);
@@ -698,7 +698,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
     Execution member = FunctionService.onServer(pool);
 
     try {
-      ResultCollector rs = member.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      ResultCollector rs = member.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -730,7 +730,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
     Execution member = FunctionService.onServer(pool);
 
     try {
-      ResultCollector rs = member.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      ResultCollector rs = member.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -887,7 +887,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution member = FunctionService.onServers(pool);
     try {
-      ResultCollector rs = member.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      ResultCollector rs = member.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -920,11 +920,11 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
       Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
       LogWriterUtils.getLogWriter().info("The function name to execute : " + function.getId());
-      Execution me = member.withArgs(args);
+      Execution me = member.setArguments(args);
       LogWriterUtils.getLogWriter().info("The args passed  : " + args);
       return me.execute(function.getId());
     } else { // By Instance
-      return member.withArgs(args).execute(function);
+      return member.setArguments(args).execute(function);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
@@ -960,7 +960,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
 
   public static void executeInlineFunction() {
-    List list = (List) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+    List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
@@ -1067,12 +1067,12 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
     for (int i = 100; i < 120; i++) {
       filter.add("execKey-" + i);
     }
-    ResultCollector rs = FunctionService.onRegion(region).withFilter(filter).withArgs(Boolean.TRUE)
-        .execute(function);
+    ResultCollector rs = FunctionService.onRegion(region).withFilter(filter)
+        .setArguments(Boolean.TRUE).execute(function);
     List list = (List) rs.getResult();
     assertTrue(list.get(0) instanceof MyFunctionExecutionException);
 
-    rs = FunctionService.onRegion(region).withFilter(filter).withArgs((Serializable) filter)
+    rs = FunctionService.onRegion(region).withFilter(filter).setArguments((Serializable) filter)
         .execute(function);
     List resultList = (List) rs.getResult();
     assertEquals((filter.size() + 1), resultList.size());
@@ -1115,7 +1115,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
   public static void executeFunctionFunctionInvocationTargetException() {
     try {
-      ResultCollector rc1 = FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+      ResultCollector rc1 = FunctionService.onRegion(region).setArguments(Boolean.TRUE)
           .execute("DistribuedRegionFunctionFunctionInvocationException");
       List list = (ArrayList) rc1.getResult();
       assertEquals(5, list.get(0));
@@ -1127,7 +1127,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
   public static void executeFunctionFunctionInvocationTargetExceptionWithoutHA() {
     try {
-      ResultCollector rc1 = FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+      ResultCollector rc1 = FunctionService.onRegion(region).setArguments(Boolean.TRUE)
           .execute("DistribuedRegionFunctionFunctionInvocationException", true, false);
       rc1.getResult();
       fail("Function Invocation Target Exception should be thrown");
@@ -1141,7 +1141,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
   public static void executeFunctionFunctionInvocationTargetException_ClientServer() {
     try {
-      List list = (ArrayList) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+      List list = (ArrayList) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
           .execute("DistribuedRegionFunctionFunctionInvocationException").getResult();
       assertEquals(1, list.size());
       assertEquals(5, list.get(0));
@@ -1153,7 +1153,7 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
 
   public static void executeFunctionFunctionInvocationTargetException_ClientServer_WithoutHA() {
     try {
-      FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+      FunctionService.onRegion(region).setArguments(Boolean.TRUE)
           .execute("DistribuedRegionFunctionFunctionInvocationException", true, false).getResult();
       fail("Function Invocation Target Exception should be thrown");
     } catch (Exception e) {
@@ -1185,8 +1185,8 @@ public class DistributedRegionFunctionExecutionDUnitTest extends JUnit4Distribut
     }
     // dummy argument Boolean.TRUE indicates that cache should be closed
     // in the function body itself on the first try
-    List list = (List) FunctionService.onRegion(region).withFilter(filter).withArgs(Boolean.TRUE)
-        .execute(function).getResult();
+    List list = (List) FunctionService.onRegion(region).withFilter(filter)
+        .setArguments(Boolean.TRUE).execute(function).getResult();
     return list;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionExecution_ExceptionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionExecution_ExceptionDUnitTest.java
@@ -96,12 +96,12 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 = null;
-        rs1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         ArrayList results = (ArrayList) rs1.getResult();
         assertTrue(results.get(0) instanceof Exception);
 
-        rs1 =
-            dataSet.withFilter(testKeysSet).withArgs((Serializable) testKeysSet).execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments((Serializable) testKeysSet)
+            .execute(function);
         results = (ArrayList) rs1.getResult();
         assertEquals((testKeysSet.size() + 1), results.size());
         Iterator resultIterator = results.iterator();
@@ -155,7 +155,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 = null;
-        rs1 = dataSet.withFilter(testKeysSet).withArgs("Multiple").execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments("Multiple").execute(function);
         ArrayList results = (ArrayList) rs1.getResult();
         assertTrue(results.get(0) instanceof Exception);
         return Boolean.TRUE;
@@ -200,7 +200,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 = null;
-        rs1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         try {
           ArrayList results = (ArrayList) rs1.getResult();
           fail("Expecting Exception");
@@ -261,13 +261,13 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 = null;
-        // rs1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(
+        // rs1 = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(
         // function);
         // ArrayList results = (ArrayList)rs1.getResult();
         // assertTrue(results.get(0) instanceof Exception);
         //
-        rs1 =
-            dataSet.withFilter(testKeysSet).withArgs((Serializable) testKeysSet).execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments((Serializable) testKeysSet)
+            .execute(function);
         ArrayList results = (ArrayList) rs1.getResult();
         assertEquals((testKeysSet.size() + 1), results.size());
         Iterator resultIterator = results.iterator();
@@ -332,7 +332,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 = null;
-        rs1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+        rs1 = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         try {
           ArrayList results = (ArrayList) rs1.getResult();
           fail("Expecting Exception");
@@ -396,7 +396,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
           pr.put(val, "MyValue_" + i);
         }
         ResultCollector rs1 =
-            dataSet.withFilter(origVals).withArgs((Serializable) origVals).execute(function);
+            dataSet.withFilter(origVals).setArguments((Serializable) origVals).execute(function);
         List results = (ArrayList) rs1.getResult();
         assertEquals(((origVals.size() * 3) + 3), results.size());
         Iterator resultIterator = results.iterator();
@@ -458,7 +458,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
         }
         ResultCollector rc2 = null;
         ResultCollector rs1 =
-            dataSet.withFilter(origVals).withArgs((Serializable) origVals).execute(function);
+            dataSet.withFilter(origVals).setArguments((Serializable) origVals).execute(function);
         List results = (ArrayList) rs1.getResult();
         assertEquals(((origVals.size() * 4) + 4), results.size());
         Iterator resultIterator = results.iterator();
@@ -527,7 +527,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
           pr.put(val, "MyValue_" + i);
         }
         ResultCollector rc2 = null;
-        rc2 = dataSet.withFilter(origVals).withArgs(origVals).execute(function.getId());
+        rc2 = dataSet.withFilter(origVals).setArguments(origVals).execute(function.getId());
         try {
           ArrayList results = (ArrayList) rc2.getResult();
           fail("Expecting Exception");
@@ -585,7 +585,7 @@ public class FunctionExecution_ExceptionDUnitTest extends PartitionedRegionDUnit
           pr.put(val, "MyValue_" + i);
         }
         ResultCollector rc2 = null;
-        rc2 = dataSet.withFilter(origVals).withArgs(origVals).execute(function.getId());
+        rc2 = dataSet.withFilter(origVals).setArguments(origVals).execute(function.getId());
         try {
           ArrayList results = (ArrayList) rc2.getResult();
           fail("Expecting Exception");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
@@ -217,8 +217,8 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
                 origVals.add(val);
                 region.put(i.next(), val);
               }
-              ResultCollector rc =
-                  dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+              ResultCollector rc = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
+                  .execute(function.getId());
               int resultSize = ((List) rc.getResult()).size();
               resultReceived_Aggregate += resultSize;
               resultReceived_TESTFUNCTION2 += resultSize;
@@ -227,7 +227,8 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
               noOfExecutionsCompleted_Aggregate++;
               noOfExecutionsCompleted_TESTFUNCTION2++;
 
-              rc = dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function.getId());
+              rc = dataSet.withFilter(testKeysSet).setArguments(testKeysSet)
+                  .execute(function.getId());
               resultSize = ((List) rc.getResult()).size();
               resultReceived_Aggregate += resultSize;
               resultReceived_TESTFUNCTION2 += resultSize;
@@ -238,7 +239,8 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
 
               function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
               FunctionService.registerFunction(function);
-              rc = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+              rc = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
+                  .execute(function.getId());
               resultSize = ((List) rc.getResult()).size();
               resultReceived_Aggregate += resultSize;
               resultReceived_TESTFUNCTION3 += resultSize;
@@ -548,7 +550,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         Execution member = FunctionService.onServers(pool);
 
         try {
-          ResultCollector rs = member.withArgs(Boolean.TRUE).execute(function.getId());
+          ResultCollector rs = member.setArguments(Boolean.TRUE).execute(function.getId());
           int size = ((List) rs.getResult()).size();
           resultReceived_Aggregate += size;
           noOfExecutionCalls_Aggregate++;
@@ -568,7 +570,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
           for (int i = 0; i < 20; i++) {
             testKeysSet.add("execKey-" + i);
           }
-          ResultCollector rs = member.withArgs("Success").execute(function.getId());
+          ResultCollector rs = member.setArguments("Success").execute(function.getId());
           int size = ((List) rs.getResult()).size();
           resultReceived_Aggregate += size;
           noOfExecutionCalls_Aggregate++;
@@ -771,19 +773,19 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function);
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
         int size = ((List) rc1.getResult()).size();
         resultReceived_Aggregate += size;
         resultReceived_TESTFUNCTION2 += size;
 
-        rc1 = dataSet.withArgs(testKeys).execute(function);
+        rc1 = dataSet.setArguments(testKeys).execute(function);
         size = ((List) rc1.getResult()).size();
         resultReceived_Aggregate += size;
         resultReceived_TESTFUNCTION2 += size;
 
         function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
         FunctionService.registerFunction(function);
-        rc1 = dataSet.withArgs(Boolean.TRUE).execute(function);
+        rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
         size = ((List) rc1.getResult()).size();
         resultReceived_Aggregate += size;
         resultReceived_TESTFUNCTION3 += size;
@@ -942,7 +944,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
           public Object call() throws Exception {
             Region region = getCache().getRegion(rName);
             try {
-              List list = (List) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+              List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
                   .execute(TestFunction.TEST_FUNCTION2).getResult();
               // this is the Distributed Region with Empty Data policy.
               // therefore no function execution takes place here. it only receives the results.
@@ -1057,7 +1059,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         DistributedMember localmember = ds.getDistributedMember();
         memberExecution = FunctionService.onMember(ds, localmember);
 
-        memberExecution.withArgs("Key");
+        memberExecution.setArguments("Key");
         try {
           ResultCollector rc = memberExecution.execute(inlineFunction);
           int size = ((List) rc.getResult()).size();
@@ -1198,7 +1200,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
           Function function = new TestFunction(true, "TestFunctionException");
           FunctionService.registerFunction(function);
           Execution dataSet = FunctionService.onRegion(pr);
-          ResultCollector rc = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+          ResultCollector rc = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
           // Wait Criterion is added to make sure that the function execution
           // happens on all nodes and all nodes get the FunctionException so that the stats will get
           // incremented,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/LocalFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/LocalFunctionExecutionDUnitTest.java
@@ -143,7 +143,7 @@ public class LocalFunctionExecutionDUnitTest extends JUnit4DistributedTestCase {
       Function function1 = new TestFunction(true, TestFunction.TEST_FUNCTION_EXCEPTION);
       FunctionService.registerFunction(function1);
       ResultCollector rc =
-          FunctionService.onRegion(region).withArgs(Boolean.TRUE).execute(function1.getId());
+          FunctionService.onRegion(region).setArguments(Boolean.TRUE).execute(function1.getId());
       rc.getResult();
       Assert.fail("Exception should occur", new Exception("Test Failed"));
     } catch (Exception e) {
@@ -157,7 +157,7 @@ public class LocalFunctionExecutionDUnitTest extends JUnit4DistributedTestCase {
       FunctionService.registerFunction(function1);
       DistributedMember localmember = getSystemStatic().getDistributedMember();
       ResultCollector rc = FunctionService.onMember(getSystemStatic(), localmember)
-          .withArgs(Boolean.TRUE).execute(function1.getId());
+          .setArguments(Boolean.TRUE).execute(function1.getId());
       rc.getResult();
       Assert.fail("Exception should occur", new Exception("Test Failed"));
     } catch (Exception e) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutionDUnitTest.java
@@ -379,7 +379,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
     DistributedMember localmember = ds.getDistributedMember();
     Execution memberExcution = null;
     memberExcution = FunctionService.onMember(ds, localmember);
-    Execution executor = memberExcution.withArgs("Key");
+    Execution executor = memberExcution.setArguments("Key");
     try {
       ResultCollector rc = executor.execute(new FunctionAdapter() {
         @Override
@@ -492,7 +492,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
       memberExcution = (InternalExecution) FunctionService.onMembers(ds, memberSet);
     }
     try {
-      ResultCollector rc = memberExcution.withArgs(Boolean.TRUE).execute(function);
+      ResultCollector rc = memberExcution.setArguments(Boolean.TRUE).execute(function);
       List li = (ArrayList) rc.getResult();
       LogWriterUtils.getLogWriter()
           .info("MemberFunctionExecutionDUnitTest#excuteOnMembers: Result : " + li);
@@ -569,7 +569,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
       memberSet.remove(localVM);
       memberExcution = FunctionService.onMembers(ds, memberSet);
     }
-    Execution executor = memberExcution.withArgs("Key");
+    Execution executor = memberExcution.setArguments("Key");
     try {
       ResultCollector rc = executor.execute(new FunctionAdapter() {
         @Override
@@ -612,7 +612,7 @@ public class MemberFunctionExecutionDUnitTest extends JUnit4CacheTestCase {
     assertNotNull(ds);
     Function function = new TestFunction(false, TEST_FUNCTION6);
     Execution memberExcution = FunctionService.onMembers(ds);
-    Execution executor = memberExcution.withArgs("Key");
+    Execution executor = memberExcution.setArguments("Key");
     try {
       ResultCollector rc = executor.execute(function.getId());
       rc.getResult();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/OnGroupsFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/OnGroupsFunctionExecutionDUnitTest.java
@@ -237,7 +237,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = FunctionService.onMembers("gm");
         ArrayList<String> args = new ArrayList<String>();
         args.add("gm");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         if (registerFunction) {
           e.execute(OnGroupsFunction.Id).getResult();
         } else {
@@ -258,7 +258,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = FunctionService.onMembers("g0");
         ArrayList<String> args = new ArrayList<String>();
         args.add("g0");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         if (registerFunction) {
           e.execute(OnGroupsFunction.Id).getResult();
         } else {
@@ -278,7 +278,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = FunctionService.onMembers("g1");
         ArrayList<String> args = new ArrayList<String>();
         args.add("g1");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         if (registerFunction) {
           e.execute(OnGroupsFunction.Id).getResult();
         } else {
@@ -300,7 +300,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         ArrayList<String> args = new ArrayList<String>();
         args.add("g0");
         args.add("g1");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         if (registerFunction) {
           e.execute(OnGroupsFunction.Id).getResult();
         } else {
@@ -511,7 +511,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = FunctionService.onMembers("mg");
         ArrayList<String> args = new ArrayList<String>();
         args.add("runtime");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         try {
           e.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -520,7 +520,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         }
 
         Execution e1 = FunctionService.onMembers("g1");
-        e1 = e1.withArgs(args);
+        e1 = e1.setArguments(args);
         try {
           e1.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -531,7 +531,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         // fail on only one member
         Execution e2 = FunctionService.onMembers("g1");
         args.add("g2");
-        e2 = e2.withArgs(args);
+        e2 = e2.setArguments(args);
         try {
           e2.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -562,7 +562,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e1 = FunctionService.onMembers("g1");
         ArrayList<String> args = new ArrayList<String>();
         args.add("shutdown");
-        e1 = e1.withArgs(args);
+        e1 = e1.setArguments(args);
         try {
           e1.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -594,7 +594,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         ArrayList<String> args = new ArrayList<String>();
         args.add("shutdown");
         args.add("g2");
-        e1 = e1.withArgs(args);
+        e1 = e1.setArguments(args);
         try {
           e1.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -626,7 +626,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         ArrayList<String> args = new ArrayList<String>();
         args.add("shutdown");
         args.add("g2");
-        e1 = e1.withArgs(args);
+        e1 = e1.setArguments(args);
         ((AbstractExecution) e1).setIgnoreDepartedMembers(true);
         ArrayList l = (ArrayList) e1.execute(new OnGroupsExceptionFunction()).getResult();
         assertEquals(2, l.size());
@@ -705,7 +705,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         if (withArgs) {
           ArrayList<String> args = new ArrayList<String>();
           args.add("g0");
-          e = e.withArgs(args);
+          e = e.setArguments(args);
         }
         if (register) {
           e.execute(OnGroupsFunction.Id).getResult();
@@ -728,7 +728,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         if (withArgs) {
           ArrayList<String> args = new ArrayList<String>();
           args.add("mg");
-          e = e.withArgs(args);
+          e = e.setArguments(args);
         }
         if (register) {
           e.execute(OnGroupsFunction.Id).getResult();
@@ -752,7 +752,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
           ArrayList<String> args = new ArrayList<String>();
           args.add("g0");
           args.add("g1");
-          e = e.withArgs(args);
+          e = e.setArguments(args);
         }
         if (register) {
           e.execute(OnGroupsFunction.Id).getResult();
@@ -977,7 +977,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = InternalFunctionService.onServers(c, "mg");
         ArrayList<String> args = new ArrayList<String>();
         args.add("runtime");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         try {
           e.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -986,7 +986,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         }
 
         Execution e1 = InternalFunctionService.onServers(c, "g1");
-        e1 = e1.withArgs(args);
+        e1 = e1.setArguments(args);
         try {
           e1.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -997,7 +997,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         // only one member
         Execution e2 = InternalFunctionService.onServers(c, "g1");
         args.add("g2");
-        e2 = e2.withArgs(args);
+        e2 = e2.setArguments(args);
         try {
           e2.execute(new OnGroupsExceptionFunction()).getResult();
           fail("expected exception not thrown");
@@ -1045,7 +1045,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         Execution e = InternalFunctionService.onServers(c, "g1");
         ArrayList<String> args = new ArrayList<String>();
         args.add("disconnect");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
 
         IgnoredException.addIgnoredException("FunctionInvocationTargetException");
         try {
@@ -1096,7 +1096,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         ArrayList<String> args = new ArrayList<String>();
         args.add("disconnect");
         args.add("g2");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         IgnoredException.addIgnoredException("FunctionInvocationTargetException");
         try {
           e.execute(new OnGroupsExceptionFunction()).getResult();
@@ -1146,7 +1146,7 @@ public class OnGroupsFunctionExecutionDUnitTest extends JUnit4DistributedTestCas
         ArrayList<String> args = new ArrayList<String>();
         args.add("disconnect");
         args.add("g2");
-        e = e.withArgs(args);
+        e = e.setArguments(args);
         ((AbstractExecution) e).setIgnoreDepartedMembers(true);
         ArrayList l = (ArrayList) e.execute(new OnGroupsExceptionFunction()).getResult();
         LogWriterUtils.getLogWriter().info("SWAP:result:" + l);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
@@ -235,19 +235,19 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
     if (isByName.booleanValue()) {// by name
       if (toRegister.booleanValue()) {
         LogWriterUtils.getLogWriter().info("The function name to execute : " + function.getId());
-        Execution me = member.withArgs(args);
+        Execution me = member.setArguments(args);
         LogWriterUtils.getLogWriter().info("The args passed  : " + args);
         return me.execute(function.getId());
       } else {
         LogWriterUtils.getLogWriter()
             .info("The function name to execute : (without Register) " + function.getId());
-        Execution me = member.withArgs(args);
+        Execution me = member.setArguments(args);
         LogWriterUtils.getLogWriter().info("The args passed  : " + args);
         return me.execute(function.getId(), function.hasResult(), function.isHA(),
             function.optimizeForWrite());
       }
     } else { // By Instance
-      return member.withArgs(args).execute(function);
+      return member.setArguments(args).execute(function);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
@@ -606,7 +606,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       Integer val = new Integer(j++);
       region.put(i.next(), val);
     }
-    List list = (List) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+    List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
@@ -672,7 +672,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Execution dataSet = FunctionService.onRegion(region);
     try {
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
       List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
@@ -696,7 +696,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     ResultCollector rc1 =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
     LogWriterUtils.getLogWriter().info("Result size : " + l.size());
     return l;
@@ -993,7 +993,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       }
       List l = null;
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
@@ -1045,28 +1045,29 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
     ResultCollector rc1 = null;
     try {
-      rc1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
-        @Override
-        public void execute(FunctionContext context) {
-          if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-            context.getResultSender().lastResult(new Integer(retryCount));
-            return;
-          }
-          if (context.getArguments() instanceof Boolean) {
-            throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
-          }
-        }
+      rc1 =
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
+            @Override
+            public void execute(FunctionContext context) {
+              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
+                context.getResultSender().lastResult(new Integer(retryCount));
+                return;
+              }
+              if (context.getArguments() instanceof Boolean) {
+                throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
+              }
+            }
 
-        @Override
-        public String getId() {
-          return getClass().getName();
-        }
+            @Override
+            public String getId() {
+              return getClass().getName();
+            }
 
-        @Override
-        public boolean hasResult() {
-          return true;
-        }
-      });
+            @Override
+            public boolean hasResult() {
+              return true;
+            }
+          });
 
       List list = (ArrayList) rc1.getResult();
       assertEquals(list.get(0), 0);
@@ -1120,7 +1121,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
     Function function = new TestFunction(false, TEST_FUNCTION2);
     Execution dataSet = FunctionService.onRegion(region);
-    dataSet.withArgs(Boolean.TRUE).execute(function);
+    dataSet.setArguments(Boolean.TRUE).execute(function);
     region.put(new Integer(2), "KB_2");
     assertEquals("KB_2", region.get(new Integer(2)));
   }
@@ -1130,7 +1131,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertNotNull(region);
     Function function = new TestFunction(false, TEST_FUNCTION2);
     Execution dataSet = FunctionService.onServer(pool);
-    dataSet.withArgs(Boolean.TRUE).execute(function);
+    dataSet.setArguments(Boolean.TRUE).execute(function);
     region.put(new Integer(1), "KB_1");
     assertEquals("KB_1", region.get(new Integer(1)));
   }
@@ -1190,14 +1191,14 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Execution dataSet = FunctionService.onRegion(region);
     region.put(testKey, new Integer(1));
     ((AbstractExecution) dataSet).removeFunctionAttributes(TestFunction.TEST_FUNCTION2);
-    ResultCollector rs =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(TestFunction.TEST_FUNCTION2);
+    ResultCollector rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
+        .execute(TestFunction.TEST_FUNCTION2);
     assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
     byte[] functionAttributes =
         ((AbstractExecution) dataSet).getFunctionAttributes(TestFunction.TEST_FUNCTION2);
     assertNotNull(functionAttributes);
 
-    rs = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE)
+    rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
         .execute(TestFunction.TEST_FUNCTION2);
     assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
     assertNotNull(functionAttributes);
@@ -1371,7 +1372,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
           .info("<ExpectedException action=add>" + "No target node found for KEY = "
               + "|Server could not send the reply" + "|Unexpected exception during"
               + "</ExpectedException>");
-      dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
@@ -1406,7 +1407,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     region.put(testKey, new Integer(1));
 
     ResultCollector rs =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -1429,7 +1430,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertEquals("Failure", ((List) rs.getResult()).get(0));
 
     ResultCollector rs2 =
-        dataSet.withFilter(testKeysSet).withArgs(testKey).execute(new FunctionAdapter() {
+        dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -1483,7 +1484,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
           .info("<ExpectedException action=add>"
               + "Could not create an instance of  org.apache.geode.internal.cache.execute.PRClientServerRegionFunctionExecutionDUnitTest$UnDeserializable"
               + "</ExpectedException>");
-      dataSet.withFilter(testKeysSet).withArgs(new UnDeserializable())
+      dataSet.withFilter(testKeysSet).setArguments(new UnDeserializable())
           .execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
@@ -1519,9 +1520,9 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function.getId());
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function);
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
@@ -483,7 +483,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
 
   public static Object executeFunction() {
     Execution execute = FunctionService.onRegion(region);
-    ResultCollector rc = execute.withArgs(Boolean.TRUE)
+    ResultCollector rc = execute.setArguments(Boolean.TRUE)
         .execute(new TestFunction(true, TestFunction.TEST_FUNCTION_LASTRESULT));
     LogWriterUtils.getLogWriter().info("Exeuction Result :" + rc.getResult());
     List l = ((List) rc.getResult());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
@@ -436,7 +436,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       Integer val = new Integer(j++);
       region.put(i.next(), val);
     }
-    HashMap resultMap = (HashMap) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+    HashMap resultMap = (HashMap) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -511,7 +511,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
 
       HashMap resultMap = ((HashMap) rc1.getResult());
       assertEquals(3, resultMap.size());
@@ -549,7 +549,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     ResultCollector rc1 =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
     LogWriterUtils.getLogWriter().info("Result size : " + l.size());
     return l;
@@ -880,7 +880,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       }
       List l = null;
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -929,25 +929,26 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
     ResultCollector rc1 = null;
     try {
-      rc1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
-        public void execute(FunctionContext context) {
-          if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-            context.getResultSender().lastResult(new Integer(retryCount));
-            return;
-          }
-          if (context.getArguments() instanceof Boolean) {
-            throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
-          }
-        }
+      rc1 =
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
+            public void execute(FunctionContext context) {
+              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
+                context.getResultSender().lastResult(new Integer(retryCount));
+                return;
+              }
+              if (context.getArguments() instanceof Boolean) {
+                throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
+              }
+            }
 
-        public String getId() {
-          return getClass().getName();
-        }
+            public String getId() {
+              return getClass().getName();
+            }
 
-        public boolean hasResult() {
-          return true;
-        }
-      });
+            public boolean hasResult() {
+              return true;
+            }
+          });
 
       List list = (ArrayList) rc1.getResult();
       assertEquals(list.get(0), 0);
@@ -1078,7 +1079,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
           .info("<ExpectedException action=add>" + "No target node found for KEY = "
               + "|Server could not send the reply" + "|Unexpected exception during"
               + "</ExpectedException>");
-      dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -1109,7 +1110,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     region.put(testKey, new Integer(1));
     try {
       ResultCollector rs =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -1129,7 +1130,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       assertEquals("Failure", ((List) rs.getResult()).get(0));
 
       ResultCollector rs2 =
-          dataSet.withFilter(testKeysSet).withArgs(testKey).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -1158,18 +1159,18 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function.getId());
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function);
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
     }
   }
 
   private static ResultCollector executeOnAll(Execution dataSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withArgs(args).execute(function.getId());
+      return dataSet.setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withArgs(args).execute(function);
+      return dataSet.setArguments(args).execute(function);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
@@ -414,7 +414,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       Integer val = new Integer(j++);
       region.put(i.next(), val);
     }
-    HashMap resultMap = (HashMap) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+    HashMap resultMap = (HashMap) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -489,7 +489,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
 
       HashMap resultMap = ((HashMap) rc1.getResult());
       assertEquals(3, resultMap.size());
@@ -527,7 +527,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     ResultCollector rc1 =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
     LogWriterUtils.getLogWriter().info("Result size : " + l.size());
     return l;
@@ -851,7 +851,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       }
       List l = null;
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -900,25 +900,26 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
     ResultCollector rc1 = null;
     try {
-      rc1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
-        public void execute(FunctionContext context) {
-          if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-            context.getResultSender().lastResult(new Integer(retryCount));
-            return;
-          }
-          if (context.getArguments() instanceof Boolean) {
-            throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
-          }
-        }
+      rc1 =
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
+            public void execute(FunctionContext context) {
+              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
+                context.getResultSender().lastResult(new Integer(retryCount));
+                return;
+              }
+              if (context.getArguments() instanceof Boolean) {
+                throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
+              }
+            }
 
-        public String getId() {
-          return getClass().getName();
-        }
+            public String getId() {
+              return getClass().getName();
+            }
 
-        public boolean hasResult() {
-          return true;
-        }
-      });
+            public boolean hasResult() {
+              return true;
+            }
+          });
 
       List list = (ArrayList) rc1.getResult();
       assertEquals(list.get(0), 0);
@@ -1049,7 +1050,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
           .info("<ExpectedException action=add>" + "No target node found for KEY = "
               + "|Server could not send the reply" + "|Unexpected exception during"
               + "</ExpectedException>");
-      dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
             context.getResultSender().lastResult("Success");
@@ -1080,7 +1081,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     region.put(testKey, new Integer(1));
     try {
       ResultCollector rs =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -1100,7 +1101,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       assertEquals("Failure", ((List) rs.getResult()).get(0));
 
       ResultCollector rs2 =
-          dataSet.withFilter(testKeysSet).withArgs(testKey).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
                 context.getResultSender().lastResult("Success");
@@ -1129,18 +1130,18 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function.getId());
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function);
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
     }
   }
 
   private static ResultCollector executeOnAll(Execution dataSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withArgs(args).execute(function.getId());
+      return dataSet.setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withArgs(args).execute(function);
+      return dataSet.setArguments(args).execute(function);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
@@ -449,7 +449,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       Integer val = new Integer(j++);
       region.put(i.next(), val);
     }
-    HashMap resultMap = (HashMap) FunctionService.onRegion(region).withArgs(Boolean.TRUE)
+    HashMap resultMap = (HashMap) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
@@ -525,7 +525,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
 
       HashMap resultMap = ((HashMap) rc1.getResult());
       assertEquals(3, resultMap.size());
@@ -561,7 +561,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     ResultCollector rc1 =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
     LogWriterUtils.getLogWriter().info("Result size : " + l.size());
     return l;
@@ -889,7 +889,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       }
       List l = null;
       ResultCollector rc1 =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
@@ -941,28 +941,29 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     }
     ResultCollector rc1 = null;
     try {
-      rc1 = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
-        @Override
-        public void execute(FunctionContext context) {
-          if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-            context.getResultSender().lastResult(new Integer(retryCount));
-            return;
-          }
-          if (context.getArguments() instanceof Boolean) {
-            throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
-          }
-        }
+      rc1 =
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
+            @Override
+            public void execute(FunctionContext context) {
+              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
+                context.getResultSender().lastResult(new Integer(retryCount));
+                return;
+              }
+              if (context.getArguments() instanceof Boolean) {
+                throw new FunctionInvocationTargetException("I have been thrown from TestFunction");
+              }
+            }
 
-        @Override
-        public String getId() {
-          return getClass().getName();
-        }
+            @Override
+            public String getId() {
+              return getClass().getName();
+            }
 
-        @Override
-        public boolean hasResult() {
-          return true;
-        }
-      });
+            @Override
+            public boolean hasResult() {
+              return true;
+            }
+          });
 
       List list = (ArrayList) rc1.getResult();
       assertEquals(list.get(0), 0);
@@ -1093,7 +1094,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
           .info("<ExpectedException action=add>" + "No target node found for KEY = "
               + "|Server could not send the reply" + "|Unexpected exception during"
               + "</ExpectedException>");
-      dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+      dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext context) {
           if (context.getArguments() instanceof String) {
@@ -1127,7 +1128,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     region.put(testKey, new Integer(1));
     try {
       ResultCollector rs =
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
@@ -1150,7 +1151,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       assertEquals("Failure", ((List) rs.getResult()).get(0));
 
       ResultCollector rs2 =
-          dataSet.withFilter(testKeysSet).withArgs(testKey).execute(new FunctionAdapter() {
+          dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
               if (context.getArguments() instanceof String) {
@@ -1182,18 +1183,18 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function.getId());
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withFilter(testKeysSet).withArgs(args).execute(function);
+      return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
     }
   }
 
   private static ResultCollector executeOnAll(Execution dataSet, Serializable args,
       Function function, Boolean isByName) throws Exception {
     if (isByName.booleanValue()) {// by name
-      return dataSet.withArgs(args).execute(function.getId());
+      return dataSet.setArguments(args).execute(function.getId());
     } else { // By Instance
-      return dataSet.withArgs(args).execute(function);
+      return dataSet.setArguments(args).execute(function);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
@@ -139,7 +139,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         Execution dataSet = FunctionService.onRegion(pr);
         ResultCollector result =
-            dataSet.withArgs(Boolean.TRUE).withFilter(testKeysSet).execute(function);
+            dataSet.setArguments(Boolean.TRUE).withFilter(testKeysSet).execute(function);
         System.out.println("KBKBKB : Result I got : " + result.getResult());
         return Boolean.TRUE;
       }
@@ -179,7 +179,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         try {
           Execution dataSet = FunctionService.onRegion(pr);
-          dataSet.withFilter(testKeysSet).withArgs(testKey).execute(function);
+          dataSet.withFilter(testKeysSet).setArguments(testKey).execute(function);
           fail("It should have failed with Function attributes don't match");
         } catch (Exception expected) {
           expected.printStackTrace();
@@ -239,24 +239,24 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
         }
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
         ResultCollector rs2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKey).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKey).execute(function.getId());
         assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
 
         HashMap putData = new HashMap();
         putData.put(testKey + "1", new Integer(2));
         putData.put(testKey + "2", new Integer(3));
         ResultCollector rs3 =
-            dataSet.withFilter(testKeysSet).withArgs(putData).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(putData).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs3.getResult()).get(0));
 
         assertEquals(new Integer(2), pr.get(testKey + "1"));
@@ -299,7 +299,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         pr.put(testKey, new Integer(1));
         try {
           ResultCollector rs1 =
-              dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+              dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           List list = (ArrayList) rs1.getResult();
           assertEquals(list.get(0), 5);
         } catch (Throwable e) {
@@ -364,7 +364,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         pr.put(testKey, new Integer(1));
         try {
           ResultCollector rs1 =
-              dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+              dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           List list = (ArrayList) rs1.getResult();
           assertEquals(list.get(0), 5);
         } catch (Throwable e) {
@@ -425,7 +425,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Execution dataSet = FunctionService.onRegion(pr); // withCollector(rs);
 
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
 
         } catch (Exception expected) {
           // No data should cause exec to throw
@@ -434,15 +434,17 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
-        ResultCollector rs2 = dataSet.withFilter(testKeysSet).withArgs(testKey).execute(function);
+        ResultCollector rs2 =
+            dataSet.withFilter(testKeysSet).setArguments(testKey).execute(function);
         assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
 
         HashMap putData = new HashMap();
         putData.put(testKey + "1", new Integer(2));
         putData.put(testKey + "2", new Integer(3));
-        ResultCollector rs3 = dataSet.withFilter(testKeysSet).withArgs(putData).execute(function);
+        ResultCollector rs3 =
+            dataSet.withFilter(testKeysSet).setArguments(putData).execute(function);
         assertEquals(Boolean.TRUE, ((List) rs3.getResult()).get(0));
 
         assertEquals(new Integer(2), pr.get(testKey + "1"));
@@ -496,8 +498,8 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         DistributedSystem.setThreadsSocketPolicy(false);
         Execution dataSet = FunctionService.onRegion(pr);
         pr.put(testKey, new Integer(1));
-        ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+        ResultCollector rs1 = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
+            .execute(new FunctionAdapter() {
               @Override
               public void execute(FunctionContext context) {
                 if (context.getArguments() instanceof String) {
@@ -577,7 +579,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Execution dataSet = FunctionService.onRegion(pr);
 
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           assertTrue(expected.getMessage(),
               expected.getMessage().contains("No target node found for KEY"));
@@ -591,7 +593,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           pr.put(i.next(), val);
         }
         ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rs.getResult());
         assertEquals(3, l.size());
 
@@ -601,7 +603,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
         ResultCollector rc2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function.getId());
         List l2 = ((List) rc2.getResult());
         assertEquals(3, l2.size());
         HashSet foundVals = new HashSet();
@@ -688,7 +690,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_LASTRESULT);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc2 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc2 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc2.getResult());
         return l;
       }
@@ -749,7 +751,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_LASTRESULT);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc2 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc2 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc2.getResult());
         return l;
       }
@@ -825,7 +827,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
         try {
           ResultCollector rs =
-              dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+              dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           List list = (ArrayList) rs.getResult();
           assertEquals(list.get(0), 5);
         } catch (Throwable e) {
@@ -1036,7 +1038,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(pr);
     ResultCollector rs =
-        dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rs.getResult());
     return l;
   }
@@ -1095,8 +1097,8 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           origVals.add(val);
           pr.put(i.next(), val);
         }
-        ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+        ResultCollector rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
+            .execute(new FunctionAdapter() {
               @Override
               public void execute(FunctionContext context) {
                 if (context.getArguments() instanceof String) {
@@ -1184,7 +1186,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           pr.put(i.next(), val);
         }
         ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rs.getResult());
         assertEquals(3, l.size());
 
@@ -1256,7 +1258,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
         ResultCollector rs;
         try {
-          rs = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           rs.getResult();
         } catch (Exception expected) {
           expected.printStackTrace();
@@ -1332,8 +1334,8 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           pr.put(i.next(), val);
         }
         // long startTime = System.currentTimeMillis();
-        ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs("TestingTimeOut").execute(function.getId());
+        ResultCollector rs = dataSet.withFilter(testKeysSet).setArguments("TestingTimeOut")
+            .execute(function.getId());
         // long endTime = System.currentTimeMillis();
         List l = ((List) rs.getResult(10000, TimeUnit.MILLISECONDS));
         assertEquals(3, l.size()); // this test may fail..but rarely
@@ -1404,7 +1406,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
         ResultCollector rs;
         try {
-          rs = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           rs.getResult();
         } catch (Exception expected) {
           assertTrue(expected.getMessage()
@@ -1470,7 +1472,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         } catch (Exception expected) {
           // No data should cause exec to throw
           LogWriterUtils.getLogWriter().warning("Exception Occured : " + expected.getMessage());
@@ -1488,7 +1490,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
         // DefaultResultCollector rc1 = new DefaultResultCollector();
         ResultCollector rc1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         List l = ((List) rc1.getResult());
         assertEquals(3, l.size());
 
@@ -1498,7 +1500,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
         ResultCollector rc2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function);
+            dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function);
         List l2 = ((List) rc2.getResult());
         // assertIndexDetailsEquals(pr.getTotalNumberOfBuckets(), l2.size());
         assertEquals(3, l2.size());
@@ -1753,7 +1755,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         final HashSet testKeysSet = new HashSet();
         testKeysSet.add(testKey);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
@@ -1773,7 +1775,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
 
         ResultCollector rc1 =
-            dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         // assertIndexDetailsEquals(pr.getTotalNumberOfBuckets(), l.size());
         assertEquals(1, l.size());
@@ -1783,7 +1785,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
         ResultCollector rc2 =
-            dataSet.withFilter(testKeys).withArgs(testKeys).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(testKeys).execute(function.getId());
         List l2 = ((List) rc2.getResult());
         assertEquals(1, l2.size());
 
@@ -1829,7 +1831,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         final HashSet testKeysSet = new HashSet();
         testKeysSet.add(testKey);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function);
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function);
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
@@ -1849,7 +1851,8 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
 
         // DefaultResultCollector rc1 = new DefaultResultCollector();
-        ResultCollector rc1 = dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function);
+        ResultCollector rc1 =
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function);
         List l = ((List) rc1.getResult());
         assertEquals(1, l.size());
         for (Iterator i = l.iterator(); i.hasNext();) {
@@ -1857,7 +1860,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         }
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
-        ResultCollector rc2 = dataSet.withFilter(testKeys).withArgs(testKeys).execute(function);
+        ResultCollector rc2 = dataSet.withFilter(testKeys).setArguments(testKeys).execute(function);
         List l2 = ((List) rc2.getResult());
         assertEquals(1, l2.size());
 
@@ -1932,14 +1935,14 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           FunctionService.registerFunction(function);
           Execution dataSet = FunctionService.onRegion(pr);
           ResultCollector rc1 =
-              dataSet.withFilter(singleKeySet).withArgs(Boolean.TRUE).execute(function.getId());
+              dataSet.withFilter(singleKeySet).setArguments(Boolean.TRUE).execute(function.getId());
           List l = ((List) rc1.getResult());
           assertEquals(1, l.size());
           assertEquals(Boolean.TRUE, l.iterator().next());
 
           // DefaultResultCollector rc2 = new DefaultResultCollector();
-          ResultCollector rc2 = dataSet.withFilter(singleKeySet).withArgs(new HashSet(singleKeySet))
-              .execute(function.getId());
+          ResultCollector rc2 = dataSet.withFilter(singleKeySet)
+              .setArguments(new HashSet(singleKeySet)).execute(function.getId());
           List l2 = ((List) rc2.getResult());
 
           assertEquals(1, l2.size());
@@ -2009,14 +2012,14 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           FunctionService.registerFunction(function);
           Execution dataSet = FunctionService.onRegion(pr);
           ResultCollector rc1 =
-              dataSet.withFilter(singleKeySet).withArgs(Boolean.TRUE).execute(function);
+              dataSet.withFilter(singleKeySet).setArguments(Boolean.TRUE).execute(function);
           List l = ((List) rc1.getResult());
           assertEquals(1, l.size());
           assertEquals(Boolean.TRUE, l.iterator().next());
 
           // DefaultResultCollector rc2 = new DefaultResultCollector();
-          ResultCollector rc2 = dataSet.withFilter(singleKeySet).withArgs(new HashSet(singleKeySet))
-              .execute(function);
+          ResultCollector rc2 = dataSet.withFilter(singleKeySet)
+              .setArguments(new HashSet(singleKeySet)).execute(function);
           List l2 = ((List) rc2.getResult());
 
           assertEquals(1, l2.size());
@@ -2083,7 +2086,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         LogWriterUtils.getLogWriter()
             .info("PRFunctionExecutionDUnitTest#testExecutionOnAllNodes_byName : Result size :"
@@ -2166,7 +2169,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function);
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
 
         List l = ((List) rc1.getResult());
         assertEquals(3, l.size());
@@ -2228,7 +2231,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           assertTrue(pr.getBucketKeys(bid).size() > 0);
         }
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -2328,7 +2331,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
           assertTrue(pr.getBucketKeys(bid).size() > 0);
         }
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(new FunctionAdapter() {
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
             if (context.getArguments() instanceof String) {
@@ -2425,7 +2428,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(testKeys).execute(function.getId());
+        ResultCollector rc1 = dataSet.setArguments(testKeys).execute(function.getId());
 
         List l = ((List) rc1.getResult());
         assertEquals(4, l.size());
@@ -2824,7 +2827,7 @@ public class PRFunctionExecutionDUnitTest extends PartitionedRegionDUnitTestCase
     keysForGet.add("KEY_7");
     try {
       Execution execution =
-          FunctionService.onRegion(region).withFilter(keysForGet).withArgs(Boolean.TRUE);
+          FunctionService.onRegion(region).withFilter(keysForGet).setArguments(Boolean.TRUE);
       ResultCollector rc = execution.execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext fc) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionTimeOutDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionTimeOutDUnitTest.java
@@ -116,14 +116,14 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
         }
         pr.put(testKey, new Integer(1));
         ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
         try {
           rs1.getResult();
@@ -134,7 +134,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
 
 
         ResultCollector rs2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKey).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKey).execute(function.getId());
         assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
         try {
           rs1.getResult();
@@ -147,7 +147,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         putData.put(testKey + "1", new Integer(2));
         putData.put(testKey + "2", new Integer(3));
         ResultCollector rs3 =
-            dataSet.withFilter(testKeysSet).withArgs(putData).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(putData).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs3.getResult(4000, TimeUnit.MILLISECONDS)).get(0));
         try {
           rs1.getResult();
@@ -161,7 +161,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
 
 
         ResultCollector rst1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         try {
           rst1.getResult(1000, TimeUnit.MILLISECONDS);
           fail("Did not get the expected timeout exception.");
@@ -177,7 +177,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
 
         ResultCollector rst2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKey).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKey).execute(function.getId());
         try {
           rst2.getResult(1000, TimeUnit.MILLISECONDS);
           fail("Did not get the expected timeout exception.");
@@ -196,7 +196,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         putDataTimeOut.put(testKey + "4", new Integer(4));
         putDataTimeOut.put(testKey + "5", new Integer(5));
         ResultCollector rst3 =
-            dataSet.withFilter(testKeysSet).withArgs(putDataTimeOut).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(putDataTimeOut).execute(function.getId());
         try {
           rst3.getResult(1000, TimeUnit.MILLISECONDS);
           fail("Did not get the expected timeout exception.");
@@ -273,7 +273,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         Execution dataSet = FunctionService.onRegion(pr);
 
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           assertTrue(expected.getMessage(),
               expected.getMessage().contains("No target node found for KEY"));
@@ -287,7 +287,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
           pr.put(i.next(), val);
         }
         ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rs.getResult());
         assertEquals(3, l.size());
 
@@ -304,7 +304,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
         ResultCollector rc2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function.getId());
         List l2 = ((List) rc2.getResult());
 
         assertEquals(3, l2.size());
@@ -327,7 +327,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
 
 
         ResultCollector rst =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         try {
           rst.getResult(1000, TimeUnit.MILLISECONDS);
           fail("Did not get the expected exception.");
@@ -344,7 +344,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
 
         ResultCollector rct2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function.getId());
 
         try {
           rct2.getResult(1000, TimeUnit.MILLISECONDS);
@@ -428,7 +428,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
           pr.put(i.next(), val);
         }
         ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         List l = (List) rs.getResult();
         assertEquals(3, l.size());
 
@@ -436,7 +436,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
           assertEquals(Boolean.TRUE, i.next());
         }
         ResultCollector rst =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
 
         try {
           rst.getResult(1000, TimeUnit.MILLISECONDS);
@@ -520,7 +520,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
         ResultCollector rs;
         try {
-          rs = dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           rs.getResult(1000, TimeUnit.MILLISECONDS);
           fail("Did not get the expected exception.");
         } catch (Exception expected) {
@@ -595,13 +595,13 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
           origVals.add(val);
           pr.put(i.next(), val);
         }
-        ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs("TestingTimeOut").execute(function.getId());
+        ResultCollector rs = dataSet.withFilter(testKeysSet).setArguments("TestingTimeOut")
+            .execute(function.getId());
         List l = ((List) rs.getResult(8000, TimeUnit.MILLISECONDS));
         assertEquals(3, l.size()); // this test may fail..but rarely
 
-        ResultCollector rst =
-            dataSet.withFilter(testKeysSet).withArgs("TestingTimeOut").execute(function.getId());
+        ResultCollector rst = dataSet.withFilter(testKeysSet).setArguments("TestingTimeOut")
+            .execute(function.getId());
         rst.getResult(8000, TimeUnit.MILLISECONDS);
         assertEquals(3, l.size());
 
@@ -652,7 +652,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         final HashSet testKeysSet = new HashSet();
         testKeysSet.add(testKey);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
           // TODO: expected exception pattern requires fail here
         } catch (Exception expected) {
           // No data should cause exec to throw
@@ -682,7 +682,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
 
         ResultCollector rc1 =
-            dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         assertEquals(1, l.size());
         for (Iterator i = l.iterator(); i.hasNext();) {
@@ -691,7 +691,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
 
         // DefaultResultCollector rc2 = new DefaultResultCollector();
         ResultCollector rc2 =
-            dataSet.withFilter(testKeys).withArgs(testKeys).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(testKeys).execute(function.getId());
         List l2 = ((List) rc2.getResult());
         assertEquals(1, l2.size());
 
@@ -706,7 +706,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         assertEquals(origVals, foundVals);
 
         ResultCollector rct1 =
-            dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function.getId());
 
         try {
           rct1.getResult(1000, TimeUnit.MILLISECONDS);
@@ -734,7 +734,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
 
         ResultCollector rct2 =
-            dataSet.withFilter(testKeys).withArgs(testKeys).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(testKeys).execute(function.getId());
 
         try {
           rct2.getResult(1000, TimeUnit.MILLISECONDS);
@@ -825,7 +825,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         Function function = new TestFunction(true, TEST_FUNCTION_TIMEOUT);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         assertEquals(4, l.size());
 
@@ -834,7 +834,7 @@ public class PRFunctionExecutionTimeOutDUnitTest extends PartitionedRegionDUnitT
         }
 
 
-        ResultCollector rct1 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rct1 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
 
         try {
           rct1.getResult(1000, TimeUnit.MILLISECONDS);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionWithResultSenderDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionWithResultSenderDUnitTest.java
@@ -120,7 +120,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
@@ -132,16 +132,16 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         testKeysSet.add(testKey + "4");
 
         ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
-        ResultCollector rs2 = dataSet.withFilter(testKeysSet).withArgs((Serializable) testKeysSet)
-            .execute(function.getId());
+        ResultCollector rs2 = dataSet.withFilter(testKeysSet)
+            .setArguments((Serializable) testKeysSet).execute(function.getId());
 
         HashMap putData = new HashMap();
         putData.put(testKey + "1", new Integer(2));
         putData.put(testKey + "2", new Integer(3));
         ResultCollector rs3 =
-            dataSet.withFilter(testKeysSet).withArgs(putData).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(putData).execute(function.getId());
         assertEquals(Boolean.TRUE, ((List) rs3.getResult()).get(0));
 
         assertEquals(new Integer(2), pr.get(testKey + "1"));
@@ -209,7 +209,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         testKeysSet.add(testKey + "4");
 
         ResultCollector rs1 =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         try {
           assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
           fail("Expected FunctionException : Function did not send last result");
@@ -279,7 +279,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         Execution dataSet = FunctionService.onRegion(pr);
 
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           assertTrue(expected.getMessage().contains("No target node found for KEY = "));
         }
@@ -292,7 +292,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
           pr.put(i.next(), val);
         }
         ResultCollector rs =
-            dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rs.getResult());
 
         assertEquals(3, l.size());
@@ -302,7 +302,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         }
 
         ResultCollector rc2 =
-            dataSet.withFilter(testKeysSet).withArgs(testKeysSet).execute(function.getId());
+            dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function.getId());
         List l2 = ((List) rc2.getResult());
         assertEquals(pr.getTotalNumberOfBuckets() * 2 * 3, l2.size());
 
@@ -341,7 +341,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         final HashSet testKeysSet = new HashSet();
         testKeysSet.add(testKey);
         try {
-          dataSet.withFilter(testKeysSet).withArgs(Boolean.TRUE).execute(function.getId());
+          dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
         } catch (Exception expected) {
           // No data should cause exec to throw
           assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey));
@@ -361,7 +361,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         }
 
         ResultCollector rc1 =
-            dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         assertEquals(1, l.size());
         for (Iterator i = l.iterator(); i.hasNext();) {
@@ -369,7 +369,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         }
 
         ResultCollector rc2 =
-            dataSet.withFilter(testKeys).withArgs(testKeys).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(testKeys).execute(function.getId());
         List l2 = ((List) rc2.getResult());
         assertEquals(226, l2.size());
 
@@ -419,7 +419,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         }
 
         ResultCollector rc1 =
-            dataSet.withFilter(testKeys).withArgs(Boolean.TRUE).execute(function.getId());
+            dataSet.withFilter(testKeys).setArguments(Boolean.TRUE).execute(function.getId());
         try {
           assertEquals(Boolean.TRUE, ((List) rc1.getResult()).get(0));
           fail("Expected FunctionException : Function did not send last result");
@@ -489,7 +489,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_NO_LASTRESULT);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         try {
           assertEquals(Boolean.TRUE, ((List) rc1.getResult()).get(0));
           fail("Expected FunctionException : Function did not send last result");
@@ -552,7 +552,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
         Function function = new TestFunction(true, TestFunction.TEST_FUNCTION9);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
         List l = ((List) rc1.getResult());
         LogWriterUtils.getLogWriter()
             .info("PRFunctionExecutionDUnitTest#testExecutionOnAllNodes_byName : Result size :"
@@ -613,7 +613,7 @@ public class PRFunctionExecutionWithResultSenderDUnitTest extends PartitionedReg
 
         Execution dataSet = FunctionService.onRegion(region);
         try {
-          ResultCollector rc = dataSet.withArgs(Boolean.TRUE).execute(function.getId());
+          ResultCollector rc = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
           Object o = rc.getResult();
           fail("Expected Function Exception");
         } catch (Exception expected) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PRTransactionDUnitTest.java
@@ -184,7 +184,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
         args.add(order);
         filter.add(custId);
         try {
-          e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+          e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
           fail("Expected exception was not thrown");
         } catch (FunctionException fe) {
           LogWriterUtils.getLogWriter().info("Caught Expected exception");
@@ -201,7 +201,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
         LogWriterUtils.getLogWriter().info("VERIFY_TX");
         orderpr.put(orderId, order);
         assertNotNull(orderpr.get(orderId));
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         assertTrue("Unexpected customer value after commit", newCus.equals(pr.get(custId)));
         Order commitedOrder = (Order) orderpr.get(orderId);
         assertTrue(
@@ -209,19 +209,19 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
             order.equals(commitedOrder));
         // verify conflict detection
         args.set(0, new Integer(VERIFY_TXSTATE_CONFLICT));
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         // verify that the transaction is rolled back
         args.set(0, new Integer(VERIFY_ROLLBACK));
         LogWriterUtils.getLogWriter().info("VERIFY_ROLLBACK");
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         // verify destroy
         args.set(0, new Integer(VERIFY_DESTROY));
         LogWriterUtils.getLogWriter().info("VERIFY_DESTROY");
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         // verify invalidate
         args.set(0, new Integer(VERIFY_INVALIDATE));
         LogWriterUtils.getLogWriter().info("VERIFY_INVALIDATE");
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         return Boolean.TRUE;
       }
     });
@@ -933,7 +933,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
         args.add(order);
         filter.add(custId);
         caughtException = false;
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
         return null;
       }
     });
@@ -979,7 +979,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
         args.add(orderId);
         args.add(order);
         filter.add(custId);
-        e.withFilter(filter).withArgs(args).execute(txFunction.getId()).getResult();
+        e.withFilter(filter).setArguments(args).execute(txFunction.getId()).getResult();
 
         return null;
       }
@@ -1036,7 +1036,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
           if (iterations > warmupIterations) {
             startTime = NanoTimer.getTime();
           }
-          e.withFilter(filter).withArgs(args).execute("perfFunction").getResult();
+          e.withFilter(filter).setArguments(args).execute("perfFunction").getResult();
           if (startTime > 0) {
             perfTime += NanoTimer.getTime() - startTime;
           }
@@ -1074,7 +1074,7 @@ public class PRTransactionDUnitTest extends PRColocationDUnitTest {
           if (iterations > warmupIterations) {
             startTime = NanoTimer.getTime();
           }
-          e.withFilter(filter).withArgs(args).execute("perfTxFunction").getResult();
+          e.withFilter(filter).setArguments(args).execute("perfTxFunction").getResult();
           if (startTime > 0) {
             perfTime += NanoTimer.getTime() - startTime;
           }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionResolverDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionResolverDUnitTest.java
@@ -316,7 +316,7 @@ public class PartitionResolverDUnitTest extends JUnit4CacheTestCase {
 
     accessor.invoke(new SerializableCallable() {
       public Object call() throws Exception {
-        FunctionService.onRegion(getGemfireCache().getRegion(CUSTOMER)).withArgs(type)
+        FunctionService.onRegion(getGemfireCache().getRegion(CUSTOMER)).setArguments(type)
             .execute(IteratorFunction.id).getResult();
         return null;
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
@@ -1161,7 +1161,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
       DistributedMember... members) {
     Set<DistributedMember> membersSet = new HashSet<>();
     Collections.addAll(membersSet, members);
-    Execution execution = FunctionService.onMembers(membersSet).withArgs(dsClassName);
+    Execution execution = FunctionService.onMembers(membersSet).setArguments(dsClassName);
     ResultCollector rc = execution.execute(functionId);
     List result = (List) rc.getResult();
     assertEquals(membersSet.size(), result.size());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
@@ -118,7 +118,7 @@ public class DiskStoreCommandsJUnitTest {
         will(returnValue(null));
         oneOf(mockMember).getId();
         will(returnValue(memberId));
-        oneOf(mockFunctionExecutor).withArgs(with(equal(diskStoreName)));
+        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
         will(returnValue(mockFunctionExecutor));
         oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
         will(returnValue(mockResultCollector));
@@ -185,7 +185,7 @@ public class DiskStoreCommandsJUnitTest {
         will(returnValue(null));
         oneOf(mockMember).getId();
         will(returnValue(memberId));
-        oneOf(mockFunctionExecutor).withArgs(with(equal(diskStoreName)));
+        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
         will(returnValue(mockFunctionExecutor));
         oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
         will(throwException(new DiskStoreNotFoundException("expected")));
@@ -221,7 +221,7 @@ public class DiskStoreCommandsJUnitTest {
         will(returnValue(null));
         oneOf(mockMember).getId();
         will(returnValue(memberId));
-        oneOf(mockFunctionExecutor).withArgs(with(equal(diskStoreName)));
+        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
         will(returnValue(mockFunctionExecutor));
         oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
         will(throwException(new RuntimeException("expected")));
@@ -260,7 +260,7 @@ public class DiskStoreCommandsJUnitTest {
         will(returnValue(null));
         oneOf(mockMember).getId();
         will(returnValue(memberId));
-        oneOf(mockFunctionExecutor).withArgs(with(equal(diskStoreName)));
+        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
         will(returnValue(mockFunctionExecutor));
         oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
         will(returnValue(mockResultCollector));

--- a/geode-core/src/test/java/org/apache/geode/security/ClientExecuteFunctionAuthDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientExecuteFunctionAuthDUnitTest.java
@@ -63,15 +63,15 @@ public class ClientExecuteFunctionAuthDUnitTest extends JUnit4DistributedTestCas
       FunctionService.registerFunction(function);
 
       assertNotAuthorized(() -> FunctionService.onServer(cache.getDefaultPool())
-          .withArgs(Boolean.TRUE).execute(function.getId()), "DATA:WRITE");
+          .setArguments(Boolean.TRUE).execute(function.getId()), "DATA:WRITE");
     });
 
     client2.invoke("logging in with super-user", () -> {
       ClientCache cache = createClientCache("super-user", "1234567", server.getPort());
 
       FunctionService.registerFunction(function);
-      ResultCollector rc = FunctionService.onServer(cache.getDefaultPool()).withArgs(Boolean.TRUE)
-          .execute(function.getId());
+      ResultCollector rc = FunctionService.onServer(cache.getDefaultPool())
+          .setArguments(Boolean.TRUE).execute(function.getId());
       rc.getResult();
     });
   }
@@ -83,7 +83,7 @@ public class ClientExecuteFunctionAuthDUnitTest extends JUnit4DistributedTestCas
     client1.invoke("logging in with dataReader", () -> {
       ClientCache cache = createClientCache("dataReader", "1234567", server.getPort());
       assertNotAuthorized(() -> FunctionService.onServer(cache.getDefaultPool())
-          .withArgs(Boolean.TRUE).execute(function.getId()), "DATA:WRITE");
+          .setArguments(Boolean.TRUE).execute(function.getId()), "DATA:WRITE");
     });
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/security/ClientExecuteRegionFunctionAuthDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientExecuteRegionFunctionAuthDUnitTest.java
@@ -64,9 +64,8 @@ public class ClientExecuteRegionFunctionAuthDUnitTest extends JUnit4DistributedT
 
       Region region = createProxyRegion(cache, REGION_NAME);
       FunctionService.registerFunction(function);
-      assertNotAuthorized(
-          () -> FunctionService.onRegion(region).withArgs(Boolean.TRUE).execute(function.getId()),
-          "DATA:WRITE");
+      assertNotAuthorized(() -> FunctionService.onRegion(region).setArguments(Boolean.TRUE)
+          .execute(function.getId()), "DATA:WRITE");
     });
 
     client2.invoke("logging in with super-user", () -> {
@@ -75,7 +74,7 @@ public class ClientExecuteRegionFunctionAuthDUnitTest extends JUnit4DistributedT
       Region region = createProxyRegion(cache, REGION_NAME);
       FunctionService.registerFunction(function);
       ResultCollector rc =
-          FunctionService.onRegion(region).withArgs(Boolean.TRUE).execute(function.getId());
+          FunctionService.onRegion(region).setArguments(Boolean.TRUE).execute(function.getId());
       rc.getResult();
     });
   }

--- a/geode-docs/developing/function_exec/function_execution.html.md.erb
+++ b/geode-docs/developing/function_exec/function_execution.html.md.erb
@@ -185,7 +185,7 @@ See [Function Execution Commands](../../tools_modules/gfsh/quick_ref_commands_by
 1.  Use one of the `FunctionService` `on*` methods to create an `Execute` object. The `on*` methods, `onRegion`, `onMembers`, etc., define the highest level where the function is run. For colocated partitioned regions, use `onRegion` and specify any one of the colocated regions. The function run using `onRegion` is referred to as a data dependent function - the others as data-independent functions.
 2.  Use the `Execution` object as needed for additional function configuration. You can:
     -   Provide a key `Set` to `withFilters` to narrow the execution scope for `onRegion` `Execution` objects. You can retrieve the key set in your `Function` `execute` method through `RegionFunctionContext.getFilter`.
-    -   Provide function arguments to `withArgs`. You can retrieve these in your `Function` `execute` method through `FunctionContext.getArguments`.
+    -   Provide function arguments to `setArguments`. You can retrieve these in your `Function` `execute` method through `FunctionContext.getArguments`.
     -   Define a custom `ResultCollector`
 
 3.  Call the `Execution` object to `execute` method to run the function.
@@ -209,7 +209,7 @@ keysForGet.add("KEY_7");
 
 Execution execution = FunctionService.onRegion(exampleRegion)
     .withFilter(keysForGet)
-    .withArgs(Boolean.TRUE)
+    .setArguments(Boolean.TRUE)
     .withCollector(new MyArrayListResultCollector());
 
 ResultCollector rc = execution.execute(function);
@@ -245,7 +245,7 @@ To customize results collecting:
     ``` pre
     Execution execution = FunctionService.onRegion(exampleRegion)
         .withFilter(keysForGet)
-        .withArgs(Boolean.TRUE)
+        .setArguments(Boolean.TRUE)
         .withCollector(new MyArrayListResultCollector());
     ```
 

--- a/geode-docs/developing/partitioned_regions/join_query_partitioned_regions.html.md.erb
+++ b/geode-docs/developing/partitioned_regions/join_query_partitioned_regions.html.md.erb
@@ -74,7 +74,7 @@ ArrayList argList = new ArrayList();
 argList.add(queryString);
 Object result = FunctionService.onRegion(CacheFactory.getAnyInstance()
      .getRegion("QueryRegion1" ))
-     .withArgs(argList).execute(function).getResult();
+     .setArguments(argList).execute(function).getResult();
 ArrayList resultList = (ArrayList)result;
 resultList.trimToSize();
 List queryResults = null;
@@ -92,6 +92,6 @@ On the client side, note that you can specify a bucket filter while invoking Fun
 
 **Additional Notes on Using the Query.execute and RegionFunctionContext APIs**
 
-You can also pass multiple parameters (besides the query itself) to the query function by specifying the parameters in the client-side code (`FunctionService.onRegion(..).withArgs()`). Then you can handle the parameters inside the function on the server side using `context.getArguments`. Note that it does not matter which order you specify the parameters as long as you match the parameter handling order on the server with the order specified in the client.
+You can also pass multiple parameters (besides the query itself) to the query function by specifying the parameters in the client-side code (`FunctionService.onRegion(..).setArguments()`). Then you can handle the parameters inside the function on the server side using `context.getArguments`. Note that it does not matter which order you specify the parameters as long as you match the parameter handling order on the server with the order specified in the client.
 
 

--- a/geode-docs/developing/query_additional/partitioned_region_key_or_field_value.html.md.erb
+++ b/geode-docs/developing/query_additional/partitioned_region_key_or_field_value.html.md.erb
@@ -53,7 +53,7 @@ The following is an example how to optimize a query that will be run on data par
           //for ID=1 and query will execute on that bucket.
           rcollector = FunctionService
               .onRegion(region)
-              .withArgs(qStr)
+              .setArguments(qStr)
               .withFilter(filter)
               .execute(func);
 

--- a/geode-docs/developing/query_additional/query_on_a_single_node.html.md.erb
+++ b/geode-docs/developing/query_additional/query_on_a_single_node.html.md.erb
@@ -142,7 +142,7 @@ To direct a query to specific partitioned region node, you can execute the query
           //for ID=1 and query will execute on that bucket.
           rcollector = FunctionService
               .onRegion(region)
-              .withArgs(qStr)
+              .setArguments(qStr)
               .withFilter(filter)
               .execute(func);
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
@@ -177,7 +177,7 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
   @Override
   public void dumpFiles(final String directory) {
     ResultCollector results = FunctionService.onRegion(getDataRegion())
-        .withArgs(new String[] {directory, indexName}).execute(DumpDirectoryFiles.ID);
+        .setArguments(new String[] {directory, indexName}).execute(DumpDirectoryFiles.ID);
     results.getResult();
   }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -111,7 +111,7 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
     try {
       TopEntriesFunctionCollector collector = new TopEntriesFunctionCollector(context);
       ResultCollector<TopEntriesCollector, TopEntries<K>> rc =
-          onRegion().withArgs(context).withCollector(collector).execute(LuceneQueryFunction.ID);
+          onRegion().setArguments(context).withCollector(collector).execute(LuceneQueryFunction.ID);
       entries = rc.getResult();
     } catch (FunctionException e) {
       if (e.getCause() instanceof LuceneQueryException) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -409,7 +409,7 @@ public class LuceneServiceImpl implements InternalLuceneService {
     WaitUntilFlushedFunctionContext context =
         new WaitUntilFlushedFunctionContext(indexName, timeout, unit);
     Execution execution = FunctionService.onRegion(dataRegion);
-    ResultCollector rs = execution.withArgs(context).execute(WaitUntilFlushedFunction.ID);
+    ResultCollector rs = execution.setArguments(context).execute(WaitUntilFlushedFunction.ID);
     List<Boolean> results = (List<Boolean>) rs.getResult();
     for (Boolean oneResult : results) {
       if (oneResult == false) {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryImplJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryImplJUnitTest.java
@@ -66,7 +66,7 @@ public class LuceneQueryImplJUnitTest {
     collector = mock(ResultCollector.class);
     provider = mock(LuceneQueryProvider.class);
 
-    when(execution.withArgs(any())).thenReturn(execution);
+    when(execution.setArguments(any())).thenReturn(execution);
     when(execution.withCollector(any())).thenReturn(execution);
     when(execution.execute(anyString())).thenReturn((ResultCollector) collector);
     results = mock(PageableLuceneQueryResults.class);
@@ -145,7 +145,7 @@ public class LuceneQueryImplJUnitTest {
     verify(execution).execute(eq(LuceneQueryFunction.ID));
     ArgumentCaptor<LuceneFunctionContext> captor =
         ArgumentCaptor.forClass(LuceneFunctionContext.class);
-    verify(execution).withArgs(captor.capture());
+    verify(execution).setArguments(captor.capture());
     LuceneFunctionContext context = captor.getValue();
     assertEquals(LIMIT, context.getLimit());
     assertEquals(provider, context.getQueryProvider());

--- a/geode-spark-connector/geode-spark-connector/src/main/scala/org/apache/geode/spark/connector/internal/DefaultGeodeConnection.scala
+++ b/geode-spark-connector/geode-spark-connector/src/main/scala/org/apache/geode/spark/connector/internal/DefaultGeodeConnection.scala
@@ -129,7 +129,7 @@ private[connector] class DefaultGeodeConnection (
     val collector = new StructStreamingResultCollector(desc)
         // RetrieveRegionResultCollector[(K, V)]
     import scala.collection.JavaConversions.setAsJavaSet
-    val exec = FunctionService.onRegion(region).withArgs(args).withCollector(collector).asInstanceOf[InternalExecution]
+    val exec = FunctionService.onRegion(region).setArguments(args).withCollector(collector).asInstanceOf[InternalExecution]
       .withBucketFilter(split.bucketSet.map(Integer.valueOf))
     exec.setWaitOnExceptionFlag(true)
     exec.execute(RetrieveRegionFunction.ID)
@@ -144,7 +144,7 @@ private[connector] class DefaultGeodeConnection (
     val args: Array[String] = Array[String](queryString, bucketSet.toString)
     val exec = FunctionService.onRegion(region).withCollector(collector).asInstanceOf[InternalExecution]
       .withBucketFilter(bucketSet.map(Integer.valueOf))
-      .withArgs(args)
+      .setArguments(args)
     exec.execute(QueryFunction.ID)
     collector.getResult
   }

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderDistributedDeadlockDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderDistributedDeadlockDUnitTest.java
@@ -343,7 +343,7 @@ public class SerialGatewaySenderDistributedDeadlockDUnitTest extends WANTestBase
     FunctionService.registerFunction(new TestFunction());
     Execution exe = FunctionService.onRegion(region);
     for (int x = 0; x < num; x++) {
-      exe.withArgs(useThreadOwnedSocket)
+      exe.setArguments(useThreadOwnedSocket)
           .execute("org.apache.geode.internal.cache.wan.serial.TestFunction");
     }
   }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/FunctionAccessController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/FunctionAccessController.java
@@ -203,9 +203,9 @@ public class FunctionAccessController extends AbstractBaseController {
 
         // execute function with specified arguments
         if (args.length == 1) {
-          results = function.withArgs(args[0]).execute(functionId);
+          results = function.setArguments(args[0]).execute(functionId);
         } else {
-          results = function.withArgs(args).execute(functionId);
+          results = function.setArguments(args).execute(functionId);
         }
       } else {
         // execute function with no args


### PR DESCRIPTION
 * created setArguments
 * deprecated withArgs
 * implemented setArguments of all Execution implementations in Geode project
 * replaced all of withArgs with setArguments