### PR TITLE
GEODE-2788: Add official Socket timeout parameter when connecting to servers/locators

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -35,7 +35,6 @@ import org.apache.geode.internal.statistics.DummyStatisticsFactory;
 import org.apache.geode.internal.ScheduledThreadPoolExecutorWithKeepAlive;
 import org.apache.geode.internal.admin.ClientStatsManager;
 import org.apache.geode.internal.cache.*;
-import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.InternalLogWriter;
@@ -63,9 +62,6 @@ public class PoolImpl implements InternalPool {
 
   private static final Logger logger = LogService.getLogger();
 
-  public static final int HANDSHAKE_TIMEOUT =
-      Long.getLong(DistributionConfig.GEMFIRE_PREFIX + "PoolImpl.HANDSHAKE_TIMEOUT",
-          AcceptorImpl.DEFAULT_HANDSHAKE_TIMEOUT_MS).intValue();
   public static final long SHUTDOWN_TIMEOUT = Long
       .getLong(DistributionConfig.GEMFIRE_PREFIX + "PoolImpl.SHUTDOWN_TIMEOUT", 30000).longValue();
   public static final int BACKGROUND_TASK_POOL_SIZE = Integer
@@ -104,6 +100,7 @@ public class PoolImpl implements InternalPool {
   private final int statisticInterval;
   private final boolean multiuserSecureModeEnabled;
 
+  private final int connectTimeout;
   private final ConnectionSource source;
   private final ConnectionManager manager;
   private QueueManager queueManager;
@@ -211,6 +208,9 @@ public class PoolImpl implements InternalPool {
     } else {
       this.proxyId = ClientProxyMembershipID.getNewProxyMembership(ds);
     }
+    this.connectTimeout =
+        Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "PoolImpl.HANDSHAKE_TIMEOUT",
+            ds.getConfig().getConnectTimeout()).intValue();
     StatisticsFactory statFactory = null;
     if (this.gatewaySender != null) {
       statFactory = new DummyStatisticsFactory();
@@ -225,7 +225,7 @@ public class PoolImpl implements InternalPool {
     source = getSourceImpl(((PoolFactoryImpl.PoolAttributes) attributes).locatorCallback);
     endpointManager = new EndpointManagerImpl(name, ds, this.cancelCriterion, this.stats);
     connectionFactory = new ConnectionFactoryImpl(source, endpointManager, ds, socketBufferSize,
-        HANDSHAKE_TIMEOUT, readTimeout, proxyId, this.cancelCriterion, usedByGateway, gatewaySender,
+        connectTimeout, readTimeout, proxyId, this.cancelCriterion, usedByGateway, gatewaySender,
         pingInterval, multiuserSecureModeEnabled, this);
     if (subscriptionEnabled) {
       queueManager = new QueueManagerImpl(this, endpointManager, source, connectionFactory,
@@ -615,7 +615,7 @@ public class PoolImpl implements InternalPool {
       return new ExplicitConnectionSourceImpl(getServers());
     } else {
       AutoConnectionSourceImpl source =
-          new AutoConnectionSourceImpl(locators, getServerGroup(), HANDSHAKE_TIMEOUT);
+          new AutoConnectionSourceImpl(locators, getServerGroup(), connectTimeout);
       if (locatorDiscoveryCallback != null) {
         source.setLocatorDiscoveryCallback(locatorDiscoveryCallback);
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -309,6 +309,17 @@ public interface ConfigurationProperties {
    */
   String CLUSTER_SSL_TRUSTSTORE_PASSWORD = "cluster-ssl-truststore-password";
   /**
+   * The static String definition of the <i>"connect-timeout"</i> property <a
+   * name="connect-timeout"/a>
+   * </p>
+   * <U>Description</U>: The number of milli seconds specified as socket timeout when the client
+   * connects to the servers/locators. A timeout of zero is interpreted as an infinite timeout. The
+   * connection will then block until established or an error occurs. <U>Default</U>: "59000"
+   * </p>
+   * <U>Since</U>: Geode 1.2
+   */
+  String CONNECT_TIMEOUT = "connect-timeout";
+  /**
    * The static String definition of the <i>"conflate-events"</i> property <a
    * name="conflate-events"/a>
    * </p>

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -928,6 +928,9 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
     m.put(START_LOCATOR,
         LocalizedStrings.AbstractDistributionConfig_START_LOCATOR_NAME.toLocalizedString());
 
+    m.put(CONNECT_TIMEOUT, LocalizedStrings.AbstractDistributionConfig_CONNECT_TIMEOUT_NAME_0
+        .toLocalizedString(DEFAULT_CONNECT_TIMEOUT));
+
     m.put(DURABLE_CLIENT_ID, LocalizedStrings.AbstractDistributionConfig_DURABLE_CLIENT_ID_NAME_0
         .toLocalizedString(DEFAULT_DURABLE_CLIENT_ID));
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -1859,6 +1859,32 @@ public interface DistributionConfig extends Config, LogConfig {
    */
   @ConfigAttributeSetter(name = CONFLATE_EVENTS)
   void setClientConflation(String clientConflation);
+
+  /**
+   * Returns the value of the {@link ConfigurationProperties#CONNECT_TIMEOUT} property.
+   */
+  @ConfigAttributeGetter(name = CONNECT_TIMEOUT)
+  int getConnectTimeout();
+
+  /**
+   * Sets the value of the {@link ConfigurationProperties#CONNECT_TIMEOUT} property.
+   */
+  @ConfigAttributeSetter(name = CONNECT_TIMEOUT)
+  void setConnectTimeout(int connectTimeout);
+
+  /**
+   * The name of the {@link ConfigurationProperties#CONNECT_TIMEOUT} property
+   */
+  @ConfigAttribute(type = Integer.class)
+  String CONNECT_TIMEOUT_NAME = CONNECT_TIMEOUT;
+
+  /**
+   * The default {@link ConfigurationProperties#CONNECT_TIMEOUT} in seconds.
+   * <p>
+   * Actual value of this constant is <code>"59000"</code>.
+   */
+  int DEFAULT_CONNECT_TIMEOUT = 59000;
+
   // -------------------------------------------------------------------------
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -263,6 +263,11 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private int asyncMaxQueueSize = DEFAULT_ASYNC_MAX_QUEUE_SIZE;
 
   /**
+   * The socket timeout value when the client connects to the servers/locators.
+   */
+  private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+  /**
    * @since GemFire 5.7
    */
   private String clientConflation = CLIENT_CONFLATION_PROP_VALUE_DEFAULT;
@@ -654,6 +659,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     this.membershipPortRange = other.getMembershipPortRange();
     this.maxWaitTimeForReconnect = other.getMaxWaitTimeForReconnect();
     this.maxNumReconnectTries = other.getMaxNumReconnectTries();
+    this.connectTimeout = other.getConnectTimeout();
     this.clientConflation = other.getClientConflation();
     this.durableClientId = other.getDurableClientId();
     this.durableClientTimeout = other.getDurableClientTimeout();
@@ -2160,6 +2166,14 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     this.clientConflation = (String) value;
   }
 
+  public int getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public void setConnectTimeout(int value) {
+    connectTimeout = value;
+  }
+
   public String getDurableClientId() {
     return durableClientId;
   }
@@ -2887,7 +2901,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(clusterSSLAlias, that.clusterSSLAlias)
         .append(mcastFlowControl, that.mcastFlowControl)
         .append(membershipPortRange, that.membershipPortRange)
-        .append(clientConflation, that.clientConflation)
+        .append(connectTimeout, that.connectTimeout).append(clientConflation, that.clientConflation)
         .append(durableClientId, that.durableClientId)
         .append(securityClientAuthInit, that.securityClientAuthInit)
         .append(securityClientAuthenticator, that.securityClientAuthenticator)
@@ -2984,11 +2998,11 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(enableTimeStatistics).append(memberTimeout).append(membershipPortRange)
         .append(maxWaitTimeForReconnect).append(maxNumReconnectTries)
         .append(asyncDistributionTimeout).append(asyncQueueTimeout).append(asyncMaxQueueSize)
-        .append(clientConflation).append(durableClientId).append(durableClientTimeout)
-        .append(securityClientAuthInit).append(securityClientAuthenticator).append(securityManager)
-        .append(postProcessor).append(securityClientDHAlgo).append(securityPeerAuthInit)
-        .append(securityPeerAuthenticator).append(securityClientAccessor)
-        .append(securityClientAccessorPP).append(securityLogLevel)
+        .append(connectTimeout).append(clientConflation).append(durableClientId)
+        .append(durableClientTimeout).append(securityClientAuthInit)
+        .append(securityClientAuthenticator).append(securityManager).append(postProcessor)
+        .append(securityClientDHAlgo).append(securityPeerAuthInit).append(securityPeerAuthenticator)
+        .append(securityClientAccessor).append(securityClientAccessorPP).append(securityLogLevel)
         .append(enableNetworkPartitionDetection).append(disableAutoReconnect)
         .append(securityLogFile).append(securityPeerMembershipTimeout).append(security)
         .append(userDefinedProps).append(removeUnresponsiveClient).append(deltaPropagation)

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -32,7 +32,7 @@ import org.apache.geode.i18n.StringId;
  * }
  * }
  * </code>
- * 
+ *
  * @since GemFire 6.0
  */
 public class LocalizedStrings {
@@ -5449,6 +5449,9 @@ public class LocalizedStrings {
   public static final StringId AbstractDistributionConfig_SERVER_BIND_ADDRESS_NAME_0 = new StringId(
       4246,
       "The address server sockets in a client-server topology will listen on. An empty string causes the server socket to listen on all local addresses. Defaults to \"{0}\".");
+  public static final StringId AbstractDistributionConfig_CONNECT_TIMEOUT_NAME_0 = new StringId(
+      4247,
+      "The value (in milli seconds) used by the socket timeout when the client connects to the servers/locators. Defaults to \"{0}\".");
   public static final StringId AbstractDistributionConfig_STATISTIC_ARCHIVE_FILE_NAME_0 =
       new StringId(4248,
           "The file a running system will write statistic samples to.  Defaults to \"{0}\".");

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -99,7 +99,7 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testGetAttributeNames() {
     String[] attNames = AbstractDistributionConfig._getAttNames();
-    assertEquals(attNames.length, 156);
+    assertEquals(attNames.length, 157);
 
     List boolList = new ArrayList();
     List intList = new ArrayList();
@@ -134,7 +134,7 @@ public class DistributionConfigJUnitTest {
     // TODO - This makes no sense. One has no idea what the correct expected number of attributes
     // are.
     assertEquals(29, boolList.size());
-    assertEquals(33, intList.size());
+    assertEquals(34, intList.size());
     assertEquals(85, stringList.size());
     assertEquals(5, fileList.size());
     assertEquals(4, otherList.size());


### PR DESCRIPTION
When connecting from the client to the servers/locators, if the servers/locators is not started, the connection can not be established and a Socket timeout occurs.
This timeout value is 59 seconds by default. This timeout value is too long. This timeout value can be changed by specifying the unofficial parameter "gemfire.PoolImpl.HANDSHAKE_TIMEOUT" in java system property, but I corresponded so that it can be specified by official parameters.
Like the NativeClient, the official parameters should be specified by "connect-timeout" in gemfire.properties.

Timeout values are determined in the following order of priority.

1. java system property:gemfire.PoolImpl.HANDSHAKE_TIMEOUT
2. java system property:gemfire.connect-timeout
3. gemfire.properties:connect-timeout
4. default:59000 milli seconds

As another idea, there is also an idea to make it possible to specify it as an attribute of Pool. In that case NativeClient needs the same modification.