### PR TITLE
Feature/geode 2703

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.TransactionException;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
@@ -42,6 +43,8 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.logging.log4j.Logger;
 
 public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
+  public static final String LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION =
+      "Lucene Query cannot be executed within a transaction";
   Logger logger = LogService.getLogger();
 
   private int limit = LuceneQueryFactory.DEFAULT_LIMIT;
@@ -120,8 +123,10 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
         throw (RuntimeException) e.getCause();
       }
       throw e;
-
+    } catch (TransactionException e) {
+      throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
     }
+
     return entries;
   }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -120,14 +120,14 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
       if (e.getCause() instanceof LuceneQueryException) {
         throw new LuceneQueryException(e);
       } else if (e.getCause() instanceof TransactionException) {
-        //When run from client with single hop disabled
+        // When run from client with single hop disabled
         throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
       } else if (e.getCause() instanceof RuntimeException) {
         throw (RuntimeException) e.getCause();
       }
       throw e;
     } catch (TransactionException e) {
-      //When function execution is run from server
+      // When function execution is run from server
       throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
     }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -119,11 +119,15 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
     } catch (FunctionException e) {
       if (e.getCause() instanceof LuceneQueryException) {
         throw new LuceneQueryException(e);
+      } else if (e.getCause() instanceof TransactionException) {
+        //When run from client with single hop disabled
+        throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
       } else if (e.getCause() instanceof RuntimeException) {
         throw (RuntimeException) e.getCause();
       }
       throw e;
     } catch (TransactionException e) {
+      //When function execution is run from server
       throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
     }
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
@@ -18,14 +18,11 @@ import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.DEFAULT_FIE
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import org.apache.geode.cache.lucene.internal.LuceneQueryImpl;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
@@ -36,6 +33,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 import org.junit.runner.RunWith;
 
 import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 
 @Category(DistributedTest.class)
 @RunWith(JUnitParamsRunner.class)
@@ -72,6 +70,8 @@ public class LuceneQueriesClientDUnitTest extends LuceneQueriesDUnitTest {
 
   // Due to singlehop transactions differences, the exception actually isn't thrown
   // So the parent test behaves differently if singlehop is enabled or not for a client
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
   public void transactionWithLuceneQueriesShouldThrowException(RegionTestableType regionTestType) {
     SerializableRunnableIF createIndex = () -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
@@ -15,7 +15,9 @@
 package org.apache.geode.cache.lucene;
 
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
@@ -64,6 +66,19 @@ public class LuceneQueriesClientDUnitTest extends LuceneQueriesDUnitTest {
     return new RegionTestableType[] {RegionTestableType.PARTITION_WITH_CLIENT};
   }
 
+  //Due to singlehop transactions differences, the exception actually isn't thrown
+  //So the parent test behaves differently if singlehop is enabled or not for a client
+  public void transactionWithLuceneQueriesShouldThrowException(RegionTestableType regionTestType) {
+    try {
+      super.transactionWithLuceneQueriesShouldThrowException(regionTestType);
+      fail();
+    }
+    catch (AssertionError e) {
+      //Expecting the parent test to fail because client transactions with single hop do not fail with Lucene Querying at this point
+    }
+
+  }
 
 
-}
+
+  }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
@@ -78,8 +78,7 @@ public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
             .equals(LuceneQueryImpl.LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION)) {
           fail();
         }
-      }
-      finally {
+      } finally {
         cache.getCacheTransactionManager().rollback();
       }
     });

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
@@ -64,9 +64,9 @@ public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
     assertTrue(waitForFlushBeforeExecuteTextSearch(dataStore1, 60000));
 
     accessor.invoke(() -> {
+      Cache cache = getCache();
+      cache.getCacheTransactionManager().begin();
       try {
-        Cache cache = getCache();
-        cache.getCacheTransactionManager().begin();
         Region<Object, Object> region = cache.getRegion(REGION_NAME);
 
         LuceneService service = LuceneServiceProvider.get(cache);
@@ -83,13 +83,13 @@ public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
         }
 
         assertEquals(new HashMap(region), data);
-        cache.getCacheTransactionManager().commit();
         fail();
       } catch (LuceneQueryException e) {
         if (!e.getMessage()
             .equals(LuceneQueryImpl.LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION)) {
           fail();
         }
+        cache.getCacheTransactionManager().rollback();
       }
     });
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.lucene.internal.LuceneQueryImpl;
 import org.apache.geode.cache.lucene.test.LuceneTestUtilities;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
@@ -30,6 +31,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
@@ -43,6 +47,53 @@ import junitparams.Parameters;
 public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
 
   private static final long serialVersionUID = 1L;
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void transactionWithLuceneQueries(RegionTestableType regionTestType) {
+    SerializableRunnableIF createIndex = () -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      luceneService.createIndexFactory().addField("text").create(INDEX_NAME, REGION_NAME);
+    };
+    dataStore1.invoke(() -> initDataStore(createIndex, regionTestType));
+    dataStore2.invoke(() -> initDataStore(createIndex, regionTestType));
+    accessor.invoke(() -> initAccessor(createIndex, regionTestType));
+
+    putDataInRegion(accessor);
+    assertTrue(waitForFlushBeforeExecuteTextSearch(accessor, 60000));
+    assertTrue(waitForFlushBeforeExecuteTextSearch(dataStore1, 60000));
+
+    accessor.invoke(() -> {
+      try {
+        Cache cache = getCache();
+        cache.getCacheTransactionManager().begin();
+        Region<Object, Object> region = cache.getRegion(REGION_NAME);
+
+        LuceneService service = LuceneServiceProvider.get(cache);
+        LuceneQuery<Integer, TestObject> query;
+        query = service.createLuceneQueryFactory().create(INDEX_NAME, REGION_NAME, "text:world",
+            DEFAULT_FIELD);
+        PageableLuceneQueryResults<Integer, TestObject> results = query.findPages();
+        assertEquals(3, results.size());
+        List<LuceneResultStruct<Integer, TestObject>> page = results.next();
+
+        Map<Integer, TestObject> data = new HashMap<Integer, TestObject>();
+        for (LuceneResultStruct<Integer, TestObject> row : page) {
+          data.put(row.getKey(), row.getValue());
+        }
+
+        assertEquals(new HashMap(region), data);
+        cache.getCacheTransactionManager().commit();
+        fail();
+      } catch (LuceneQueryException e) {
+        if (!e.getMessage()
+            .equals(LuceneQueryImpl.LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION)) {
+          fail();
+        }
+      }
+    });
+
+  }
 
   @Test
   @Parameters(method = "getListOfRegionTestTypes")


### PR DESCRIPTION
Modified transaction exception messaging when executing a lucene query within a geode transaction.

The client transactions behave differently in geode depending on whether single hop is enabled or not.  If single hop is enabled, the expected transaction exception actually never is thrown.

Possible reviewers : @nabarunnag @upthewaterspout @boglesby 
