### PR TITLE
GEODE-2103 Update gfsh start server|locator command

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
@@ -401,7 +401,7 @@ See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of 
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-http-service-port</span></td>
-<td>Specifies the port on which the HTTP service will listen.</td>
+<td>Specifies the HTTP service port.</td>
 <td>7070</td>
 </tr>
 <tr class="even">
@@ -768,7 +768,7 @@ See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of 
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-http-service-port</span></td>
-<td>Specifies the port on which the HTTP service will listen.</td>
+<td>Specifies the HTTP service port.</td>
 <td>7070</td>
 </tr>
 <tr class="even">

--- a/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
@@ -275,7 +275,9 @@ start locator --name=value [--bind-address=value] [--force(=value)] [--group=val
  [--locators=value] [--log-level=value] [--mcast-address=value] [--mcast-port=value] [--port=value] [--dir=value]
  [--properties-file=value] [--security-properties-file=value] [--initial-heap=value] [--max-heap=value]
  [--connect(=value)] [--enable-cluster-configuration(=value)] [--load-from-cluster-configuration-dir(=value)]
- [--cluster-config-dir=value] [--J=value(,value)*]
+ [--cluster-config-dir=value]
+ [--http-service-port=value] [--http-service-bind-address=value] 
+ [--J=value(,value)*]
 ```
 
 <a id="topic_591260CF25D64562A0EDD7260D2AC6D4__table_hly_vvg_2w"></a>
@@ -396,6 +398,17 @@ See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of 
 <td><span class="keyword parmname">\-\-cluster-config-dir</span></td>
 <td>Directory used by the cluster configuration service to store the cluster configuration on the filesystem</td>
 <td>cluster-config</td>
+</tr>
+<tr class="even">
+<td><span class="keyword parmname">\-\-http-service-port</span></td>
+<td>Specifies the port on which the HTTP service will listen.</td>
+<td>7070</td>
+</tr>
+<tr class="even">
+<td><span class="keyword parmname">\-\-http-service-bind-address</span></td>
+<td>Specifies the IP address to which the HTTP service will be bound.
+</td>
+<td>the local host machine's address</td>
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-J </span></td>
@@ -756,13 +769,13 @@ See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of 
 <tr class="even">
 <td><span class="keyword parmname">\-\-http-service-port</span></td>
 <td>Specifies the port on which the HTTP service will listen.</td>
-<td></td>
+<td>7070</td>
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-http-service-bind-address</span></td>
 <td>Specifies the IP address to which the HTTP service will be bound.
 </td>
-<td>all local addresses</td>
+<td>the local host machine's address</td>
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-user</span></td>


### PR DESCRIPTION
reference page.

- the optional http-service-port defaults to 7070
- both http-service-port and http-service-bind-address
are available for gfsh start server and gfsh start locator

New PR for the doc task.  @kirklund @joeymcallister @davebarnes97 @kohlmu-pivotal  please review.