### PR TITLE
GEODE-1728: Http session filter should only apply to REQUEST

### DIFF
--- a/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
@@ -51,10 +51,6 @@ To modify your war or ear file manually, make the following updates:
     <filter-mapping>
         <filter-name>gemfire-session-filter</filter-name>
         <url-pattern>/*</url-pattern>
-        <dispatcher>FORWARD</dispatcher>
-        <dispatcher>INCLUDE</dispatcher>
-        <dispatcher>REQUEST</dispatcher>
-        <dispatcher>ERROR</dispatcher>
     </filter-mapping>
     <listener>
         <listener-class>org.apache.geode.modules.session.filter.SessionListener</listener-class>


### PR DESCRIPTION
The docs should not tell users to add apply the session filter to
FORWARD, INCLUDE, and ERROR dispatchers. It should just be the default,
REQUEST.