### PR TITLE
GEODE-2870: Local node function execution failure correctly returns e…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
@@ -214,16 +214,15 @@ public final class PartitionedRegionFunctionResultSender implements InternalResu
   private synchronized void lastResult(Object oneResult, ResultCollector collector,
       boolean lastRemoteResult, boolean lastLocalResult, DistributedMember memberID) {
 
+
+    boolean completedLocal = lastLocalResult | this.localLastResultRecieved;
     if (lastRemoteResult) {
       this.completelyDoneFromRemote = true;
     }
 
-    if (lastLocalResult) {
-      this.localLastResultRecieved = true;
-    }
 
     if (this.serverSender != null) { // Client-Server
-      if (this.completelyDoneFromRemote && this.localLastResultRecieved) {
+      if (this.completelyDoneFromRemote && completedLocal) {
         if (lastLocalResult) {
           checkForBucketMovement(oneResult);
           if (bme != null) {
@@ -252,7 +251,7 @@ public final class PartitionedRegionFunctionResultSender implements InternalResu
 
       }
     } else { // P2P
-      if (this.completelyDoneFromRemote && this.localLastResultRecieved) {
+      if (this.completelyDoneFromRemote && completedLocal) {
         if (lastLocalResult) {
           checkForBucketMovement(oneResult);
           if (bme != null) {
@@ -278,6 +277,9 @@ public final class PartitionedRegionFunctionResultSender implements InternalResu
           collector.addResult(memberID, oneResult);
         }
       }
+    }
+    if (lastLocalResult) {
+      this.localLastResultRecieved = true;
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
@@ -215,7 +215,7 @@ public final class PartitionedRegionFunctionResultSender implements InternalResu
       boolean lastRemoteResult, boolean lastLocalResult, DistributedMember memberID) {
 
 
-    boolean completedLocal = lastLocalResult | this.localLastResultRecieved;
+    boolean completedLocal = lastLocalResult || this.localLastResultRecieved;
     if (lastRemoteResult) {
       this.completelyDoneFromRemote = true;
     }


### PR DESCRIPTION
…xception

* Race condition and escaping synchronized block led to function possibly missing results
* It was possible a remote node would enter the synchronized block after local node threw exception
* Certain side effects would allow processing of remote node results to be considered last result
* Local processing thread would be paused/non active and miss opportunity to write exception
* This would manifest as incomplete results instead of a retry

Reviewers:
@upthewaterspout @nabarunnag @gesterzhou @boglesby @ladyVader 