### PR TITLE
GEODE-2754: Changed the name of unknown host

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
@@ -625,7 +625,7 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
   }
 
   private void addUnknownHost(Set<String> remoteLocators) {
-    String unknownHostName = "unknown";
+    String unknownHostName = "unknownGeodeHostWanAutoDiscoveryDUnitTest";
     boolean unknownHostFound = false;
     int numTries = 10;
     for (int i = 0; i < numTries; i++) {


### PR DESCRIPTION
	* Assert failures occured if the network contained machines named "unknown" as the test function also named the unknown host as "unknown"
	* This led to test to find multiple machines named "unknown" rather than one.
	* Changed the name of the unknown host set by the test to be "unknownGeodeHostWanAutoDiscoveryDUnitTest"

Potential reviewers:
@jhuynh1 @upthewaterspout @gesterzhou @ladyVader @boglesby 