### PR TITLE
GEODE-2815 Incorrect Error Message in REST API docs for {region}/{key…

### DIFF
--- a/geode-docs/rest_apps/get_region_data.html.md.erb
+++ b/geode-docs/rest_apps/get_region_data.html.md.erb
@@ -127,6 +127,6 @@ Date: Sat, 18 Jan 2014 21:03:08 GMT
 
 | Status Code        | Description                                                                                                                      |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| 400 BAD REQUEST    | Limit parameter **X** is not valid! The specified limit value must ALL or an integer.                                            |
-| 404 NOT FOUND      | Returned in region does not exist.                                                                                               |
+| 400 BAD REQUEST    | Limit parameter **X** is not valid! The specified limit value must be ALL or an integer.                                            |
+| 404 NOT FOUND      | Returned if region does not exist.                                                                                               |
 | 500 INTERNAL ERROR | Error encountered at Geode server. Check the HTTP response body for a stack trace of the exception. |

--- a/geode-docs/rest_apps/get_region_data_for_multiple_keys.html.md.erb
+++ b/geode-docs/rest_apps/get_region_data_for_multiple_keys.html.md.erb
@@ -213,7 +213,7 @@ Date: Sat, 18 Jan 2014 21:39:04 GMT
 | Status Code     | Description                                                                                                                                                                                                                                             |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 400 BAD REQUEST | Returned if one or more of the supplied keys is not found in the region and ignoreMissingKey=false (default if parameter is not specified); returned if the specified value for the ignoreMissingKey parameter is a value other than 'true' or 'false'. |
-| 404 NOT FOUND   | If the specified region does not exist.                                                                                                                                                                                                                 |
+| 404 NOT FOUND   | The specified region does not exist.                    |
 
 ## Example Error Response
 

--- a/geode-docs/rest_apps/get_region_key_data.html.md.erb
+++ b/geode-docs/rest_apps/get_region_key_data.html.md.erb
@@ -80,8 +80,8 @@ Date: Sat, 18 Jan 2014 21:27:59 GMT
 
 ## Error Codes
 
-| Status Code               | Description                                                                                                                      |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| 400 BAD REQUEST           | Returned if the supplied key is not found in the region.                                                                         |
-| 404 NOT FOUND             | Returned if key does not exist for the region.                                                                                   |
+| Status Code               | Description                                                                                         |
+|---------------------------|-----------------------------------------------------------------------------------------------------|
+| 400 BAD REQUEST           | Returned if the supplied key is not found in the region.                                            |
+| 404 NOT FOUND             | Returned if the region or specified key is not found.                                               |
 | 500 INTERNAL SERVER ERROR | Error encountered at Geode server. Check the HTTP response body for a stack trace of the exception. |


### PR DESCRIPTION
…} HTTP.GET command

404 does mean 'not found', and in the REST API context it can mean 'Region not found', 'Key not found' or 'Either key or region not found', depending on what was being requested.
Edited the various REST API command docs accordingly.

