### PR TITLE
GEODE-2889: Update the last access time of native sessions

### DIFF
--- a/extensions/geode-modules-session/src/main/java/org/apache/geode/modules/session/filter/SessionCachingFilter.java
+++ b/extensions/geode-modules-session/src/main/java/org/apache/geode/modules/session/filter/SessionCachingFilter.java
@@ -145,22 +145,10 @@ public class SessionCachingFilter implements Filter {
      */
     @Override
     public HttpSession getSession(boolean create) {
+      super.getSession(false);
       if (session != null && session.isValid()) {
         session.setIsNew(false);
         session.updateAccessTime();
-        /*
-         * This is a massively gross hack. Currently, there is no way to actually update the last
-         * accessed time for a session, so what we do here is once we're into X% of the session's
-         * TTL we grab a new session from the container.
-         *
-         * (inactive * 1000) * (pct / 100) ==> (inactive * 10 * pct)
-         */
-        if (session.getLastAccessedTime()
-            - session.getCreationTime() > (session.getMaxInactiveInterval() * 10
-                * percentInactiveTimeTriggerRebuild)) {
-          HttpSession nativeSession = super.getSession();
-          session.failoverSession(nativeSession);
-        }
         return session;
       }
 


### PR DESCRIPTION
Our getSession method had some races where we were holding onto a
reference to the native session, but not updating the last accessed time
of the native session by calling into getSession of the container. This
could allow the container to expire the session in the middle of our
method.