### PR TITLE
GEODE-2879: Shutdown() called from close() in LonerDistributionManager

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -101,7 +101,7 @@ public class LonerDistributionManager implements DM {
   private ConcurrentMap<InternalDistributedMember, InternalDistributedMember> canonicalIds =
       new ConcurrentHashMap();
   static private final DummyDMStats stats = new DummyDMStats();
-  static private final ExecutorService executor = Executors.newCachedThreadPool();
+  private final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Override
   public long cacheTimeMillis() {
@@ -284,7 +284,9 @@ public class LonerDistributionManager implements DM {
     return null;
   }
 
-  public void close() {}
+  public void close() {
+    shutdown();
+  }
 
   public void restartCommunications() {
 


### PR DESCRIPTION
	* LonerDistributionManager shutdown was not being called from close() method call.
	* This resulted in the thread pool's threads to wait for 1 minute of inactivity for them to be killed.
	* This resulted in an extra delay while test executions.
	* shutdown called from close method

Potential reviewers
@upthewaterspout @jhuynh1 @gesterzhou @ladyVader @boglesby 