### PR TITLE
GEODE-254: Removed deprecated Region.keys and Region.entries

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
@@ -184,15 +184,6 @@ public class ProxyRegion implements Region {
     }
   }
 
-  public Set entries(boolean recursive) {
-    try {
-      preOp();
-      return this.realRegion.entrySet(recursive);
-    } finally {
-      postOp();
-    }
-  }
-
   public Set entrySet(boolean recursive) {
     try {
       preOp();
@@ -372,10 +363,6 @@ public class ProxyRegion implements Region {
     return this.realRegion.isEmpty();
   }
 
-  public Set keySet() {
-    return this.realRegion.keySet();
-  }
-
   public Set keySetOnServer() {
     try {
       preOp();
@@ -385,7 +372,7 @@ public class ProxyRegion implements Region {
     }
   }
 
-  public Set keys() {
+  public Set keySet() {
     try {
       preOp();
       return this.realRegion.keySet();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
@@ -320,7 +320,7 @@ public class QRegion implements SelectResults {
     this.region.destroyRegion(aCallbackArgument);
   }
 
-  public Set entries(boolean recursive) {
+  public Set entrySet(boolean recursive) {
     return this.region.entrySet(recursive);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/DummyQRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/DummyQRegion.java
@@ -217,7 +217,7 @@ public class DummyQRegion extends QRegion {
   }
 
   @Override
-  public Set entries(boolean recursive) {
+  public Set entrySet(boolean recursive) {
     return (ResultsSet) getEntries();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRegion.java
@@ -252,7 +252,8 @@ public class AdminRegion implements Region {
     throw new UnsupportedOperationException();
   }
 
-  public Set keys() {
+  @Override
+  public Set keySet() {
     try {
       ObjectNamesResponse resp = (ObjectNamesResponse) sendAndWait(ObjectNamesRequest.create());
       return resp.getNameSet();
@@ -262,10 +263,6 @@ public class AdminRegion implements Region {
   }
 
   public Collection values() {
-    throw new UnsupportedOperationException();
-  }
-
-  public Set entries(boolean recursive) {
     throw new UnsupportedOperationException();
   }
 
@@ -519,10 +516,6 @@ public class AdminRegion implements Region {
   }
 
   public Set entrySet() {
-    throw new UnsupportedOperationException();
-  }
-
-  public Set keySet() {
     throw new UnsupportedOperationException();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -1698,12 +1698,6 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
     return result.iterator().next();
   }
 
-  public Set entrySet(boolean recursive) {
-    return entries(recursive);
-  }
-
-  public abstract Set entries(boolean recursive);
-
   public EvictionAttributes getEvictionAttributes() {
     return this.evictionAttributes;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
@@ -83,16 +83,13 @@ public class LocalDataSet implements Region, QueryExecutor {
     this.buckets = buckets;
   }
 
+  @Override
   public Set<Region.Entry> entrySet(boolean recursive) {
-    return entries(recursive);
+    return this.proxy.entrySet(getBucketSet());
   }
 
   public Set<Region.Entry> entrySet() {
-    return entries(false);
-  }
-
-  public Set<Region.Entry> entries(boolean recursive) {
-    return this.proxy.entries(getBucketSet());
+    return entrySet(false);
   }
 
   public Collection values() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1888,7 +1888,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return new SubregionsSet(recursive);
   }
 
-  public Set entries(boolean recursive) {
+  public Set entrySet(boolean recursive) {
     checkReadiness();
     checkForNoAccess();
     return basicEntries(recursive);
@@ -3724,7 +3724,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     DataOutputStream out = new DataOutputStream(outputStream);
     try {
       out.writeByte(SNAPSHOT_VERSION);
-      for (Iterator itr = entries(false).iterator(); itr.hasNext();) {
+      for (Iterator itr = entrySet(false).iterator(); itr.hasNext();) {
         Region.Entry entry = (Region.Entry) itr.next();
         try {
           Object key = entry.getKey();
@@ -4255,7 +4255,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * @see #registerInterest(Object)
    */
   private void clearViaList(List keys) {
-    for (Iterator it = this.entries(false).iterator(); it.hasNext();) {
+    for (Iterator it = this.entrySet(false).iterator(); it.hasNext();) {
       Region.Entry entry = (Region.Entry) it.next();
       try {
         Object entryKey = entry.getKey();
@@ -4286,7 +4286,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   private void clearViaRegEx(String key) {
     // @todo: if (key.equals(".*)) then cmnClearRegionNoCallbacks
     Pattern keyPattern = Pattern.compile(key);
-    for (Iterator it = this.entries(false).iterator(); it.hasNext();) {
+    for (Iterator it = this.entrySet(false).iterator(); it.hasNext();) {
       Region.Entry entry = (Region.Entry) it.next();
       try {
         Object entryKey = entry.getKey();
@@ -4323,7 +4323,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           LocalizedStrings.LocalRegion_CLASS_0_COULD_NOT_BE_INSTANTIATED.toLocalizedString(key), e);
     }
 
-    for (Iterator it = this.entries(false).iterator(); it.hasNext();) {
+    for (Iterator it = this.entrySet(false).iterator(); it.hasNext();) {
       Region.Entry entry = (Region.Entry) it.next();
       try {
         Object entryKey = entry.getKey();
@@ -9211,7 +9211,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    */
   public Set entrySet() {
     // entries(false) takes care of open transactions
-    return entries(false);
+    return entrySet(false);
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -6039,12 +6039,12 @@ public class PartitionedRegion extends LocalRegion
    *         OVERRIDES
    */
   @Override
-  public Set entries(boolean recursive) {
+  public Set entrySet(boolean recursive) {
     checkReadiness();
     return Collections.unmodifiableSet(new PREntriesSet());
   }
 
-  public Set<Region.Entry> entries(Set<Integer> bucketIds) {
+  public Set<Region.Entry> entrySet(Set<Integer> bucketIds) {
     return new PREntriesSet(bucketIds);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -432,7 +432,7 @@ public class HARegionQueue implements RegionQueue {
    * @throws InterruptedException
    */
   void putGIIDataInRegion() throws CacheException, InterruptedException {
-    Set entrySet = this.region.entries(false);
+    Set entrySet = this.region.entrySet(false);
     // check if the region is not empty. if there is
     // data, then the relevant data structures have to
     // be populated

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
@@ -482,27 +482,6 @@ public class IndexMaintenanceJUnitTest {
   }
 
   /**
-   * Tests Index maintenance on method entries(boolean ) as iterator ( with focus on behaviour if
-   * not implemented in DummyQRegion
-   */
-  @Test
-  public void testIndexMaintenanceWithIndexOnMethodEntries() {
-    try {
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "entries.value.getID",
-          "/portfolio.entries(false) entries");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForEntries(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
-  }
-
-  /**
    * Tests Index maintenance on method getEntries( ) as iterator ( with focus on behaviour if not
    * implemented in DummyQRegion
    */

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -215,7 +215,7 @@ public class AbstractRegionJUnitTest {
     }
 
     @Override
-    public Set entries(boolean recursive) {
+    public Set entrySet(boolean recursive) {
       throw new UnsupportedOperationException();
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
@@ -233,7 +233,7 @@ public class HAGIIBugDUnitTest extends JUnit4DistributedTestCase {
     HARegion regionForQueue = (HARegion) cache.getRegion(
         Region.SEPARATOR + HARegionQueue.createRegionName(HAExpiryDUnitTest.regionQueueName));
     LogWriterUtils.getLogWriter().info("Region Queue size : " + regionForQueue.keys().size());
-    Iterator itr = regionForQueue.entries(false).iterator();
+    Iterator itr = regionForQueue.entrySet(false).iterator();
     while (itr.hasNext()) {
       Entry entry = (Entry) itr.next();
       if (entry.getKey() instanceof Long) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -290,7 +290,7 @@ public class HARQAddOperationJUnitTest {
       // After the expiry of the data , AvaialbleIds size should be 0,
       // entry
       // removed from Region, LastDispatchedWrapperSet should have size 0.
-      assertEquals(0, regionqueue.getRegion().entries(false).size());
+      assertEquals(0, regionqueue.getRegion().entrySet(false).size());
       assertEquals(0, regionqueue.getAvalaibleIds().size());
       assertNull(regionqueue.getCurrentCounterSet(id1));
 


### PR DESCRIPTION
Addressing review comment from 
https://github.com/apache/geode/pull/488
- removed method entries
- IndexMaintenanceJUnitTest#testIndexMaintenanceWithIndexOnMethodEntries is no longer applicable so removed the same.
- Other than GMSMembershipManagerJUnitTest all tests are passing
- This also fixed ConsoleDistributionManagerDUnitTest#testApplications, which was failing due to my previous fix.

@dschneider-pivotal , @kirklund  Please review.