### PR TITLE
[GEODE-2890]: Corrected debug log location in AbstractGatewaySenderEventProcessor.processQueue().

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -551,12 +551,12 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
                 BucketRegion bucket = qpr.getDataStore().getLocalBucketById(bucketId);
                 if (bucket == null || !bucket.getBucketAdvisor().isPrimary()) {
                   event.setPossibleDuplicate(true);
+                  if (isDebugEnabled) {
+                    logger.debug(
+                        "Bucket id: {} is no longer primary on this node. The event: {} will be dispatched from this node with possibleDuplicate set to true.",
+                        bucketId, event);
+                  }
                 }
-              }
-              if (isDebugEnabled) {
-                logger.debug(
-                    "Bucket id: {} is no longer primary on this node. The event {} will be dispatched from this node with possibleDuplicate set to true.",
-                    bucketId, event);
               }
             }
           }


### PR DESCRIPTION
Corrected debug log location in AbstractGatewaySenderEventProcessor.processQueue().