### PR TITLE
GEODE-231 :  Remove deprecated AttributesMutator.setCacheListener

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/AttributesMutator.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/AttributesMutator.java
@@ -107,19 +107,6 @@ public interface AttributesMutator<K, V> {
   public CustomExpiry<K, V> setCustomEntryIdleTimeout(CustomExpiry<K, V> custom);
 
   /**
-   * Changes the CacheListener for the region. Removes listeners already added and calls
-   * {@link CacheCallback#close} on each of them.
-   * 
-   * @param aListener a user defined cache listener
-   * @return the previous CacheListener if a single one exists; otherwise null.
-   * @throws IllegalStateException if more than one cache listener has already been added
-   * @deprecated as of GemFire 5.0, use {@link #addCacheListener} or {@link #initCacheListeners}
-   *             instead.
-   */
-  @Deprecated
-  public CacheListener<K, V> setCacheListener(CacheListener<K, V> aListener);
-
-  /**
    * Adds a cache listener to the end of the list of cache listeners on this region.
    * 
    * @param aListener the user defined cache listener to add to the region.

--- a/geode-core/src/main/java/org/apache/geode/cache/RegionRoleListener.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/RegionRoleListener.java
@@ -25,7 +25,7 @@ package org.apache.geode.cache;
  * 
  * @see AttributesFactory#setCacheListener
  * @see RegionAttributes#getCacheListener
- * @see AttributesMutator#setCacheListener
+ * @see AttributesMutator#addCacheListener
  * @deprecated this feature is scheduled to be removed
  */
 public interface RegionRoleListener<K, V> extends CacheListener<K, V> {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -848,53 +848,6 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
     return this;
   }
 
-  // /**
-  // * A CacheListener implementation that delegates to an array of listeners.
-  // */
-  // public static class ArrayCacheListener implements CacheListener {
-  // private final CacheListener [] listeners;
-  // /**
-  // * Creates a cache listener given the list of listeners it will delegate to.
-  // */
-  // public ArrayCacheListener(CacheListener[] listeners) {
-  // this.listeners = listeners;
-  // }
-  // }
-  public CacheListener setCacheListener(CacheListener aListener) {
-    checkReadiness();
-    CacheListener result = null;
-    CacheListener[] oldListeners = null;
-    synchronized (this.clSync) {
-      oldListeners = this.cacheListeners;
-      if (oldListeners != null && oldListeners.length > 1) {
-        throw new IllegalStateException(
-            LocalizedStrings.AbstractRegion_MORE_THAN_ONE_CACHE_LISTENER_EXISTS
-                .toLocalizedString());
-      }
-      this.cacheListeners = new CacheListener[] {aListener};
-    }
-    // moved the following out of the sync for bug 34512
-    if (oldListeners != null && oldListeners.length > 0) {
-      if (oldListeners.length == 1) {
-        result = oldListeners[0];
-      }
-      for (int i = 0; i < oldListeners.length; i++) {
-        if (aListener != oldListeners[i]) {
-          closeCacheCallback(oldListeners[i]);
-        }
-      }
-      if (aListener == null) {
-        cacheListenersChanged(false);
-      }
-    } else { // we have no old listeners
-      if (aListener != null) {
-        // we have added a new listener
-        cacheListenersChanged(true);
-      }
-    }
-    return result;
-  }
-
   public void addGatewaySenderId(String gatewaySenderId) {
     getGatewaySenderIds().add(gatewaySenderId);
     setAllGatewaySenderIds();

--- a/geode-core/src/test/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/TXJUnitTest.java
@@ -1084,7 +1084,7 @@ public class TXJUnitTest {
         return fetchLocal ? this.aLocalDestroyCalls : this.aDestroyCalls;
       }
     };
-    mutator.setCacheListener(cntListener);
+    mutator.addCacheListener(cntListener);
     CountingCacheWriter cntWriter = new CountingCacheWriter() {
       int bCreateCalls, bUpdateCalls, bDestroyCalls, bLocalDestroyCalls;
 
@@ -3047,7 +3047,7 @@ public class TXJUnitTest {
   public void testNoCallbacksOnRollback() throws CacheException {
     // install listeners
     AttributesMutator<String, String> mutator = this.region.getAttributesMutator();
-    mutator.setCacheListener(new CacheListenerAdapter<String, String>() {
+    mutator.addCacheListener(new CacheListenerAdapter<String, String>() {
       @Override
       public void close() {
         cbCount++;
@@ -3515,7 +3515,7 @@ public class TXJUnitTest {
     };
 
     vCl.setValidator(cbv);
-    mutator.setCacheListener(vCl);
+    mutator.addCacheListener(vCl);
 
     // CacheWriter
     ValidatableCacheWriter vCw = new ValidatableCacheWriter() {

--- a/geode-core/src/test/java/org/apache/geode/TXWriterTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/TXWriterTestCase.java
@@ -113,7 +113,7 @@ public class TXWriterTestCase {
 
   void installCacheListenerAndWriter() {
     AttributesMutator<String, String> mutator = this.region.getAttributesMutator();
-    mutator.setCacheListener(new CacheListenerAdapter<String, String>() {
+    mutator.addCacheListener(new CacheListenerAdapter<String, String>() {
       @Override
       public void close() {
         cbCount++;

--- a/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
@@ -157,11 +157,11 @@ public class CacheListenerJUnitTest {
     }
 
     // commented this test as this is no more valid test scenario with new APIs
-//    try {
-//      am.setCacheListener(cl1);
-//      fail("expected IllegalStateException");
-//    } catch (IllegalStateException expected) {
-//    }
+    // try {
+    // am.setCacheListener(cl1);
+    // fail("expected IllegalStateException");
+    // } catch (IllegalStateException expected) {
+    // }
     am.removeCacheListener(cl1);
     assertEquals(Arrays.asList(new CacheListener[] {cl2}), Arrays.asList(ra.getCacheListeners()));
     am.removeCacheListener(cl1);

--- a/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
@@ -155,11 +155,13 @@ public class CacheListenerJUnitTest {
       fail("expected IllegalStateException");
     } catch (IllegalStateException expected) {
     }
-    try {
-      am.setCacheListener(cl1);
-      fail("expected IllegalStateException");
-    } catch (IllegalStateException expected) {
-    }
+
+    // commented this test as this is no more valid test scenario with new APIs
+//    try {
+//      am.setCacheListener(cl1);
+//      fail("expected IllegalStateException");
+//    } catch (IllegalStateException expected) {
+//    }
     am.removeCacheListener(cl1);
     assertEquals(Arrays.asList(new CacheListener[] {cl2}), Arrays.asList(ra.getCacheListeners()));
     am.removeCacheListener(cl1);

--- a/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/CacheListenerJUnitTest.java
@@ -156,12 +156,6 @@ public class CacheListenerJUnitTest {
     } catch (IllegalStateException expected) {
     }
 
-    // commented this test as this is no more valid test scenario with new APIs
-    // try {
-    // am.setCacheListener(cl1);
-    // fail("expected IllegalStateException");
-    // } catch (IllegalStateException expected) {
-    // }
     am.removeCacheListener(cl1);
     assertEquals(Arrays.asList(new CacheListener[] {cl2}), Arrays.asList(ra.getCacheListeners()));
     am.removeCacheListener(cl1);

--- a/geode-core/src/test/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -3462,7 +3462,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
             null);
 
         region1 = createRegion(regionName1, regionFactory.create());
-        region1.getAttributesMutator().setCacheListener(new CertifiableTestCacheListener(
+        region1.getAttributesMutator().addCacheListener(new CertifiableTestCacheListener(
             org.apache.geode.test.dunit.LogWriterUtils.getLogWriter()));
       }
     };
@@ -5310,7 +5310,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
                 .info("vm2 numberOfAfterInvalidates: " + numberOfAfterInvalidates);
           }
         };
-        region.getAttributesMutator().setCacheListener(listener);
+        region.getAttributesMutator().addCacheListener(listener);
         region.registerInterestRegex(".*", false, false);
       }
     });
@@ -5334,7 +5334,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
             // getLogWriter().info("vm3 numberOfAfterInvalidates: " + numberOfAfterInvalidates);
           }
         };
-        region.getAttributesMutator().setCacheListener(listener);
+        region.getAttributesMutator().addCacheListener(listener);
         region.registerInterestRegex(".*", false, false);
       }
     });

--- a/geode-core/src/test/java/org/apache/geode/cache30/CacheLoaderTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/CacheLoaderTestCase.java
@@ -310,7 +310,7 @@ public abstract class CacheLoaderTestCase extends CacheWriterTestCase {
       }
     };
 
-    region.getAttributesMutator().setCacheListener(listener);
+    region.getAttributesMutator().addCacheListener(listener);
 
     region.put(key, newValue);
     Wait.pause(500);

--- a/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
@@ -493,7 +493,7 @@ public class DiskRegionDUnitTest extends JUnit4CacheTestCase {
       public void close2() {}
     };
 
-    region.getAttributesMutator().setCacheListener(listener);
+    region.getAttributesMutator().addCacheListener(listener);
 
     for (int i = 0; i < total; i++) {
       String value = (String) region.get(new Integer(i));
@@ -513,7 +513,7 @@ public class DiskRegionDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
-    region.getAttributesMutator().setCacheListener(listener);
+    region.getAttributesMutator().addCacheListener(listener);
 
     for (int i = 0; i < 20; i++) {
       region.put(new Integer(i), new byte[i]);

--- a/geode-core/src/test/java/org/apache/geode/cache30/RegionAttributesTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/RegionAttributesTestCase.java
@@ -104,7 +104,7 @@ public abstract class RegionAttributesTestCase extends RegionTestCase {
     assertEquals(region, mutator.getRegion());
     assertSame(region, mutator);
 
-    mutator.setCacheListener(listener);
+    mutator.addCacheListener(listener);
     mutator.setCacheLoader(loader);
     mutator.setCacheWriter(writer);
     mutator.setEntryIdleTimeout(entryIdle);
@@ -140,7 +140,8 @@ public abstract class RegionAttributesTestCase extends RegionTestCase {
     ExpirationAttributes regionIdle2 = new ExpirationAttributes(7, ExpirationAction.DESTROY);
     ExpirationAttributes regionTTL2 = new ExpirationAttributes(8, ExpirationAction.INVALIDATE);
 
-    assertEquals(listener, mutator.setCacheListener(listener2));
+    mutator.initCacheListeners(new CacheListener[]{listener2});
+    assertEquals(listener2, attrs.getCacheListener());
     assertEquals(loader, mutator.setCacheLoader(loader2));
     assertEquals(writer, mutator.setCacheWriter(writer2));
     assertEquals(entryIdle, mutator.setEntryIdleTimeout(entryIdle2));

--- a/geode-core/src/test/java/org/apache/geode/cache30/RegionAttributesTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/RegionAttributesTestCase.java
@@ -140,7 +140,7 @@ public abstract class RegionAttributesTestCase extends RegionTestCase {
     ExpirationAttributes regionIdle2 = new ExpirationAttributes(7, ExpirationAction.DESTROY);
     ExpirationAttributes regionTTL2 = new ExpirationAttributes(8, ExpirationAction.INVALIDATE);
 
-    mutator.initCacheListeners(new CacheListener[]{listener2});
+    mutator.initCacheListeners(new CacheListener[] {listener2});
     assertEquals(listener2, attrs.getCacheListener());
     assertEquals(loader, mutator.setCacheLoader(loader2));
     assertEquals(writer, mutator.setCacheWriter(writer2));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegCbkChkJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegCbkChkJUnitTest.java
@@ -50,7 +50,7 @@ public class DiskRegCbkChkJUnitTest extends DiskRegionTestingBase {
         Scope.LOCAL);
 
     // testing create callbacks
-    region.getAttributesMutator().setCacheListener(new CacheListenerAdapter() {
+    region.getAttributesMutator().addCacheListener(new CacheListenerAdapter() {
       public void afterCreate(EntryEvent event) {
         intoCreateAfterCbk = true;
       }
@@ -64,7 +64,7 @@ public class DiskRegCbkChkJUnitTest extends DiskRegionTestingBase {
     assertTrue("Create callback not called", intoCreateAfterCbk);
 
     // testing update callbacks
-    region.getAttributesMutator().setCacheListener(new CacheListenerAdapter() {
+    region.getAttributesMutator().addCacheListener(new CacheListenerAdapter() {
       public void afterUpdate(EntryEvent event) {
         intoUpdateAfterCbk = true;
       }
@@ -79,7 +79,7 @@ public class DiskRegCbkChkJUnitTest extends DiskRegionTestingBase {
     assertTrue("Update callback not called", intoUpdateAfterCbk);
 
     // testing destroy callbacks
-    region.getAttributesMutator().setCacheListener(new CacheListenerAdapter() {
+    region.getAttributesMutator().addCacheListener(new CacheListenerAdapter() {
       public void afterDestroy(EntryEvent event) {
         intoDestroyAfterCbk = true;
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
@@ -1526,7 +1526,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
       }
     });
 
-    region.getAttributesMutator().setCacheListener(new CacheListenerAdapter() {
+    region.getAttributesMutator().addCacheListener(new CacheListenerAdapter() {
       public void afterCreate(EntryEvent event) {
         th.start();
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterface2JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/MapInterface2JUnitTest.java
@@ -110,7 +110,7 @@ public class MapInterface2JUnitTest {
   public void testBasicMapAfterClearCalback() {
     Region rgn = CacheUtils.getRegion("Portfolios");
     AttributesMutator atm = rgn.getAttributesMutator();
-    atm.setCacheListener(new CacheListenerAdapter() {
+    atm.addCacheListener(new CacheListenerAdapter() {
 
       public void afterRegionClear(RegionEvent event) {
         synchronized (MapInterface2JUnitTest.this) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/InterestListDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/InterestListDUnitTest.java
@@ -676,7 +676,7 @@ public class InterestListDUnitTest extends JUnit4DistributedTestCase {
   private static void addCacheListener(int expectedCreates) {
     // Add a cache listener to count the number of create and update events
     Region region = cache.getRegion(REGION_NAME);
-    region.getAttributesMutator().setCacheListener(new EventCountingCacheListener(expectedCreates));
+    region.getAttributesMutator().addCacheListener(new EventCountingCacheListener(expectedCreates));
   }
 
   private static void doGets(int numGets) {

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
@@ -461,7 +461,7 @@ public class CqDataDUnitTest extends JUnit4CacheTestCase {
           Region region = createRegion(cqDUnitTest.regions[i], factory.createRegionAttributes());
           // Set CacheListener.
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         }
         Wait.pause(2000);
 

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
@@ -475,7 +475,7 @@ public class CqDataUsingPoolDUnitTest extends JUnit4CacheTestCase {
           Region region = createRegion(cqDUnitTest.regions[i], factory.createRegionAttributes());
           // Set CacheListener.
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         }
         Wait.pause(2000);
 

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -973,7 +973,7 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
         try {
           region = getRootRegion().getSubregion(regionName);
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqQueryUsingPoolDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqQueryUsingPoolDUnitTest.java
@@ -843,7 +843,7 @@ public class CqQueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
         try {
           region = getRootRegion().getSubregion(regionName);
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         } catch (Exception cqe) {
           fail("Failed to get Region.", cqe);
         }

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/dunit/QueryIndexUpdateRIDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/dunit/QueryIndexUpdateRIDUnitTest.java
@@ -492,7 +492,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);
@@ -537,7 +537,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);
@@ -802,7 +802,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
@@ -425,7 +425,7 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
     Region region = null;
     try {
       region = cache.getRegion("root").getSubregion(regionName);
-      region.getAttributesMutator().setCacheListener(new CertifiableTestCacheListener(
+      region.getAttributesMutator().addCacheListener(new CertifiableTestCacheListener(
           org.apache.geode.test.dunit.LogWriterUtils.getLogWriter()));
     } catch (Exception e) {
       fail("Failed to get Region.", e);

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRule.java
@@ -14,9 +14,6 @@
  */
 package org.apache.geode.test.junit.rules;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Configuration.Defaults;
 import com.jayway.jsonpath.Option;
@@ -24,8 +21,10 @@ import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
-
 import org.apache.geode.test.junit.rules.serializable.SerializableExternalResource;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * JUnit Rule that configures json-path to use the {@code JacksonJsonProvider}


### PR DESCRIPTION
Removed AttributesMutator.setCacheListener from AttributesMutator interface and AbstractRegion.
Modified tests to use addCacheListener/initCacheListener.
Removed tests which are not valid for new APIs
Changed references in java docs.