### PR TITLE
GEODE-2637: Refactored LuceneQueryFactory.setResultLimit()

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneQueryFactory.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneQueryFactory.java
@@ -57,7 +57,7 @@ public interface LuceneQueryFactory {
    * @return itself
    * @throws IllegalArgumentException if the value is less than or equal to zero.
    */
-  LuceneQueryFactory setResultLimit(int limit);
+  LuceneQueryFactory setLimit(int limit);
 
   /**
    * Creates a query based on a query string which is parsed by Lucene's

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryFactoryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryFactoryImpl.java
@@ -41,7 +41,7 @@ public class LuceneQueryFactoryImpl implements LuceneQueryFactory {
   }
 
   @Override
-  public LuceneQueryFactory setResultLimit(int limit) {
+  public LuceneQueryFactory setLimit(int limit) {
     if (limit <= 0) {
       throw new IllegalArgumentException("Limit is <= 0: " + limit);
     }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
@@ -15,11 +15,9 @@
 
 package org.apache.geode.cache.lucene.internal.cli.functions;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -35,7 +33,6 @@ import org.apache.geode.cache.lucene.internal.cli.LuceneIndexDetails;
 import org.apache.geode.cache.lucene.internal.cli.LuceneIndexInfo;
 import org.apache.geode.cache.lucene.internal.cli.LuceneQueryInfo;
 import org.apache.geode.cache.lucene.internal.cli.LuceneSearchResults;
-import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.internal.InternalEntity;
 
 /**
@@ -74,7 +71,7 @@ public class LuceneSearchIndexFunction<K, V> extends FunctionAdapter implements 
             + queryInfo.getRegionPath());
       }
       final LuceneQuery<K, V> query = luceneService.createLuceneQueryFactory()
-          .setResultLimit(queryInfo.getLimit()).create(queryInfo.getIndexName(),
+          .setLimit(queryInfo.getLimit()).create(queryInfo.getIndexName(),
               queryInfo.getRegionPath(), queryInfo.getQueryString(), queryInfo.getDefaultField());
       if (queryInfo.getKeysOnly()) {
         query.findKeys().forEach(key -> result.add(new LuceneSearchResults(key.toString())));

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/EvictionDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/EvictionDUnitTest.java
@@ -122,7 +122,7 @@ public class EvictionDUnitTest extends LuceneQueriesAccessorBase {
     accessor.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
       LuceneQuery<Integer, TestObject> query = luceneService.createLuceneQueryFactory()
-          .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+          .setLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
       List<LuceneResultStruct<Integer, TestObject>> resultList = query.findResults();
       assertEquals(NUM_BUCKETS, resultList.size());
     });

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
@@ -30,7 +30,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import junitparams.JUnitParamsRunner;
@@ -73,7 +72,7 @@ public class ExpirationDUnitTest extends LuceneQueriesAccessorBase {
         .atMost(EXPIRATION_TIMEOUT_SEC + EXTRA_WAIT_TIME_SEC, TimeUnit.SECONDS).until(() -> {
           LuceneService luceneService = LuceneServiceProvider.get(getCache());
           LuceneQuery<Integer, TestObject> luceneQuery = luceneService.createLuceneQueryFactory()
-              .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+              .setLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
 
           Collection luceneResultList = null;
           try {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -572,7 +572,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
   private void executeQuery(String indexName, String queryString, String field,
       int expectedResultsSize) throws LuceneQueryException {
     LuceneService luceneService = LuceneServiceProvider.get(getCache());
-    LuceneQuery query = luceneService.createLuceneQueryFactory().setResultLimit(expectedResultsSize)
+    LuceneQuery query = luceneService.createLuceneQueryFactory().setLimit(expectedResultsSize)
         .create(indexName, REGION_NAME, queryString, field);
     Collection results = query.findValues();
     assertEquals(expectedResultsSize, results.size());

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesAccessorBase.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesAccessorBase.java
@@ -98,8 +98,8 @@ public class LuceneQueriesAccessorBase extends LuceneDUnitTest {
 
       LuceneService service = LuceneServiceProvider.get(cache);
       LuceneQuery<Integer, TestObject> query;
-      query = service.createLuceneQueryFactory().setResultLimit(1000).setPageSize(1000)
-          .create(INDEX_NAME, REGION_NAME, queryString, defaultField);
+      query = service.createLuceneQueryFactory().setLimit(1000).setPageSize(1000).create(INDEX_NAME,
+          REGION_NAME, queryString, defaultField);
       Collection<?> results = query.findKeys();
 
       assertEquals(expectedResultsSize, results.size());

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/MixedObjectIndexDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/MixedObjectIndexDUnitTest.java
@@ -65,7 +65,7 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
 
     accessor.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      LuceneQuery luceneQuery = luceneService.createLuceneQueryFactory().setResultLimit(100)
+      LuceneQuery luceneQuery = luceneService.createLuceneQueryFactory().setLimit(100)
           .create(INDEX_NAME, REGION_NAME, "world", "text");
       List resultList = luceneQuery.findResults();
       int objectType_1_count = 0;
@@ -108,13 +108,13 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
 
     accessor.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory()
-          .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
+          .create(INDEX_NAME, REGION_NAME, "world", "text");
       List luceneResults = luceneQueryForTextField.findResults();
       validateObjectResultCounts(luceneResults, TestObject.class, NUM_BUCKETS,
           TestObjectWithSameFieldName.class, NUM_BUCKETS, TestObjectWithNoCommonField.class, 0);
 
-      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setResultLimit(100)
+      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
           .create(INDEX_NAME, REGION_NAME, "world", "data");
       luceneResults = luceneQueryForTextField.findResults();
       validateObjectResultCounts(luceneResults, TestObject.class, 0,
@@ -149,8 +149,8 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
 
     accessor.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory()
-          .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
+          .create(INDEX_NAME, REGION_NAME, "world", "text");
       List luceneResults = luceneQueryForTextField.findResults();
       validateObjectResultCounts(luceneResults, TestObject.class, NUM_BUCKETS,
           TestObjectWithSameFieldName.class, NUM_BUCKETS, TestObjectWithNoCommonField.class, 0);
@@ -184,8 +184,8 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
     accessor.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
 
-      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory()
-          .setResultLimit(100).create(INDEX_NAME, REGION_NAME, "world", "text");
+      LuceneQuery luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
+          .create(INDEX_NAME, REGION_NAME, "world", "text");
 
       List luceneResults = luceneQueryForTextField.findResults();
       validateObjectResultCounts(luceneResults, TestObject.class, NUM_BUCKETS,
@@ -194,7 +194,7 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
 
       FloatRangeQueryProvider floatRangeQueryProvider =
           new FloatRangeQueryProvider("text", 999.0f, 999.2f);
-      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setResultLimit(100)
+      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
           .create(INDEX_NAME, REGION_NAME, floatRangeQueryProvider);
 
       luceneResults = luceneQueryForTextField.findResults();
@@ -203,7 +203,7 @@ public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
           TestObjectSameFieldNameButDifferentDataTypeInteger.class, 0);
 
       IntRangeQueryProvider intRangeQueryProvider = new IntRangeQueryProvider("text", 1000, 1000);
-      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setResultLimit(100)
+      luceneQueryForTextField = luceneService.createLuceneQueryFactory().setLimit(100)
           .create(INDEX_NAME, REGION_NAME, intRangeQueryProvider);
 
       luceneResults = luceneQueryForTextField.findResults();

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/PaginationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/PaginationDUnitTest.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.DistributedTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -79,7 +78,7 @@ public class PaginationDUnitTest extends LuceneQueriesAccessorBase {
       Cache cache = getCache();
       LuceneService service = LuceneServiceProvider.get(cache);
       LuceneQuery<Integer, TestObject> query;
-      query = service.createLuceneQueryFactory().setResultLimit(1000).setPageSize(PAGE_SIZE)
+      query = service.createLuceneQueryFactory().setLimit(1000).setPageSize(PAGE_SIZE)
           .create(INDEX_NAME, REGION_NAME, "world", "text");
       PageableLuceneQueryResults<Integer, TestObject> pages = query.findPages();
       assertTrue(pages.hasNext());
@@ -121,7 +120,7 @@ public class PaginationDUnitTest extends LuceneQueriesAccessorBase {
       Cache cache = getCache();
       LuceneService service = LuceneServiceProvider.get(cache);
       LuceneQuery<Integer, TestObject> query;
-      query = service.createLuceneQueryFactory().setResultLimit(1000).setPageSize(PAGE_SIZE)
+      query = service.createLuceneQueryFactory().setLimit(1000).setPageSize(PAGE_SIZE)
           .create(INDEX_NAME, REGION_NAME, "world", "text");
       PageableLuceneQueryResults<Integer, TestObject> pages = query.findPages();
       assertTrue(pages.hasNext());

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryFactoryImplJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryFactoryImplJUnitTest.java
@@ -43,7 +43,7 @@ public class LuceneQueryFactoryImplJUnitTest {
     when(cache.getRegion(any())).thenReturn(region);
     LuceneQueryFactoryImpl f = new LuceneQueryFactoryImpl(cache);
     f.setPageSize(5);
-    f.setResultLimit(25);
+    f.setLimit(25);
     LuceneQuery<Object, Object> query =
         f.create("index", "region", new StringQueryProvider("test", DEFAULT_FIELD));
     assertEquals(25, query.getLimit());

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
@@ -93,7 +93,7 @@ public class LuceneSearchIndexFunctionJUnitTest {
 
     doReturn(mock(LuceneIndex.class)).when(service).getIndex(anyString(), anyString());
     doReturn(mockQueryFactory).when(service).createLuceneQueryFactory();
-    doReturn(mockQueryFactory).when(mockQueryFactory).setResultLimit(anyInt());
+    doReturn(mockQueryFactory).when(mockQueryFactory).setLimit(anyInt());
     doReturn(mockQuery).when(mockQueryFactory).create(any(), any(), any(), any());
     when(mockQuery.findPages()).thenReturn(pageableLuceneQueryResults);
     when(pageableLuceneQueryResults.hasNext()).thenReturn(true).thenReturn(false);


### PR DESCRIPTION
	* Renamed LuceneQueryFactory.getResult to setLimit()
	* This is done to match the cwiki documents

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
