### PR TITLE
GEODE-1994, revisited: Removed guaranteed failures.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommands.java
@@ -1797,12 +1797,12 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
         final ServerLauncher serverLauncher = new ServerLauncher.Builder()
             .setCommand(ServerLauncher.Command.STATUS).setDebug(isDebugging())
             // NOTE since we do not know whether the "CacheServer" was enabled or not on the GemFire
-            // server when it was started,
-            // set the disableDefaultServer property in the ServerLauncher.Builder to default status
+            // server when it was started, set the disableDefaultServer property in the
+            // ServerLauncher.Builder to default status
             // to the MemberMBean
             // TODO fix this hack! (how, the 'start server' loop needs it)
-            .setDisableDefaultServer(true).setMemberName(member).setPid(pid)
-            .setWorkingDirectory(workingDirectory).build();
+            .setDisableDefaultServer(true).setPid(pid).setWorkingDirectory(workingDirectory)
+            .build();
 
         final ServerState status = serverLauncher.status();
 
@@ -1854,9 +1854,9 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
               .format(CliStrings.STOP_SERVICE__GFSH_NOT_CONNECTED_ERROR_MESSAGE, "Cache Server"));
         }
       } else {
-        final ServerLauncher serverLauncher = new ServerLauncher.Builder()
-            .setCommand(ServerLauncher.Command.STOP).setDebug(isDebugging()).setMemberName(member)
-            .setPid(pid).setWorkingDirectory(workingDirectory).build();
+        final ServerLauncher serverLauncher =
+            new ServerLauncher.Builder().setCommand(ServerLauncher.Command.STOP)
+                .setDebug(isDebugging()).setPid(pid).setWorkingDirectory(workingDirectory).build();
 
         serverState = serverLauncher.status();
         serverLauncher.stop();


### PR DESCRIPTION
Removed two uses of ServerLauncher.Builder.setMemberName that are guaranteed to throw under the changes introduced by GEODE-1994.

With the previous update to StringUtils, ServerLauncher.Builder.setMemberName throws when its input is blank.  These two uses are behind conditionals and only occur when the member name is blank, guaranteeing failure.  This results in the `status server` and `stop server` commands functioning only when `--name` is used, but failing with `--dir` and `--pid`.