### PR TITLE
GEODE-2981: Fix the line feed code of the test expected value

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/help/HelpBlockUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/help/HelpBlockUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.cli.help;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +71,12 @@ public class HelpBlockUnitTest {
     firstBlock.addChild(secondBlock);
     secondBlock.addChild(thirdBlock);
 
+    StringBuilder expected = new StringBuilder();
+    expected.append("First Line").append(GfshParser.LINE_SEPARATOR);
+    expected.append("Second Line").append(GfshParser.LINE_SEPARATOR);
+    expected.append("Third Line").append(GfshParser.LINE_SEPARATOR);
+
     String result = firstBlock.toString(-1);
-    assertThat(result).isEqualTo("First Line\nSecond Line\nThird Line\n");
+    assertThat(result).isEqualTo(expected.toString());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/help/HelperUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/help/HelperUnitTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.apache.geode.management.internal.cli.GfshParser.LINE_SEPARATOR;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class HelperUnitTest {
   @Test
   public void testGetLongHelp() {
     HelpBlock helpBlock = helper.getHelp(cliCommand, annotations, parameterType);
-    String[] helpLines = helpBlock.toString().split("\n");
+    String[] helpLines = helpBlock.toString().split(LINE_SEPARATOR);
     assertThat(helpLines.length).isEqualTo(14);
     assertThat(helpLines[0]).isEqualTo(Helper.NAME_NAME);
     assertThat(helpLines[2]).isEqualTo(Helper.IS_AVAILABLE_NAME);
@@ -84,7 +85,7 @@ public class HelperUnitTest {
   @Test
   public void testGetShortHelp() {
     HelpBlock helpBlock = helper.getHelp(cliCommand, null, null);
-    String[] helpLines = helpBlock.toString().split("\n");
+    String[] helpLines = helpBlock.toString().split(LINE_SEPARATOR);
     assertThat(helpLines.length).isEqualTo(2);
     assertThat(helpLines[0]).isEqualTo("test (Available)");
     assertThat(helpLines[1]).isEqualTo("This is a test description");
@@ -95,8 +96,8 @@ public class HelperUnitTest {
     String syntax = helper.getSyntaxString("test", annotations, parameterType);
     assertThat(syntax).isEqualTo("test --option=value");
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option\n" + "help of option\n" + "Required: true\n");
+    assertThat(optionBlock.toString()).isEqualTo("option" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR);
   }
 
   @Test
@@ -105,8 +106,8 @@ public class HelperUnitTest {
     String syntax = helper.getSyntaxString("test", annotations, parameterType);
     assertThat(syntax).isEqualTo("test [--option=value]");
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option\n" + "help of option\n" + "Required: false\n");
+    assertThat(optionBlock.toString()).isEqualTo("option" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: false" + LINE_SEPARATOR);
   }
 
   @Test
@@ -116,7 +117,8 @@ public class HelperUnitTest {
     assertThat(syntax).isEqualTo("test --option=value");
     optionBlock = helper.getOptionDetail(cliOption);
     assertThat(optionBlock.toString())
-        .isEqualTo("option\n" + "help of option\n" + "Synonyms: option2\n" + "Required: true\n");
+        .isEqualTo("option" + LINE_SEPARATOR + "help of option" + LINE_SEPARATOR
+            + "Synonyms: option2" + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR);
   }
 
   @Test
@@ -126,8 +128,8 @@ public class HelperUnitTest {
     String syntax = helper.getSyntaxString("test", annotations, parameterType);
     assertThat(syntax).isEqualTo("test option2");
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option2\n" + "help of option\n" + "Required: true\n");
+    assertThat(optionBlock.toString()).isEqualTo("option2" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR);
   }
 
   @Test
@@ -137,8 +139,8 @@ public class HelperUnitTest {
     String syntax = helper.getSyntaxString("test", annotations, parameterType);
     assertThat(syntax).isEqualTo("test [option2]");
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option2\n" + "help of option\n" + "Required: false\n");
+    assertThat(optionBlock.toString()).isEqualTo("option2" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: false" + LINE_SEPARATOR);
   }
 
   @Test
@@ -147,8 +149,8 @@ public class HelperUnitTest {
     String syntax = helper.getSyntaxString("test", annotations, parameterType);
     assertThat(syntax).isEqualTo("test --option=value(,value)*");
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option\n" + "help of option\n" + "Required: true\n");
+    assertThat(optionBlock.toString()).isEqualTo("option" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR);
   }
 
   @Test
@@ -158,9 +160,9 @@ public class HelperUnitTest {
     assertThat(syntax).isEqualTo("test --option(=value)?");
 
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString()).isEqualTo("option\n" + "help of option\n"
-        + "Required: true\n" + "Default (if the parameter is specified without value): true\n");
-
+    assertThat(optionBlock.toString()).isEqualTo("option" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR
+        + "Default (if the parameter is specified without value): true" + LINE_SEPARATOR);
   }
 
   @Test
@@ -171,10 +173,9 @@ public class HelperUnitTest {
     assertThat(syntax).isEqualTo("test --option(=value)?(,value)*");
 
     optionBlock = helper.getOptionDetail(cliOption);
-    assertThat(optionBlock.toString())
-        .isEqualTo("option\n" + "help of option\n" + "Required: true\n"
-            + "Default (if the parameter is specified without value): value1,value2\n");
-
+    assertThat(optionBlock.toString()).isEqualTo("option" + LINE_SEPARATOR + "help of option"
+        + LINE_SEPARATOR + "Required: true" + LINE_SEPARATOR
+        + "Default (if the parameter is specified without value): value1,value2" + LINE_SEPARATOR);
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshJunitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshJunitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.cli.shell;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +37,8 @@ public class GfshJunitTest {
     assertThat(Gfsh.wrapText(testString, 0, -1)).isEqualTo(testString);
     assertThat(Gfsh.wrapText(testString, 0, 0)).isEqualTo(testString);
     assertThat(Gfsh.wrapText(testString, 0, 1)).isEqualTo(testString);
-    assertThat(Gfsh.wrapText(testString, 0, 10)).isEqualTo("This is a\ntest\nstring.");
+    assertThat(Gfsh.wrapText(testString, 0, 10))
+        .isEqualTo("This is a" + Gfsh.LINE_SEPARATOR + "test" + Gfsh.LINE_SEPARATOR + "string.");
     assertThat(Gfsh.wrapText(testString, 1, 100)).isEqualTo(Gfsh.LINE_INDENT + testString);
     assertThat(Gfsh.wrapText(testString, 2, 100))
         .isEqualTo(Gfsh.LINE_INDENT + Gfsh.LINE_INDENT + testString);


### PR DESCRIPTION
Fixed the line feed code of the test expectation value so that it does not depend on the runtime environment.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
