### PR TITLE
GEODE-2986: Added null check to log message

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommands.java
@@ -485,10 +485,12 @@ public class DiskStoreCommands extends AbstractCommandsSupport {
               memberCompactInfo.clear();
             }
             String notExecutedMembers = CompactRequest.getNotExecutedMembers();
-            LogWrapper.getInstance()
-                .info("compact disk-store \"" + diskStoreName
-                    + "\" message was scheduled to be sent to but was not send to "
-                    + notExecutedMembers);
+            if (notExecutedMembers != null && !notExecutedMembers.isEmpty()) {
+              LogWrapper.getInstance()
+                  .info("compact disk-store \"" + diskStoreName
+                      + "\" message was scheduled to be sent to but was not send to "
+                      + notExecutedMembers);
+            }
           }
 
           // If compaction happened at all, then prepare the summary


### PR DESCRIPTION
Just log message if "notExecutedMembers" is not null and not empty.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
