### PR TITLE
GEODE-2951 Remove --pageSize from docs of gfsh search lucene

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
@@ -31,7 +31,7 @@ See also [create lucene index](create.html#create_lucene_index), [describe lucen
 
 ``` pre
 search lucene --name=value --region=value --queryStrings=value --defaultField=value
-    [--limit=value] [--pageSize=value] [--keys-only=value]
+    [--limit=value] [--keys-only=value]
 ```
 
 **Parameters, search lucene:**
@@ -73,11 +73,6 @@ search lucene --name=value --region=value --queryStrings=value --defaultField=va
 <tr>
 <td><span class="keyword parmname">\-\-limit</span></td>
 <td>Number of search results needed.</td>
-<td>If the parameter is not specified: -1</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-pageSize</span></td>
-<td>Number of results to be returned in a page.</td>
 <td>If the parameter is not specified: -1</td>
 </tr>
 <td><span class="keyword parmname">\-\-keys-only</span></td>


### PR DESCRIPTION
The code commit to remove this gfsh search lucene command line option has already been completed.  This PR updates the docs to remove the option from the command reference page.

@boglesby @davebarnes97 @joeymcallister @dihardman @upthewaterspout @nabarunnag @DivineEnder @ladyVader @jhuynh1 and any other interested parties
Can a couple of you do an ultra-quick review of this simple change to the docs, so that it can be merged in for inclusion in a Geode 1.2 release?