### PR TITLE
GEODE-3013: Reduce log level for FunctionInvocationTargetException

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunctionSingleHop.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunctionSingleHop.java
@@ -294,7 +294,8 @@ public class ExecuteRegionFunctionSingleHop extends BaseCommand {
     } catch (FunctionException fe) {
       String message = fe.getMessage();
 
-      if (fe.getCause() instanceof FunctionInvocationTargetException) {
+      if ((fe.getCause() instanceof FunctionInvocationTargetException)
+          || (fe instanceof FunctionInvocationTargetException)) {
         if (functionObject.isHA() && logger.isDebugEnabled()) {
           logger.debug("Exception on server while executing function: {}: {}", function, message);
         } else if (logger.isDebugEnabled()) {


### PR DESCRIPTION
GEODE-3013: Reduce log level for FunctionInvocationTargetExceptions

- Modified to display at debug vs. warning level (includes full stack trace)

@upthewaterspout @nabarunnag, @boglesby, @jhuynh1, @gesterzhou

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
