### PR TITLE
GEODE-3028: Fix the expected value of the test that depended on Locale

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/auth/GMSAuthenticatorWithAuthenticatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/auth/GMSAuthenticatorWithAuthenticatorTest.java
@@ -17,19 +17,31 @@ package org.apache.geode.distributed.internal.membership.gms.auth;
 import static org.apache.geode.distributed.ConfigurationProperties.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Locale;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.i18n.StringId;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.RestoreLocaleRule;
 
 /**
  * Unit tests GMSAuthenticator using old security.
  */
 @Category({UnitTest.class, SecurityTest.class})
 public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthenticatorTestCase {
+
+  /**
+   * This test assumes Locale is in English. Before the test, change the locale of Locale and
+   * StringId to English and restore the original locale after the test.
+   */
+  @Rule
+  public final RestoreLocaleRule restoreLocale =
+      new RestoreLocaleRule(Locale.ENGLISH, l -> StringId.setLocale(l));
 
   @Override
   protected boolean isIntegratedSecurity() {

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/auth/GMSAuthenticatorWithSecurityManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/auth/GMSAuthenticatorWithSecurityManagerTest.java
@@ -18,20 +18,32 @@ import static org.apache.geode.distributed.ConfigurationProperties.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Locale;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.i18n.StringId;
 import org.apache.geode.security.GemFireSecurityException;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.RestoreLocaleRule;
 
 /**
  * Unit tests GMSAuthenticator using new integrated security.
  */
 @Category({UnitTest.class, SecurityTest.class})
 public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenticatorTestCase {
+
+  /**
+   * This test assumes Locale is in English. Before the test, change the locale of Locale and
+   * StringId to English and restore the original locale after the test.
+   */
+  @Rule
+  public final RestoreLocaleRule restoreLocale =
+      new RestoreLocaleRule(Locale.ENGLISH, l -> StringId.setLocale(l));
 
   @Override
   protected boolean isIntegratedSecurity() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ColocationHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ColocationHelperTest.java
@@ -23,6 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+
 import org.mockito.ArgumentCaptor;
 
 import org.apache.logging.log4j.Level;
@@ -36,17 +39,28 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.i18n.StringId;
 import org.apache.geode.test.fake.Fakes;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.RestoreLocaleRule;
 
 @Category(UnitTest.class)
 public class ColocationHelperTest {
+  /**
+   * This test assumes Locale is in English. Before the test, change the locale of Locale and
+   * StringId to English and restore the original locale after the test.
+   */
+  @Rule
+  public final RestoreLocaleRule restoreLocale =
+      new RestoreLocaleRule(Locale.ENGLISH, l -> StringId.setLocale(l));
+
   private GemFireCacheImpl cache;
   private GemFireCacheImpl oldCacheInstance;
   private InternalDistributedSystem system;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -26,11 +26,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.geode.cache.Cache;
+import org.apache.geode.i18n.StringId;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.tier.Acceptor;
 import org.apache.geode.security.AuthenticationRequiredException;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.RestoreLocaleRule;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.InjectMocks;
@@ -39,9 +42,19 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Locale;
 
 @Category(UnitTest.class)
 public class ServerConnectionTest {
+
+  /**
+   * This test assumes Locale is in English. Before the test, change the locale of Locale and
+   * StringId to English and restore the original locale after the test.
+   */
+  @Rule
+  public final RestoreLocaleRule restoreLocale =
+      new RestoreLocaleRule(Locale.ENGLISH, l -> StringId.setLocale(l));
+
   @Mock
   private Message requestMsg;
 

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/RestoreLocaleRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/RestoreLocaleRule.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.rules;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * The {@code RestoreLocale} rule undoes changes of locale when the test finishes (whether it passes
+ * or fails).
+ * <p>
+ * Let's assume the locale {@code US}. Now run the test
+ * 
+ * <pre>
+ *   public void YourTest {
+ *     &#064;Rule
+ *     public final TestRule restoreLocale = new RestoreLocale();
+ *
+ *     &#064;Test
+ *     public void overrideLocale() {
+ *       Locale.setDefaule(Locale.JAPAN);
+ *       assertThat(Locale.getDefault(), is(Locale.JAPAN));
+ *     }
+ *   }
+ * </pre>
+ * 
+ * After running the test, the locale will set to {@code US} again.
+ */
+public class RestoreLocaleRule extends ExternalResource {
+  private Locale originalLocale;
+
+  private final Locale initLocale;
+  private final Consumer<Locale> consumer;
+
+  /**
+   * Creates a {@code RestoreLocale} rule that restores locale. The initial locale at the time of
+   * the test is set to the specified locale. Specify {@code consumer} if you need to modify the
+   * Locale associated with it. {@code consumer} will be run using the original {@code Locale} after
+   * the test.
+   * 
+   * @param initLocale Initial locale at test run
+   * @param consumer Changing Locale associated with
+   */
+  public RestoreLocaleRule(Locale initLocale, Consumer<Locale> consumer) {
+    this.initLocale = initLocale;
+    this.consumer = consumer;
+  }
+
+  /**
+   * Creates a {@code RestoreLocale} rule that restores locale. The initial locale at the time of
+   * the test is set to the specified locale.
+   * 
+   * @param initLocale Initial locale at test run
+   */
+  public RestoreLocaleRule(Locale initLocale) {
+    this(initLocale, null);
+  }
+
+  /**
+   * Creates a {@code RestoreLocale} rule that restores locale. Specify {@code consumer} if you need
+   * to modify the Locale associated with it. {@code consumer} will be run using the original
+   * {@code Locale} after the test.
+   * 
+   * @param consumer Changing Locale associated with
+   */
+  public RestoreLocaleRule(Consumer<Locale> consumer) {
+    this(Locale.getDefault(), consumer);
+  }
+
+  /**
+   * Creates a {@code RestoreLocale} rule that restores locale.
+   */
+  public RestoreLocaleRule() {
+    this(Locale.getDefault(), null);
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    originalLocale = Locale.getDefault();
+
+    Locale.setDefault(initLocale);
+    if (consumer != null)
+      consumer.accept(initLocale);
+  }
+
+  @Override
+  protected void after() {
+    Locale.setDefault(originalLocale);
+    if (consumer != null)
+      consumer.accept(originalLocale);
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/RestoreLocaleRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/RestoreLocaleRuleTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.rules;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.Result;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+/**
+ * Unit tests for {@link RestoreLocaleRule}.
+ */
+@Category(UnitTest.class)
+public class RestoreLocaleRuleTest {
+
+  private static Locale notDefaultLocale;
+
+  static {
+    Locale[] locales = Locale.getAvailableLocales();
+    while (notDefaultLocale == null) {
+      Locale l = locales[new Random().nextInt(locales.length)];
+      if (l != Locale.getDefault())
+        notDefaultLocale = l;
+    }
+  }
+
+  @Test
+  public void shouldRestoreLocaleInAfter() throws Throwable {
+    Locale originalLocale = Locale.getDefault();
+    Result result = TestRunner.runTest(ShouldRestoreLocaleInAfter.class);
+
+    assertTrue(result.wasSuccessful());
+    assertThat(Locale.getDefault(), is(originalLocale));
+    assertThat(ShouldRestoreLocaleInAfter.localeInTest, is(notDefaultLocale));
+  }
+
+  @Test
+  public void setInitLocaleShouldRestoreLocaleInAfter() throws Throwable {
+    Locale originalLocale = Locale.getDefault();
+    Result result = TestRunner.runTest(SetInitLocaleShouldRestoreLocaleInAfter.class);
+
+    assertTrue(result.wasSuccessful());
+    assertThat(Locale.getDefault(), is(originalLocale));
+    assertThat(SetInitLocaleShouldRestoreLocaleInAfter.localeInTest, is(Locale.ENGLISH));
+  }
+
+  @Test
+  public void shouldRestoreLocaleInAfterWithConsumer() throws Throwable {
+    Locale originalLocale = Locale.getDefault();
+    Result result = TestRunner.runTest(ShouldRestoreLocaleInAfterWithConsumer.class);
+
+    assertTrue(result.wasSuccessful());
+    assertThat(Locale.getDefault(), is(originalLocale));
+    assertThat(ShouldRestoreLocaleInAfterWithConsumer.localeInTest, is(notDefaultLocale));
+    assertThat(ShouldRestoreLocaleInAfterWithConsumer.locales.size(), is(2));
+    assertThat(ShouldRestoreLocaleInAfterWithConsumer.locales,
+        contains(originalLocale, originalLocale));
+  }
+
+  @Test
+  public void setInitLocaleShouldRestoreLocaleInAfterWithConsumer() throws Throwable {
+    Locale originalLocale = Locale.getDefault();
+    Result result = TestRunner.runTest(SetInitLocaleShouldRestoreLocaleInAfterWithConsumer.class);
+
+    assertTrue(result.wasSuccessful());
+    assertThat(Locale.getDefault(), is(originalLocale));
+    assertThat(SetInitLocaleShouldRestoreLocaleInAfterWithConsumer.localeInTest,
+        is(Locale.CHINESE));
+    assertThat(SetInitLocaleShouldRestoreLocaleInAfterWithConsumer.locales.size(), is(2));
+    assertThat(SetInitLocaleShouldRestoreLocaleInAfterWithConsumer.locales,
+        contains(Locale.CHINESE, originalLocale));
+  }
+
+  /**
+   * Used by test {@link #shouldRestoreLocaleInAfter()}
+   */
+  public static class ShouldRestoreLocaleInAfter {
+
+    static Locale localeInTest = notDefaultLocale;
+
+    @Rule
+    public final RestoreLocaleRule restoreLocale = new RestoreLocaleRule();
+
+    @Test
+    public void doTest() throws Exception {
+      Locale.setDefault(localeInTest);
+      assertThat(Locale.getDefault(), is(localeInTest));
+    }
+  }
+
+  /**
+   * Used by test {@link #setInitLocaleShouldRestoreLocaleInAfter()}
+   */
+  public static class SetInitLocaleShouldRestoreLocaleInAfter {
+
+    static Locale localeInTest;
+
+    @Rule
+    public final RestoreLocaleRule restoreLocale = new RestoreLocaleRule(Locale.ENGLISH);
+
+    @Test
+    public void doTest() throws Exception {
+      localeInTest = Locale.getDefault();
+      assertThat(Locale.getDefault(), is(Locale.ENGLISH));
+    }
+  }
+
+  /**
+   * Used by test {@link #shouldRestoreLocaleInAfterWithConsumer()}
+   */
+  public static class ShouldRestoreLocaleInAfterWithConsumer {
+
+    static List<Locale> locales = new ArrayList<>();
+    static Locale localeInTest = notDefaultLocale;
+
+    @Rule
+    public final RestoreLocaleRule restoreLocale = new RestoreLocaleRule(l -> locales.add(l));
+
+    @Test
+    public void doTest() throws Exception {
+      Locale originalLocale = Locale.getDefault();
+      Locale.setDefault(localeInTest);
+      assertThat(Locale.getDefault(), is(localeInTest));
+      assertThat(locales.size(), is(1));
+      assertThat(locales, contains(originalLocale));
+    }
+  }
+
+  /**
+   * Used by test {@link #setInitLocaleShouldRestoreLocaleInAfterWithConsumer()}
+   */
+  public static class SetInitLocaleShouldRestoreLocaleInAfterWithConsumer {
+
+    static List<Locale> locales = new ArrayList<>();
+    static Locale localeInTest;
+
+    @Rule
+    public final RestoreLocaleRule restoreLocale =
+        new RestoreLocaleRule(Locale.CHINESE, l -> locales.add(l));
+
+    @Test
+    public void doTest() throws Exception {
+      localeInTest = Locale.getDefault();
+      assertThat(Locale.getDefault(), is(Locale.CHINESE));
+      assertThat(locales.size(), is(1));
+      assertThat(locales, contains(Locale.CHINESE));
+    }
+  }
+}


### PR DESCRIPTION
Fix the test that uses the English message as the expected value so that it does not depend on the locale at runtime environment.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
