### PR TITLE
GEODE-3025: GET operation before Lucene query

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -108,6 +108,9 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
     TopEntriesCollectorManager manager = new TopEntriesCollectorManager(null, limit);
     LuceneFunctionContext<TopEntriesCollector> context =
         new LuceneFunctionContext<>(query, indexName, manager, limit);
+    if (region.getCache().getCacheTransactionManager().exists()) {
+      throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
+    }
 
     // TODO provide a timeout to the user?
     TopEntries<K> entries = null;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.lucene.LuceneIndexDestroyedException;
 import org.apache.geode.cache.lucene.LuceneIndexNotFoundException;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneIndexMaintenanceIntegrationTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneIndexMaintenanceIntegrationTest.java
@@ -46,32 +46,6 @@ public class LuceneIndexMaintenanceIntegrationTest extends LuceneIntegrationTest
 
   private static int WAIT_FOR_FLUSH_TIME = 10000;
 
-  @Test
-  public void indexIsNotUpdatedIfTransactionHasNotCommittedYet() throws Exception {
-    luceneService.createIndexFactory().setFields("title", "description").create(INDEX_NAME,
-        REGION_NAME);
-
-    Region region = createRegion(REGION_NAME, RegionShortcut.PARTITION);
-    region.put("object-1", new TestObject("title 1", "hello world"));
-    region.put("object-2", new TestObject("title 2", "this will not match"));
-    region.put("object-3", new TestObject("title 3", "hello world"));
-    region.put("object-4", new TestObject("hello world", "hello world"));
-
-    LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
-    luceneService.waitUntilFlushed(INDEX_NAME, REGION_NAME, WAIT_FOR_FLUSH_TIME,
-        TimeUnit.MILLISECONDS);
-    LuceneQuery query = luceneService.createLuceneQueryFactory().create(INDEX_NAME, REGION_NAME,
-        "description:\"hello world\"", DEFAULT_FIELD);
-    PageableLuceneQueryResults<Integer, TestObject> results = query.findPages();
-    assertEquals(3, results.size());
-
-    // begin transaction
-    cache.getCacheTransactionManager().begin();
-    region.put("object-1", new TestObject("title 1", "updated"));
-    luceneService.waitUntilFlushed(INDEX_NAME, REGION_NAME, WAIT_FOR_FLUSH_TIME,
-        TimeUnit.MILLISECONDS);
-    assertEquals(3, query.findPages().size());
-  }
 
   @Test
   public void indexIsUpdatedAfterTransactionHasCommitted() throws Exception {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
@@ -14,12 +14,8 @@
  */
 package org.apache.geode.cache.lucene;
 
-import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.DEFAULT_FIELD;
-import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
@@ -33,7 +29,6 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 import org.junit.runner.RunWith;
 
 import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 
 @Category(DistributedTest.class)
 @RunWith(JUnitParamsRunner.class)
@@ -66,39 +61,6 @@ public class LuceneQueriesClientDUnitTest extends LuceneQueriesDUnitTest {
 
   protected RegionTestableType[] getListOfRegionTestTypes() {
     return new RegionTestableType[] {RegionTestableType.PARTITION_WITH_CLIENT};
-  }
-
-  // Due to singlehop transactions differences, the exception actually isn't thrown
-  // So the parent test behaves differently if singlehop is enabled or not for a client
-  @Test
-  @Parameters(method = "getListOfRegionTestTypes")
-  public void transactionWithLuceneQueriesShouldThrowException(RegionTestableType regionTestType) {
-    SerializableRunnableIF createIndex = () -> {
-      LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      luceneService.createIndexFactory().addField("text").create(INDEX_NAME, REGION_NAME);
-    };
-    dataStore1.invoke(() -> initDataStore(createIndex, regionTestType));
-    dataStore2.invoke(() -> initDataStore(createIndex, regionTestType));
-    accessor.invoke(() -> initAccessor(createIndex, regionTestType));
-
-    putDataInRegion(accessor);
-    assertTrue(waitForFlushBeforeExecuteTextSearch(accessor, 60000));
-    assertTrue(waitForFlushBeforeExecuteTextSearch(dataStore1, 60000));
-
-    accessor.invoke(() -> {
-      Cache cache = getCache();
-      try {
-        LuceneService service = LuceneServiceProvider.get(cache);
-        LuceneQuery<Integer, TestObject> query;
-        query = service.createLuceneQueryFactory().create(INDEX_NAME, REGION_NAME, "text:world",
-            DEFAULT_FIELD);
-        cache.getCacheTransactionManager().begin();
-        PageableLuceneQueryResults<Integer, TestObject> results = query.findPages();
-      } finally {
-        cache.getCacheTransactionManager().rollback();
-      }
-    });
-
   }
 
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryImplJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneQueryImplJUnitTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheTransactionManager;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.execute.Execution;
@@ -58,6 +60,10 @@ public class LuceneQueryImplJUnitTest {
   private ResultCollector<TopEntriesCollector, TopEntries> collector;
   private Region region;
   private PageableLuceneQueryResults<Object, Object> results;
+  private Cache cache;
+  private CacheTransactionManager cacheTransactionManager;
+
+
 
   @Before
   public void createMocks() {
@@ -65,7 +71,11 @@ public class LuceneQueryImplJUnitTest {
     execution = mock(Execution.class);
     collector = mock(ResultCollector.class);
     provider = mock(LuceneQueryProvider.class);
-
+    cache = mock(Cache.class);
+    cacheTransactionManager = mock(CacheTransactionManager.class);
+    when(region.getCache()).thenReturn(cache);
+    when(region.getCache().getCacheTransactionManager()).thenReturn(cacheTransactionManager);
+    when(region.getCache().getCacheTransactionManager().exists()).thenReturn(false);
     when(execution.setArguments(any())).thenReturn(execution);
     when(execution.withCollector(any())).thenReturn(execution);
     when(execution.execute(anyString())).thenReturn((ResultCollector) collector);


### PR DESCRIPTION
	* To allow Lucene queries in single hop with transaction enabled mode, the client must get the metadata about the regions.
	* A Get operation will asynchronously fetch the metadata and the Lucene query will not throw an exception.

@jhuynh1 
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
