### PR TITLE
Add a bunch of .proto definitions to the new protocol.

### DIFF
--- a/geode-client-protobuf/src/main/proto/clientProtocol.proto
+++ b/geode-client-protobuf/src/main/proto/clientProtocol.proto
@@ -18,6 +18,8 @@ package org.apache.geode.protocol.protobuf;
 
 import "google/protobuf/any.proto";
 import "region_API.proto";
+import "server_API.proto";
+import "basicTypes.proto";
 
 message Message {
     MessageHeader messageHeader = 1;
@@ -28,16 +30,26 @@ message Message {
 }
 
 message MessageHeader {
-    int32 correlationId = 2;
-    MetaData metadata = 1;
+    int32 correlationId = 1;
+    MetaData metadata = 2;
 }
 
 message Request {
+    CallbackArguments callbackArg = 1;
     oneof requestAPI {
-        PutRequest putRequest = 1;
-        GetRequest getRequest = 2;
-        PutAllRequest putAllRequest = 3;
-        GetAllRequest getAllRequest = 4;
+        PutRequest putRequest = 2;
+        GetRequest getRequest = 3;
+        PutManyRequest putManyRequest = 4;
+        GetManyRequest getManyRequest = 5;
+        GetRegionsRequest getRegionsRequest = 6;
+        ListKeysRequest listKeysRequest = 7;
+        RemoveRequest removeRequest = 8;
+        RemoveManyRequest removeManyRequest = 9;
+        RemoveAllRequest removeAllRequest = 10;
+        CreateRegionRequest createRegionRequest = 11;
+        DestroyRegionRequest destroyRegionRequest = 12;
+        PingRequest pingRequest = 13;
+        GetServersRequest getServersRequest = 14;
     }
 }
 
@@ -46,8 +58,17 @@ message Response {
     oneof responseAPI {
         PutResponse putResponse = 2;
         GetResponse getResponse = 3;
-        PutAllResponse putAllResponse = 4;
-        GetAllResponse getAllResponse = 5;
+        PutManyResponse putManyResponse = 4;
+        GetManyResponse getManyResponse = 5;
+        GetRegionsResponse getRegionsResponse = 6;
+        ListKeysResponse listKeysResponse = 7;
+        RemoveResponse removeResponse = 8;
+        RemoveManyResponse removeManyResponse = 9;
+        RemoveAllResponse removeAllResponse = 10;
+        CreateRegionResponse createRegionResponse = 11;
+        DestroyRegionResponse destroyRegionResponse = 12;
+        PingResponse pingResponse = 13;
+        GetServersResponse getServersResponse = 14;
     }
 }
 

--- a/geode-client-protobuf/src/main/proto/region_API.proto
+++ b/geode-client-protobuf/src/main/proto/region_API.proto
@@ -21,7 +21,6 @@ import "basicTypes.proto";
 message PutRequest {
     string regionName = 1;
     Entry entry = 2;
-    CallbackArguments callbackArg = 3;
 }
 
 message PutResponse {
@@ -31,33 +30,91 @@ message PutResponse {
 message GetRequest {
     string regionName = 1;
     EncodedValue key = 2;
-    CallbackArguments callbackArg = 3;
 }
 
 message GetResponse {
     EncodedValue result = 1;
 }
 
-message PutAllRequest {
+message PutManyRequest {
     string regionName = 1;
     int32 numberOfEntries = 2;
     repeated Entry entry = 3;
-    CallbackArguments callbackArg = 4;
 }
 
-message PutAllResponse {
+message PutManyResponse {
     int32 numberOfKeysFailed = 1;
     repeated EncodedValue key = 2;
 }
 
-message GetAllRequest {
+message GetManyRequest {
     string regionName = 1;
     int32 numberOfKeys = 2;
     repeated EncodedValue key = 3;
     EncodedValue callbackArg = 4;
 }
 
-message GetAllResponse {
+message GetManyResponse {
     int32 numberOfEntries = 1;
     repeated Entry entries = 2;
+}
+
+message GetRegionsRequest {
+
+}
+
+message GetRegionsResponse {
+    int32 numberOfRegions = 1;
+    repeated Region regions = 2;
+}
+
+message ListKeysRequest {
+    string regionName = 1;
+}
+
+message ListKeysResponse {
+    int32 numberOfKeys = 1;
+    repeated EncodedValue key = 2;
+}
+
+message RemoveRequest {
+    string regionName = 1;
+    EncodedValue key = 2;
+}
+
+message RemoveResponse {
+    bool success = 1;
+}
+
+message RemoveManyRequest {
+    string regionName = 1;
+    repeated EncodedValue key = 2;
+}
+
+message RemoveManyResponse {
+    bool success = 1;
+}
+
+message RemoveAllRequest {
+    string regionName = 1;
+}
+
+message RemoveAllResponse {
+    bool success = 1;
+}
+
+message CreateRegionRequest {
+    string regionName = 1;
+}
+
+message CreateRegionResponse {
+    bool success = 1;
+}
+
+message DestroyRegionRequest {
+    string regionName = 1;
+}
+
+message DestroyRegionResponse {
+    bool success = 1;
 }

--- a/geode-client-protobuf/src/main/proto/server_API.proto
+++ b/geode-client-protobuf/src/main/proto/server_API.proto
@@ -16,45 +16,22 @@
 syntax = "proto3";
 package org.apache.geode.protocol.protobuf;
 
-import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
+import "basicTypes.proto";
 
-message Entry {
-    EncodedValue key = 1;
-    EncodedValue value = 2;
+// PingResponse sends the same number back.
+message PingRequest {
+    int32 sequenceNumber = 1;
 }
 
-message EncodedValue {
-    EncodingType encodingType = 1;
-    bytes value = 2;
+message PingResponse {
+    int32 sequenceNumber = 1;
 }
 
-enum EncodingType {
-    INVALID = 0;
-    INT = 1;
-    LONG = 2;
-    SHORT = 3;
-    BYTE = 4;
-    BOOLEAN = 5;
-    BINARY = 6;
-    FLOAT = 7;
-    DOUBLE = 8;
-    STRING = 9;
-    JSON = 10;
+message GetServersRequest {
+
 }
 
-message CallbackArguments {
-    oneof callbackArgs {
-        google.protobuf.Empty hasCallbackArgument = 1;
-        EncodedValue callbackValue = 2;
-    }
-}
-
-message Region {
-    string name = 1;
-    // TODO: key, value types?
-}
-
-message Server {
-    string URL = 1;
+message GetServersResponse {
+    int32 numberOfServers = 1;
+    repeated Server servers = 2;
 }


### PR DESCRIPTION
These are mostly unimplemented, and some, especially GetServers, may not
make it through in this form. It's a good sketch for feature parity with
the REST API, though.

This is on a feature branch, so I'm going to skip the normal test list. Please review and comment. @udo @hiteshk25 @bschuchardt and Brian and Alexander, whose github names I can't seem to find.