### PR TITLE
GEODE-3021: Any call after the first to setPdxStringFlag should no-op

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
@@ -2002,7 +2002,8 @@ public abstract class AbstractIndex implements IndexProtocol {
    */
   synchronized void setPdxStringFlag(Object key) {
     // For Null and Undefined keys do not set the isIndexedPdxKeysFlagSet flag
-    if (key == null || key == IndexManager.NULL || key == QueryService.UNDEFINED) {
+    if (isIndexedPdxKeysFlagSet || key == null || key == IndexManager.NULL
+        || key == QueryService.UNDEFINED) {
       return;
     }
     if (!this.isIndexedPdxKeys) {
@@ -2079,5 +2080,9 @@ public abstract class AbstractIndex implements IndexProtocol {
 
   public void setPopulated(boolean isPopulated) {
     this.isPopulated = isPopulated;
+  }
+
+  boolean isIndexOnPdxKeys() {
+    return isIndexedPdxKeys;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/AbstractIndexMaintenanceIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/AbstractIndexMaintenanceIntegrationTest.java
@@ -14,6 +14,10 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static junit.framework.TestCase.assertFalse;
+import static org.apache.geode.internal.Assert.assertTrue;
+
+import org.apache.geode.pdx.internal.PdxString;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,6 +41,44 @@ public abstract class AbstractIndexMaintenanceIntegrationTest {
   @After
   public void tearDown() throws Exception {
     CacheUtils.closeCache();
+  }
+
+  @Test
+  public void setPdxStringFlagWithAPdxStringShouldNotBeChangedAfterTheFirstCall() throws Exception {
+    CacheUtils.startCache();
+    Cache cache = CacheUtils.getCache();
+    LocalRegion region =
+        (LocalRegion) cache.createRegionFactory(RegionShortcut.REPLICATE).create("portfolios");
+    QueryService qs = cache.getQueryService();
+    AbstractIndex statusIndex =
+        createIndex(qs, "statusIndex", "value.status", "/portfolios.entrySet()");
+
+    statusIndex.setPdxStringFlag("StringKey");
+    assertTrue(statusIndex.isIndexedPdxKeysFlagSet);
+    assertFalse(statusIndex.isIndexOnPdxKeys());
+
+    statusIndex.setPdxStringFlag(new PdxString("PdxString Key"));
+    assertTrue(statusIndex.isIndexedPdxKeysFlagSet);
+    assertFalse(statusIndex.isIndexOnPdxKeys());
+  }
+
+  @Test
+  public void setPdxStringFlagWithAStringShouldNotBeChangedAfterTheFirstCall() throws Exception {
+    CacheUtils.startCache();
+    Cache cache = CacheUtils.getCache();
+    LocalRegion region =
+        (LocalRegion) cache.createRegionFactory(RegionShortcut.REPLICATE).create("portfolios");
+    QueryService qs = cache.getQueryService();
+    AbstractIndex statusIndex =
+        createIndex(qs, "statusIndex", "value.status", "/portfolios.entrySet()");
+
+    statusIndex.setPdxStringFlag(new PdxString("PdxString Key"));
+    assertTrue(statusIndex.isIndexedPdxKeysFlagSet);
+    assertTrue(statusIndex.isIndexOnPdxKeys());
+
+    statusIndex.setPdxStringFlag("PdxString Key");
+    assertTrue(statusIndex.isIndexedPdxKeysFlagSet);
+    assertTrue(statusIndex.isIndexOnPdxKeys());
   }
 
   @Test


### PR DESCRIPTION
  * The flag isIndexedPdxKeysFlagSet is now checked before setting pdx string flag

@nabarunnag @ladyVader 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
