### PR TITLE
GEODE-290: Removed deprecated methods from Launcher classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -86,12 +86,6 @@ import joptsimple.OptionSet;
 @SuppressWarnings({"unused"})
 public class LocatorLauncher extends AbstractLauncher<String> {
 
-  /**
-   * @deprecated This is specific to the internal implementation and may go away in a future
-   *             release.
-   */
-  public static final Integer DEFAULT_LOCATOR_PORT = getDefaultLocatorPort();
-
   private static final Boolean DEFAULT_LOAD_SHARED_CONFIG_FROM_DIR = Boolean.FALSE;
 
   private static final Map<String, String> helpMap = new HashMap<>();
@@ -136,12 +130,6 @@ public class LocatorLauncher extends AbstractLauncher<String> {
         "stop [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Locator-working-directory>] [--debug] [--help]");
     usageMap.put(Command.VERSION, "version");
   }
-
-  /**
-   * @deprecated This is specific to the internal implementation and may go away in a future
-   *             release.
-   */
-  public static final String DEFAULT_LOCATOR_PID_FILE = "vf.gf.locator.pid";
 
   private static final String DEFAULT_LOCATOR_LOG_EXT = ".log";
   private static final String DEFAULT_LOCATOR_LOG_NAME = "locator";
@@ -1080,20 +1068,6 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     } catch (UnableToControlProcessException e) {
       return createNoResponseState(e,
           "Failed to communicate with locator with process id " + getPid());
-    }
-  }
-
-  @Deprecated
-  private LocatorState stopWithPort() {
-    try {
-      new TcpClient().stop(getBindAddress(), getPort());
-      return new LocatorState(this, Status.STOPPED);
-    } catch (ConnectException e) {
-      if (getBindAddress() == null) {
-        return createNoResponseState(e, "Failed to connect to locator on port " + getPort());
-      } else {
-        return createNoResponseState(e, "Failed to connect to locator on " + getId());
-      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -98,13 +98,6 @@ import joptsimple.OptionSet;
 @SuppressWarnings({"unused"})
 public class ServerLauncher extends AbstractLauncher<String> {
 
-  /**
-   * @deprecated This is specific to the internal implementation and may go away in a future
-   *             release.
-   */
-  @Deprecated
-  protected static final Integer DEFAULT_SERVER_PORT = getDefaultServerPort();
-
   private static final Map<String, String> helpMap = new HashMap<>();
 
   static {
@@ -153,13 +146,6 @@ public class ServerLauncher extends AbstractLauncher<String> {
         "stop [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Server-working-directory>] [--debug] [--help]");
     usageMap.put(Command.VERSION, "version");
   }
-
-  /**
-   * @deprecated This is specific to the internal implementation and may go away in a future
-   *             release.
-   */
-  @Deprecated
-  public static final String DEFAULT_SERVER_PID_FILE = "vf.gf.server.pid";
 
   private static final String DEFAULT_SERVER_LOG_EXT = ".log";
   private static final String DEFAULT_SERVER_LOG_NAME = "gemfire";

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherTest.java
@@ -29,6 +29,7 @@ import org.apache.geode.distributed.LocatorLauncher.Command;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.DistributionLocator;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -299,8 +300,7 @@ public class LocatorLauncherTest {
   @Test
   public void testSetAndGetPort() {
     Builder builder = new Builder();
-
-    assertEquals(LocatorLauncher.DEFAULT_LOCATOR_PORT, builder.getPort());
+    assertEquals(Integer.valueOf(DistributionLocator.DEFAULT_LOCATOR_PORT), builder.getPort());
     assertSame(builder, builder.setPort(65535));
     assertEquals(65535, builder.getPort().intValue());
     assertSame(builder, builder.setPort(1024));
@@ -312,7 +312,7 @@ public class LocatorLauncherTest {
     assertSame(builder, builder.setPort(0));
     assertEquals(0, builder.getPort().intValue());
     assertSame(builder, builder.setPort(null));
-    assertEquals(LocatorLauncher.DEFAULT_LOCATOR_PORT, builder.getPort());
+    assertEquals(Integer.valueOf(DistributionLocator.DEFAULT_LOCATOR_PORT), builder.getPort());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
@@ -330,7 +330,7 @@ public class ServerLauncherTest {
   public void testSetAndGetServerPort() {
     Builder builder = new Builder();
 
-    assertEquals(ServerLauncher.DEFAULT_SERVER_PORT, builder.getServerPort());
+    assertEquals(Integer.valueOf(CacheServer.DEFAULT_PORT), builder.getServerPort());
     assertSame(builder, builder.setServerPort(0));
     assertEquals(0, builder.getServerPort().intValue());
     assertSame(builder, builder.setServerPort(1));
@@ -342,7 +342,7 @@ public class ServerLauncherTest {
     assertSame(builder, builder.setServerPort(65535));
     assertEquals(65535, builder.getServerPort().intValue());
     assertSame(builder, builder.setServerPort(null));
-    assertEquals(ServerLauncher.DEFAULT_SERVER_PORT, builder.getServerPort());
+    assertEquals(Integer.valueOf(CacheServer.DEFAULT_PORT), builder.getServerPort());
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
GEODE-290: Removed deprecated methods from Launcher classes

* Removed deprecated stopWithPort from LocatorLauncher class.

* Removed deprecated members from LocatorLauncher and ServerLauncher classes.

* Modified test cases to use constants alternate to deprecated ones.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
 Yes. GEODE-290
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?
Modified existing test cases.
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
