### PR TITLE
GEODE-2601: Fixing banner being logged twice during locator startup

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -1782,7 +1782,7 @@ public class InternalDistributedSystem extends DistributedSystem
   @Override
   public Statistics[] getStatistics() {
     List<Statistics> statsList = this.statsList;
-    return (Statistics[]) statsList.toArray(new Statistics[0]);
+    return statsList.toArray(new Statistics[0]);
   }
 
   // StatisticsFactory methods
@@ -1814,7 +1814,7 @@ public class InternalDistributedSystem extends DistributedSystem
   }
 
   public FunctionStats getFunctionStats(String textId) {
-    FunctionStats stats = (FunctionStats) functionExecutionStatsMap.get(textId);
+    FunctionStats stats = functionExecutionStatsMap.get(textId);
     if (stats == null) {
       stats = new FunctionStats(this, textId);
       FunctionStats oldStats = functionExecutionStatsMap.putIfAbsent(textId, stats);
@@ -1855,7 +1855,7 @@ public class InternalDistributedSystem extends DistributedSystem
    */
   public interface StatisticsVisitor {
 
-    public void visit(Statistics stat);
+    void visit(Statistics stat);
   }
 
   public Set<String> getAllFunctionExecutionIds() {
@@ -2152,7 +2152,7 @@ public class InternalDistributedSystem extends DistributedSystem
   private void notifyResourceEventListeners(ResourceEvent event, Object resource) {
     for (Iterator<ResourceEventsListener> iter = resourceListeners.iterator(); iter.hasNext();) {
       try {
-        ResourceEventsListener listener = (ResourceEventsListener) iter.next();
+        ResourceEventsListener listener = iter.next();
         listener.handleEvent(event, resource);
       } catch (CancelException e) {
         // ignore
@@ -2287,7 +2287,7 @@ public class InternalDistributedSystem extends DistributedSystem
               boolean isDurableClient = false;
 
               if (dca != null) {
-                isDurableClient = ((dca.getId() == null || dca.getId().isEmpty()) ? false : true);
+                isDurableClient = (!(dca.getId() == null || dca.getId().isEmpty()));
               }
 
               ((InternalDistributedSystem) ds).disconnect(false,
@@ -2322,7 +2322,7 @@ public class InternalDistributedSystem extends DistributedSystem
      * 
      * @param sys the the system we are disconnecting from process should take before returning.
      */
-    public void onDisconnect(InternalDistributedSystem sys);
+    void onDisconnect(InternalDistributedSystem sys);
 
   }
 
@@ -2337,7 +2337,7 @@ public class InternalDistributedSystem extends DistributedSystem
      * @param oldSystem the old DS, which is in a partially disconnected state and cannot be used
      *        for messaging
      */
-    public void reconnecting(InternalDistributedSystem oldSystem);
+    void reconnecting(InternalDistributedSystem oldSystem);
 
     /**
      * Invoked after a reconnect to the distributed system
@@ -2345,8 +2345,7 @@ public class InternalDistributedSystem extends DistributedSystem
      * @param oldSystem the old DS
      * @param newSystem the new DS
      */
-    public void onReconnect(InternalDistributedSystem oldSystem,
-        InternalDistributedSystem newSystem);
+    void onReconnect(InternalDistributedSystem oldSystem, InternalDistributedSystem newSystem);
   }
 
   /**
@@ -2359,7 +2358,7 @@ public class InternalDistributedSystem extends DistributedSystem
      * 
      * @param sys
      */
-    public void onShutdown(InternalDistributedSystem sys);
+    void onShutdown(InternalDistributedSystem sys);
   }
 
   /**
@@ -2412,10 +2411,7 @@ public class InternalDistributedSystem extends DistributedSystem
       return false;
     }
     boolean newDsConnected = (rds == null || !rds.isConnected());
-    if (!newDsConnected) {
-      return false;
-    }
-    return true;
+    return newDsConnected;
   }
 
 
@@ -2739,7 +2735,7 @@ public class InternalDistributedSystem extends DistributedSystem
         if (newDM instanceof DistributionManager) {
           // Admin systems don't carry a cache, but for others we can now create
           // a cache
-          if (((DistributionManager) newDM).getDMType() != DistributionManager.ADMIN_ONLY_DM_TYPE) {
+          if (newDM.getDMType() != DistributionManager.ADMIN_ONLY_DM_TYPE) {
             try {
               CacheConfig config = new CacheConfig();
               if (cacheXML != null) {
@@ -2947,7 +2943,7 @@ public class InternalDistributedSystem extends DistributedSystem
     /**
      * Invoked after a connection to the distributed system is created
      */
-    public void onConnect(InternalDistributedSystem sys);
+    void onConnect(InternalDistributedSystem sys);
   }
 
   public String forceStop() {
@@ -3049,8 +3045,8 @@ public class InternalDistributedSystem extends DistributedSystem
    * Privacy Violations that Fortify will complain about.
    * </p>
    */
-  public static interface CreationStackGenerator {
+  public interface CreationStackGenerator {
 
-    public Throwable generateCreationStack(final DistributionConfig config);
+    Throwable generateCreationStack(final DistributionConfig config);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -478,9 +478,8 @@ public class InternalLocator extends Locator implements ConnectListener {
     if (logWriter == null) {
       logWriter = LogWriterFactory.createLogWriterLogger(false, false, this.config,
           !startDistributedSystem);
-      if (logger.isDebugEnabled()) {
+      if (logger.isDebugEnabled())
         logger.debug("LogWriter for locator is created.");
-      }
     }
 
     if (securityLogWriter == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterFactory.java
@@ -87,19 +87,19 @@ public class LogWriterFactory {
         // LOG:CONFIG:
         logger.info(LogMarker.CONFIG, Banner.getString(null));
       }
+      System.setProperty(InternalLocator.INHIBIT_DM_BANNER, "true"); // Ensure no more banners will
+                                                                     // be logged
     } else {
       logger.debug("skipping banner - " + InternalLocator.INHIBIT_DM_BANNER + " is set to true");
     }
 
     // log the config
-    if (logConfig) {
-      if (!isLoner) {
-        // LOG:CONFIG: changed from config to info
-        logger.info(LogMarker.CONFIG,
-            LocalizedMessage.create(
-                LocalizedStrings.InternalDistributedSystem_STARTUP_CONFIGURATIONN_0,
-                config.toLoggerString()));
-      }
+    if (logConfig && !isLoner) {
+      // LOG:CONFIG: changed from config to info
+      logger.info(LogMarker.CONFIG,
+          LocalizedMessage.create(
+              LocalizedStrings.InternalDistributedSystem_STARTUP_CONFIGURATIONN_0,
+              config.toLoggerString()));
     }
 
     return logger;


### PR DESCRIPTION
Now only logs once if both locator and distributed systems are started, and still logs once if a locator is started XOR if a distributed system is started.
There appear to be some minor changes in various places, possibly due to spotless checking; the main change is in **line 90 of `LogWriterFactory.java`**. Patrick (@PurelyApplied) also noticed an unnecessary `if` statement in **lines 95 & 96 of `LogWriterFactory.java`**, which has been fixed in this PR.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
