### PR TITLE
GEODE-3070: Fix gemfire.jar to be geode-dependencies.jar

### DIFF
--- a/geode-docs/developing/transactions/JTA_transactions.html.md.erb
+++ b/geode-docs/developing/transactions/JTA_transactions.html.md.erb
@@ -122,8 +122,9 @@ To accomplish this, the application server container must use a JCA Resource Ada
 
 # How to Run JTA Transactions with Geode as a "Last Resource"
 
-1.  Locate the `$GEMFIRE/lib/gemfire-jca.rar` file in your Geode installation. 
-2.  Add your container-specific XML file to the `gemfire-jca.rar` file. 
+1.  Locate the version-specific `geode-jca` RAR file within 
+the `lib` directory of your Geode installation. 
+2.  Add your container-specific XML file to the `geode-jca` RAR file. 
 <ol>
 <li>Create a container-specific resource adapter XML file named &lt;container&gt;-ra.xml. For example, an XML file for a WebLogic resource adapter XML file might look something like this:
 
@@ -144,17 +145,21 @@ To accomplish this, the application server container must use a JCA Resource Ada
     META-INF/weblogic-ra.xml
     ```
 </li>
-<li>Navigate to the directory above the `META-INF` folder and execute the following command:
+<li>Navigate to the directory above the `META-INF` folder and execute the following command, with appropriate substitutions for 
+path and file names:
 
     ``` pre
-    $ jar -uf <GEMFIRE_INSTALL_DIR>/lib/gemfire-jca.rar META-INF/weblogic-ra.xml
+    $ jar -uf /path/to/lib/geode-jca-X-X-X.rar META-INF/weblogic-ra.xml
     ```
 </li>
 </ol>
-3.  Make sure that `$GEMFIRE/lib/gemfire.jar` is accessible in the CLASSPATH of the JTA transaction coordinator container.
-4.  Deploy `gemfire-jca.rar` file on the JTA transaction coordinator container . When deploying the file, you specify the JNDI name and so on. 
+3.  Make sure that the `geode-dependencies.jar` is accessible in 
+the CLASSPATH of the JTA transaction coordinator container.
+4.  Deploy the version-specific `geode-jca` RAR file on 
+the JTA transaction coordinator container.
+When deploying the file, you specify the JNDI name and so on. 
 5.  Configure Geode for any necessary transactional behavior. Enable `copy-on-read` and specify a transaction listener, if you need one. See [Setting Global Copy on Read](working_with_transactions.html#concept_vx2_gs4_5k) and [Configuring Transaction Plug-In Event Handlers](working_with_transactions.html#concept_ocw_vf1_wk) for details.
-6.  Get an initial context through `com.gemstone.cache.Cache.getJNDIContext`. For example:
+6.  Get an initial context through `org.apache.geode.cache.GemFireCache.getJNDIContext`. For example:
 
     ``` pre
     Context ctx = cache.getJNDIContext();
@@ -215,7 +220,7 @@ To run a global transaction, perform the following steps:
 3.  Configure Geode for any necessary transactional behavior. Enable `copy-on-read` for your cache and specify a transaction listener, if you need one. See [Setting Global Copy on Read](working_with_transactions.html#concept_vx2_gs4_5k) and [Configuring Transaction Plug-In Event Handlers](working_with_transactions.html#concept_ocw_vf1_wk) for details. 
 4.  Make sure that JTA transactions are not disabled in the `cache.xml` file or the application code. 
 5.  Initialize the Geode cache. 
-6.  Get an initial context through `org.apache.geode.cache.Cache.getJNDIContext`. For example: 
+6.  Get an initial context through `org.apache.geode.cache.GemFireCache.getJNDIContext`. For example: 
 
     ``` pre
     Context ctx = cache.getJNDIContext();

--- a/geode-docs/tools_modules/gfsh/tour_of_gfsh.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/tour_of_gfsh.html.md.erb
@@ -55,18 +55,23 @@ The following output appears:
 
 ``` pre
 gfsh>start locator --name=locator1
-Starting a GemFire Locator in /home/username/gfsh_tutorial/locator1...
-.................................
-Locator in /home/username/gfsh_tutorial/locator1 on ubuntu.local[10334] as locator1 is currently online.
-Process ID: 5610
-Uptime: 18 seconds
-GemFire Version: 8.1.0
-Java Version: 1.7.0_72
-Log File: /home/username/gfsh_tutorial/locator1/locator1.log
-JVM Arguments: -Dgemfire.enable-cluster-configuration=true -Dgemfire.load-cluster-configuration-from-dir=false -Dgemfire.launcher.registerSignalHandlers=true -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
-Class-Path: /home/username/Pivotal_GemFire_810_b50582_Linux/lib/gemfire.jar:/home/username/Pivotal_GemFire_810_b50582_Linux/lib/locator-dependencies.jar
+.....
+Locator in /home/username/gfsh_tutorial/locator1 on 192.0.2.0[10334]
+as locator1 is currently online.
+Process ID: 67666
+Uptime: 6 seconds
+Geode Version: 1.2.0
+Java Version: 1.8.0_92
+Log File: /home/username/gfsh_tutorial/locator1.log
+JVM Arguments: -Dgemfire.enable-cluster-configuration=true
+ -Dgemfire.load-cluster-configuration-from-dir=false
+ -Dgemfire.launcher.registerSignalHandlers=true
+ -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
+Class-Path: /home/username/geode/geode-assembly/build/install/apache-geode/lib
+/geode-core-1.2.0.jar:/home/username/geode/geode-assembly/build/install/apache-geode
+/lib/geode-dependencies.jar
 
-Successfully connected to: [host=ubuntu.local, port=1099]
+Successfully connected to: JMX Manager [host=192.0.2.0, port=1099]
 
 Cluster configuration service is up and running.
 ```
@@ -171,16 +176,23 @@ If the server starts successfully, the following output appears:
 
 ``` pre
 gfsh>start server --name=server1 --locators=localhost[10334]
-Starting a GemFire Server in /home/username/gfsh_tutorial/server1...
-.............
-Server in /home/username/gfsh_tutorial/server1 on ubuntu.local[40404] as server1 is currently online.
-Process ID: 5931
-Uptime: 7 seconds
-GemFire Version: 8.1.0
-Java Version: 1.7.0_72
-Log File: /home/username/gfsh_tutorial/server1/server1.log
-JVM Arguments: -Dgemfire.locators=localhost[10334] -Dgemfire.use-cluster-configuration=true -XX:OnOutOfMemoryError=kill -KILL %p -Dgemfire.launcher.registerSignalHandlers=true -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
-Class-Path: /home/username/Pivotal_GemFire_810_b50582_Linux/lib/gemfire.jar:/home/username/Pivotal_GemFire_810_b50582_Linux/lib/server-dependencies.jar
+Starting a Geode Server in /home/username/gfsh_tutorial/server1/server1.log...
+...
+Server in /home/username/gfsh_tutorial/server1 on 192.0.2.0[40404] as server1
+is currently online.
+Process ID: 68375
+Uptime: 4 seconds
+Geode Version: 1.2.0
+Java Version: 1.8.0_92
+Log File: /home/username//gfsh_tutorial/server1/server1.log
+JVM Arguments: -Dgemfire.locators=localhost[10334]
+ -Dgemfire.use-cluster-configuration=true -Dgemfire.start-dev-rest-api=false
+ -XX:OnOutOfMemoryError=kill -KILL %p
+ -Dgemfire.launcher.registerSignalHandlers=true
+ -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
+Class-Path: /home/username/geode/geode-assembly/build/install/apache-geode/lib
+/geode-core-1.2.0.jar:/home/username/geode/geode-assembly/build/install
+/apache-geode/lib/geode-dependencies.jar
 ```
 
 If you run `start server` from gfsh without specifying the member name, gfsh will automatically pick a random member name. This is useful for automation.
@@ -279,16 +291,22 @@ Because only one server is in the distributed system at the moment, the command 
 
 ``` pre
 gfsh>start server --name=server2 --server-port=40405
-Starting a GemFire Server in /home/username/gfsh_tutorial/server2...
-................
-Server in /home/username/gfsh_tutorial/server2 on ubuntu.local[40405] as server2 is currently online.
-Process ID: 6092
-Uptime: 8 seconds
-GemFire Version: 8.1.0
-Java Version: 1.7.0_72
+Starting a Geode Server in /home/username/gfsh_tutorial/server2...
+...
+Server in /home/username/gfsh_tutorial/server2 on 192.0.2.0[40405] as
+server2 is currently online.
+Process ID: 68423
+Uptime: 4 seconds
+Geode Version: 1.2.0
+Java Version: 1.8.0_92
 Log File: /home/username/gfsh_tutorial/server2/server2.log
-JVM Arguments: -Dgemfire.default.locators=192.0.2.0[10334] -Dgemfire.use-cluster-configuration=true -XX:OnOutOfMemoryError=kill -KILL %p -Dgemfire.launcher.registerSignalHandlers=true -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
-Class-Path: /home/username/Pivotal_GemFire_810_b50582_Linux/lib/gemfire.jar:/home/username/Pivotal_GemFire_810_b50582_Linux/lib/server-dependencies.jar
+JVM Arguments: -Dgemfire.default.locators=192.0.2.0[10334]
+ -Dgemfire.use-cluster-configuration=true -Dgemfire.start-dev-rest-api=false
+ -XX:OnOutOfMemoryError=kill -KILL %p -Dgemfire.launcher.registerSignalHandlers=true
+ -Djava.awt.headless=true -Dsun.rmi.dgc.server.gcInterval=9223372036854775806
+Class-Path: /home/username/geode/geode-assembly/build/install/apache-geode
+/lib/geode-core-1.2.0.jar:/home/username/geode/geode-assembly/build/install
+/apache-geode/lib/geode-dependencies.jar
 ```
 
 **Step 11: Create a replicated region.**
@@ -466,3 +484,9 @@ gfsh>export data --region=region1 --file=region1.gfd --member=server1
 ```
 
 You can later use the `import data` command to import that data into the same region on another member.
+
+**Step 20: Shutdown the cluster.**
+
+``` pre
+gfsh>shutdown --include-locators=true
+```


### PR DESCRIPTION
Updated a few other errors found along the way, including
the name of the RAR file for JTA transactions, and outdated
output of sample gfsh commands in the gfsh tutorial.  Also
added a final step that shuts down the cluster in the tutorial.

@dschneider-pivotal @sbawaska @davebarnes97 @joeymcallister and all of the Geode community, please review.
