### PR TITLE
GEODE-2301 Doc note to deprecate Geode JTA trans mgr

### DIFF
--- a/geode-docs/developing/transactions/JTA_transactions.html.md.erb
+++ b/geode-docs/developing/transactions/JTA_transactions.html.md.erb
@@ -190,6 +190,7 @@ See [JCA Resource Adapter Example](jca_adapter_example.html#concept_swv_z2p_wk) 
 ## <a id="concept_8567sdkbigige" class="no-quick-link"></a>Using Geode as the JTA Transaction Manager
 
 You can also use Geode as the JTA transaction manager.
+As of Geode 1.2, Geode's JTA transaction manager is deprecated.
 
 Geode ships with its own implementation of a JTA transaction manager. However, note that this implementation is not XA-compliant; therefore, it does not persist any state, which could lead to an inconsistent state after recovering a crashed member.
 


### PR DESCRIPTION
Simple addition to the beginning of the documentation of the Geode JTA transaction manager that the Geode JTA transaction manager is deprecated for 1.2.

