### PR TITLE
GEODE-2820: Added awaitlity clause to wait for the region size to be …

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.test.dunit.Invoke.*;
 import static org.apache.geode.test.dunit.LogWriterUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URL;
@@ -28,8 +29,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -474,10 +477,9 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
   /**
    * Creates async indexes and compares the results between index and non-index results.
    * <p>
-   * DISABLED. This test is disabled due to a high rate of throw new AssertionError. See ticket
-   * #52167
+   * TEST RE-ENABLED : Tweaks made so that the test does not throw Assertion failures
+   *
    */
-  @Ignore("TODO: test is disabled because of #52167")
   @Test
   public void testCreateAsyncIndexWhileDoingGIIAndCompareQueryResults() throws Exception {
     Host host = Host.getHost(0);
@@ -510,9 +512,32 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
     vm1.invoke(prIndexCreationCheck(PERSISTENT_REG_NAME, "secIndex", 50));
     vm1.invoke(indexCreationCheck(REP_REG_NAME, "secIndex"));
 
+    vm0.invoke(() -> validateIndexSize());
+    vm1.invoke(() -> validateIndexSize());
+
+
     // Execute query and verify index usage
     vm0.invoke(executeQueryAndCompareResult(false));
     vm1.invoke(executeQueryAndCompareResult(false));
+  }
+
+  public void validateIndexSize() {
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(() -> {
+      boolean indexSizeCheck_NAME = validateIndexSizeForRegion(NAME);
+      boolean indexSizeCheck_REP_REG_NAME = validateIndexSizeForRegion(REP_REG_NAME);
+      boolean indexSizeCheck_PERSISTENT_REG_NAME = validateIndexSizeForRegion(PERSISTENT_REG_NAME);
+      assertEquals("Index does not contain all the entries after 60 seconds have elapsed ", true,
+          (indexSizeCheck_NAME && indexSizeCheck_REP_REG_NAME
+              && indexSizeCheck_PERSISTENT_REG_NAME));
+    });
+  }
+
+  private boolean validateIndexSizeForRegion(final String regionName) {
+    Region region = getCache().getRegion(regionName);
+    QueryService queryService = getCache().getQueryService();
+    return queryService.getIndex(region, "statusIndex").getStatistics().getNumberOfValues() == 500
+        && queryService.getIndex(region, "idIndex").getStatistics().getNumberOfValues() == 500
+        && queryService.getIndex(region, "statusIndex").getStatistics().getNumberOfValues() == 500;
   }
 
   @Test


### PR DESCRIPTION
…correct

	* Added awaitility clause to wait for all the regions to have all the entries
	* This is done to make sure that the queries are executed.
	* This may not solve the issue of queries being executed before async index is updated
	* However this shortens the window of failure happening.


Potential reviewers
@jhuynh1 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
