### PR TITLE
GEODE-3073: Renamed OrderByComparatorUnmapped to OrderByComparatorMapped

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/OrderByComparatorMapped.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/OrderByComparatorMapped.java
@@ -15,7 +15,6 @@
 package org.apache.geode.cache.query.internal;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,11 +28,11 @@ import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.query.types.ObjectType;
 import org.apache.geode.pdx.internal.PdxString;
 
-public class OrderByComparatorUnmapped extends OrderByComparator {
+public class OrderByComparatorMapped extends OrderByComparator {
 
   private final Map<Object, Object[]> orderByMap;
 
-  public OrderByComparatorUnmapped(List<CompiledSortCriterion> orderByAttrs, ObjectType objType,
+  public OrderByComparatorMapped(List<CompiledSortCriterion> orderByAttrs, ObjectType objType,
       ExecutionContext context) {
     super(orderByAttrs, objType, context);
     if (objType.isStructType()) {
@@ -42,14 +41,12 @@ public class OrderByComparatorUnmapped extends OrderByComparator {
     } else {
       this.orderByMap = new HashMap<Object, Object[]>();
     }
-
   }
 
   @Override
   void addEvaluatedSortCriteria(Object row, ExecutionContext context)
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException {
-
     this.orderByMap.put(row, this.calculateSortCriteria(context, row));
   }
 
@@ -58,30 +55,26 @@ public class OrderByComparatorUnmapped extends OrderByComparator {
     int result = -1;
     Object[] list1 = this.evaluateSortCriteria(obj1);
     Object[] list2 = this.evaluateSortCriteria(obj2);
-
     if (list1.length != list2.length) {
       Support.assertionFailed("Error Occurred due to improper sort criteria evaluation ");
     } else {
       for (int i = 0; i < list1.length; i++) {
         Object arr1[] = (Object[]) list1[i];
         Object arr2[] = (Object[]) list2[i];
-        // check for null.
-        if (arr1[0] == null || arr2[0] == null) {
-          if (arr1[0] == null) {
-            result = (arr2[0] == null ? 0 : -1);
-          } else {
-            result = 1;
-          }
-        } else if (arr1[0] == QueryService.UNDEFINED || arr2[0] == QueryService.UNDEFINED) {
-          if (arr1[0] == QueryService.UNDEFINED) {
-            result = (arr2[0] == QueryService.UNDEFINED ? 0 : -1);
-          } else {
-            result = 1;
-          }
+
+        if (arr1[0] == null) {
+          result = (arr2[0] == null ? 0 : -1);
+        } else if (arr2[0] == null) {
+          result = 1;
+        } else if (arr1[0] == QueryService.UNDEFINED) {
+          result = (arr2[0] == QueryService.UNDEFINED ? 0 : -1);
+        } else if (arr2[0] == QueryService.UNDEFINED) {
+          result = 1;
         } else {
           if (arr1[0] instanceof Number && arr2[0] instanceof Number) {
-            double diff = ((Number) arr1[0]).doubleValue() - ((Number) arr2[0]).doubleValue();
-            result = diff > 0 ? 1 : diff < 0 ? -1 : 0;
+            Number num1 = (Number) arr1[0];
+            Number num2 = (Number) arr2[0];
+            result = Double.compare(num1.doubleValue(), num2.doubleValue());
           } else {
             if (arr1[0] instanceof PdxString && arr2[0] instanceof String) {
               arr2[0] = new PdxString((String) arr2[0]);
@@ -90,17 +83,13 @@ public class OrderByComparatorUnmapped extends OrderByComparator {
             }
             result = ((Comparable) arr1[0]).compareTo(arr2[0]);
           }
-
         }
 
-        // equals.
-        if (result == 0) {
-          continue;
-        } else {
+        if (result != 0) {
           // not equal, change the sign based on the order by type (asc,
-          // desc).
+          // desc)
           if (((Boolean) arr1[1]).booleanValue()) {
-            result = (result * -1);
+            result *= -1;
           }
           break;
         }
@@ -109,39 +98,29 @@ public class OrderByComparatorUnmapped extends OrderByComparator {
     return result;
   }
 
-
-
   @Override
   protected Object[] evaluateSortCriteria(Object row) {
     return orderByMap.get(row);
   }
 
-
   private Object[] calculateSortCriteria(ExecutionContext context, Object row)
-
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException {
-
-    CompiledSortCriterion csc;
     if (orderByAttrs != null) {
       Object[] evaluatedResult = new Object[this.orderByAttrs.size()];
-
-      Iterator<CompiledSortCriterion> orderiter = orderByAttrs.iterator();
       int index = 0;
-      while (orderiter.hasNext()) {
-        csc = orderiter.next();
+      for (CompiledSortCriterion csc : orderByAttrs) {
         Object[] arr = new Object[2];
         if (csc.getColumnIndex() == -1) {
           arr[0] = csc.evaluate(context);
         } else {
           arr[0] = csc.evaluate(row, context);
         }
-        arr[1] = Boolean.valueOf(csc.getCriterion());
+        arr[1] = csc.getCriterion();
         evaluatedResult[index++] = arr;
       }
       return evaluatedResult;
     }
     return null;
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/OrderByComparatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/OrderByComparatorJUnitTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -81,7 +80,8 @@ public class OrderByComparatorJUnitTest {
         Collection base = (Collection) baseField.get(rcw);
         assertTrue(base instanceof SortedStructSet);
         SortedStructSet sss = (SortedStructSet) base;
-        assertTrue(sss.comparator() instanceof OrderByComparatorUnmapped);
+        assertTrue(sss.comparator() instanceof OrderByComparatorMapped);
+
       } catch (Exception e) {
         e.printStackTrace();
         fail(q.getQueryString());
@@ -118,7 +118,7 @@ public class OrderByComparatorJUnitTest {
         Collection base = (Collection) baseField.get(rcw);
         assertTrue(base instanceof SortedStructSet);
         SortedStructSet sss = (SortedStructSet) base;
-        assertFalse(sss.comparator() instanceof OrderByComparatorUnmapped);
+        assertFalse(sss.comparator() instanceof OrderByComparatorMapped);
         assertTrue(sss.comparator() instanceof OrderByComparator);
       } catch (Exception e) {
         e.printStackTrace();

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedSerializables.txt
@@ -152,6 +152,7 @@ org/apache/geode/cache/query/QueryInvalidException,true,2849255122285215114
 org/apache/geode/cache/query/QueryInvocationTargetException,true,2978208305701582906
 org/apache/geode/cache/query/RegionNotFoundException,true,592495934010222373
 org/apache/geode/cache/query/TypeMismatchException,true,4205901708655503775
+org/apache/geode/cache/query/internal/CompiledSelect$DataContainerType,false,isDistinct:boolean,isIgnoreOrderBy:boolean,isOrdered:boolean,isStructType:boolean
 org/apache/geode/cache/query/internal/CompiledSelect$NullIteratorException,false
 org/apache/geode/cache/query/internal/CompiledSortCriterion$1,false,this$0:org/apache/geode/cache/query/internal/CompiledSortCriterion
 org/apache/geode/cache/query/internal/ObjectIntHashMap,true,7718697444988416372,hashingStrategy:org/apache/geode/cache/query/internal/HashingStrategy,loadFactor:float,threshold:int
@@ -447,7 +448,6 @@ org/apache/geode/internal/process/PidUnavailableException,true,-1660269538268828
 org/apache/geode/internal/process/signal/Signal,false,description:java/lang/String,name:java/lang/String,number:int,type:org/apache/geode/internal/process/signal/SignalType
 org/apache/geode/internal/process/signal/SignalEvent,false,signal:org/apache/geode/internal/process/signal/Signal
 org/apache/geode/internal/process/signal/SignalType,false,description:java/lang/String
-org/apache/geode/internal/security/SecurityServiceType,false
 org/apache/geode/internal/sequencelog/GraphType,false
 org/apache/geode/internal/sequencelog/model/GraphID,false,graphName:java/lang/String,type:org/apache/geode/internal/sequencelog/GraphType
 org/apache/geode/internal/size/ReflectionObjectSizer,false


### PR DESCRIPTION
[View the JIRA ticket here.](https://issues.apache.org/jira/browse/GEODE-3073)

`OrderByComparatorUnmapped.java` actually uses mapping, which is why it should really be called `OrderByComparatorMapped.java`. Some refactoring was also done (similar to the refactoring done in [pull request #580](https://github.com/apache/geode/pull/580), although to a lesser extent).

**_Precheckin status: completed successfully_**

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
