### PR TITLE
GEODE-3172: Fix serialization errors with client queues from between 1.0 and 1.2

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -18,6 +18,8 @@ import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.internal.ByteArrayDataInput;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.offheap.annotations.Retained;
 
@@ -54,9 +56,9 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
   }
 
   @Override
-  public boolean fillInValue(LocalRegion r, InitialImageOperation.Entry entry,
-      ByteArrayDataInput in, DM mgr) {
-    return Helper.fillInValue(this, entry, r.getDiskRegion(), mgr, in, r);
+  public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
+      final Version version) {
+    return Helper.fillInValue(this, entry, r.getDiskRegion(), mgr, in, r, version);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionEntry.java
@@ -19,6 +19,7 @@ import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.*;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
@@ -326,8 +327,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
 
   @Override
   public boolean fillInValue(LocalRegion region,
-      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) InitialImageOperation.Entry entry,
-      ByteArrayDataInput in, DM mgr) {
+      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in, DM mgr,
+      final Version version) {
 
     // starting default value
     entry.setSerialized(false);
@@ -362,7 +363,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
           entry.value = tmp;
         } else {
           try {
-            HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+            HeapDataOutputStream hdos = new HeapDataOutputStream(version);
             BlobHelper.serializeTo(tmp, hdos);
             hdos.trim();
             entry.value = hdos;
@@ -386,7 +387,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
         }
       }
       try {
-        HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+        HeapDataOutputStream hdos = new HeapDataOutputStream(version);
         BlobHelper.serializeTo(preparedValue, hdos);
         hdos.trim();
         entry.value = hdos;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskEntry.java
@@ -276,7 +276,7 @@ public interface DiskEntry extends RegionEntry {
      * @since GemFire 3.2.1
      */
     static boolean fillInValue(DiskEntry de, InitialImageOperation.Entry entry, DiskRegion dr,
-        DM mgr, ByteArrayDataInput in, RegionEntryContext context) {
+        DM mgr, ByteArrayDataInput in, RegionEntryContext context, Version version) {
       @Retained
       @Released
       Object v = null;
@@ -310,7 +310,7 @@ public interface DiskEntry extends RegionEntry {
               }
               assert did != null;
               // do recursive call to get readLock on did
-              return fillInValue(de, entry, dr, mgr, in, context);
+              return fillInValue(de, entry, dr, mgr, in, context, version);
             }
             if (logger.isDebugEnabled()) {
               logger.debug(
@@ -360,7 +360,7 @@ public interface DiskEntry extends RegionEntry {
               entry.setSerialized(true);
             } else {
               try {
-                HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+                HeapDataOutputStream hdos = new HeapDataOutputStream(version);
                 BlobHelper.serializeTo(tmp, hdos);
                 hdos.trim();
                 entry.value = hdos;
@@ -401,7 +401,7 @@ public interface DiskEntry extends RegionEntry {
         }
         {
           try {
-            HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+            HeapDataOutputStream hdos = new HeapDataOutputStream(version);
             BlobHelper.serializeTo(preparedValue, hdos);
             hdos.trim();
             entry.value = hdos;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -1910,7 +1910,8 @@ public class InitialImageOperation {
                     entry = new InitialImageOperation.Entry();
                     entry.key = key;
                     entry.setVersionTag(stamp.asVersionTag());
-                    fillRes = mapEntry.fillInValue(rgn, entry, in, rgn.getDistributionManager());
+                    fillRes = mapEntry.fillInValue(rgn, entry, in, rgn.getDistributionManager(),
+                        sender.getVersionObject());
                     if (versionVector != null) {
                       if (logger.isTraceEnabled(LogMarker.GII)) {
                         logger.trace(LogMarker.GII, "chunkEntries:entry={},stamp={}", entry, stamp);
@@ -1920,7 +1921,8 @@ public class InitialImageOperation {
                 } else {
                   entry = new InitialImageOperation.Entry();
                   entry.key = key;
-                  fillRes = mapEntry.fillInValue(rgn, entry, in, rgn.getDistributionManager());
+                  fillRes = mapEntry.fillInValue(rgn, entry, in, rgn.getDistributionManager(),
+                      sender.getVersionObject());
                 }
               } catch (DiskAccessException dae) {
                 rgn.handleDiskAccessException(dae);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
@@ -30,6 +30,8 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.ByteArrayDataInput;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -184,8 +186,8 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return false;
   }
 
-  public boolean fillInValue(LocalRegion r, InitialImageOperation.Entry entry,
-      ByteArrayDataInput in, DM mgr) {
+  public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
+      final Version version) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -7126,9 +7126,8 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public boolean fillInValue(LocalRegion r,
-        org.apache.geode.internal.cache.InitialImageOperation.Entry entry, ByteArrayDataInput in,
-        DM mgr) {
+    public boolean fillInValue(LocalRegion r, InitialImageOperation.Entry entry,
+        ByteArrayDataInput in, DM mgr, final Version version) {
       // TODO Auto-generated method stub
       return false;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
@@ -32,7 +32,9 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.ByteArrayDataInput;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.AbstractRegionMap.ARMLockTestHook;
+import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.geode.internal.cache.lru.LRUEntry;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.persistence.DiskRegionView;
@@ -485,8 +487,8 @@ class ProxyRegionMap implements RegionMap {
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean fillInValue(LocalRegion r, InitialImageOperation.Entry entry,
-        ByteArrayDataInput in, DM mgr) {
+    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
+        final Version version) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
@@ -25,6 +25,8 @@ import org.apache.geode.cache.TimeoutException;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.internal.ByteArrayDataInput;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -179,8 +181,8 @@ public interface RegionEntry {
    * @since GemFire 3.2.1
    */
   public boolean fillInValue(LocalRegion r,
-      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) InitialImageOperation.Entry entry,
-      ByteArrayDataInput in, DM mgr);
+      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in, DM mgr,
+      final Version version);
 
   /**
    * Returns true if this entry has overflowed to disk.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
@@ -27,6 +27,7 @@ import org.apache.geode.cache.TimeoutException;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.internal.ByteArrayDataInput;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.DistributedRegion.DiskPosition;
 import org.apache.geode.internal.cache.InitialImageOperation.Entry;
 import org.apache.geode.internal.cache.lru.EnableLRU;
@@ -339,7 +340,8 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr) {
+    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
+        final Version version) {
       // TODO Auto-generated method stub
       return false;
     }

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -19,5 +19,6 @@ dependencies {
   provided project(':geode-core')
 
   testCompile files(project(':geode-core').sourceSets.test.output)
+  testCompile project(':geode-old-versions')
   testCompile project(':geode-junit')
 }


### PR DESCRIPTION
Adding new tests and fixing errors when copying a client queue from a 1.0 member to a 1.2 member, or from a 1.2 member to a 1.0 member.

We were not respecting the version of the 1.0 member when deserializing or serializing the HAEventWrapper class, which is stored as a value in a geode region.

This will affect *all* GII's between different versions, because I had to change the GII code to serialize values using the version of the GII recipient.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
