### PR TITLE
GEODE-1731: Modifying region size check to be more accurate

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
@@ -631,13 +631,15 @@ public class ConcurrentParallelGatewaySenderDUnitTest extends WANTestBase {
 
     AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
 
+    int prevRegionSize = vm2.invoke(() -> WANTestBase.getRegionSize(getTestMethodName() + "_PR"));
+
     AsyncInvocation inv3 =
         vm6.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10000));
 
     vm2.invoke(() -> Awaitility.await().atMost(30000, TimeUnit.MILLISECONDS)
         .until(() -> assertEquals(
-            "Failure in waiting for additional 10 events to be received by the receiver ", true,
-            getRegionSize(getTestMethodName() + "_PR") > 5010)));
+            "Failure in waiting for additional 20 events to be received by the receiver ", true,
+            getRegionSize(getTestMethodName() + "_PR") > 20 + prevRegionSize)));
 
     AsyncInvocation inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
 


### PR DESCRIPTION
Changed the hardcoded 5010 region size check to the size of the region already plus 20 new elements. The 20 new elements is due to the fact that a synchronous call to get the region size of vm2 had to be used, so there should be more time for elements to be put.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
