### PR TITLE
GEODE-3051: Remove unreachable exception handling in AcceptorImpl.accept

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1280,19 +1280,6 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
           }
         }
       } catch (IOException e) {
-        if (isRunning()) {
-          if (e instanceof SSLException) {
-            try {
-              // Try to send a proper rejection message
-              ServerHandShakeProcessor.refuse(s.getOutputStream(), e.toString(),
-                  HandShake.REPLY_EXCEPTION_AUTHENTICATION_FAILED);
-            } catch (IOException ex) {
-              if (logger.isDebugEnabled()) {
-                logger.debug("Bridge server: Unable to write SSL error");
-              }
-            }
-          }
-        }
         closeSocket(s);
         if (isRunning()) {
           if (!this.loggedAcceptError) {


### PR DESCRIPTION
This removes handling of SSL exceptions from the AccepterImpl.accept call, as the SSL handling code is now all done in another thread.
The exception handling being done in the other thread appears to be correct, as validated by CacheServerSSLConnectionDUnitTest.testNonSSLClient

Signed-off-by: Brian Rowe <browe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
