### PR TITLE
GEODE-3203: fixing protobuf build.gradle to respect buildRoot

### DIFF
--- a/geode-protobuf/build.gradle
+++ b/geode-protobuf/build.gradle
@@ -50,7 +50,7 @@ protobuf {
 sourceSets {
     main {
         java {
-            srcDir 'build/generated-src/proto/main/java'
+            srcDir "$buildDir/generated-src/proto/main/java"
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Bruce Schuchardt <bschuchardt@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
