### PR TITLE
GetServersResponse number of servers was redundant.

### DIFF
--- a/geode-protobuf/src/main/proto/server_API.proto
+++ b/geode-protobuf/src/main/proto/server_API.proto
@@ -32,6 +32,5 @@ message GetServersRequest {
 }
 
 message GetServersResponse {
-    int32 numberOfServers = 1;
-    repeated Server servers = 2;
+    repeated Server servers = 1;
 }


### PR DESCRIPTION
@kohlmu-pivotal @bschuchardt @hiteshk25 @WireBaron @pivotal-amurmann 

I think that the number was redundant. What do y'all think? Did we miss some use for it?

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [no. Sorry.] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
