### PR TITLE
GEODE-3192,GEODE-3229: Change API and implementation of protobuf PutAll.

### DIFF
--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Failure.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Failure.java
@@ -17,19 +17,19 @@ package org.apache.geode.protocol.protobuf;
 import java.util.function.Function;
 
 public class Failure<SuccessType> implements Result<SuccessType> {
-  private final ClientProtocol.ErrorResponse errorResponse;
+  private final BasicTypes.ErrorResponse errorResponse;
 
-  public Failure(ClientProtocol.ErrorResponse errorResponse) {
+  public Failure(BasicTypes.ErrorResponse errorResponse) {
     this.errorResponse = errorResponse;
   }
 
-  public static <T> Failure<T> of(ClientProtocol.ErrorResponse errorResponse) {
+  public static <T> Failure<T> of(BasicTypes.ErrorResponse errorResponse) {
     return new Failure<>(errorResponse);
   }
 
   @Override
   public <T> T map(Function<SuccessType, T> successFunction,
-      Function<ClientProtocol.ErrorResponse, T> errorFunction) {
+      Function<BasicTypes.ErrorResponse, T> errorFunction) {
     return errorFunction.apply(errorResponse);
   }
 
@@ -39,7 +39,7 @@ public class Failure<SuccessType> implements Result<SuccessType> {
   }
 
   @Override
-  public ClientProtocol.ErrorResponse getErrorMessage() {
+  public BasicTypes.ErrorResponse getErrorMessage() {
     return errorResponse;
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/OperationContext.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/OperationContext.java
@@ -15,15 +15,15 @@
 
 package org.apache.geode.protocol.protobuf;
 
-import java.util.function.Function;
-
 import org.apache.geode.protocol.operations.OperationHandler;
+
+import java.util.function.Function;
 
 public class OperationContext<OperationRequest, OperationResponse> {
   private final OperationHandler<OperationRequest, OperationResponse> operationHandler;
   private final Function<ClientProtocol.Request, OperationRequest> fromRequest;
   private final Function<OperationResponse, ClientProtocol.Response.Builder> toResponse;
-  private final Function<ClientProtocol.ErrorResponse, ClientProtocol.Response.Builder> toErrorResponse;
+  private final Function<BasicTypes.ErrorResponse, ClientProtocol.Response.Builder> toErrorResponse;
 
   public OperationContext(Function<ClientProtocol.Request, OperationRequest> fromRequest,
       OperationHandler<OperationRequest, OperationResponse> operationHandler,
@@ -35,7 +35,7 @@ public class OperationContext<OperationRequest, OperationResponse> {
   }
 
   public static ClientProtocol.Response.Builder makeErrorBuilder(
-      ClientProtocol.ErrorResponse errorResponse) {
+      BasicTypes.ErrorResponse errorResponse) {
     return ClientProtocol.Response.newBuilder().setErrorResponse(errorResponse);
   }
 
@@ -51,7 +51,7 @@ public class OperationContext<OperationRequest, OperationResponse> {
     return toResponse;
   }
 
-  public Function<ClientProtocol.ErrorResponse, ClientProtocol.Response.Builder> getToErrorResponse() {
+  public Function<BasicTypes.ErrorResponse, ClientProtocol.Response.Builder> getToErrorResponse() {
     return toErrorResponse;
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Result.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Result.java
@@ -18,9 +18,9 @@ import java.util.function.Function;
 
 public interface Result<SuccessType> {
   <T> T map(Function<SuccessType, T> successFunction,
-      Function<ClientProtocol.ErrorResponse, T> errorFunction);
+      Function<BasicTypes.ErrorResponse, T> errorFunction);
 
   SuccessType getMessage();
 
-  ClientProtocol.ErrorResponse getErrorMessage();
+  BasicTypes.ErrorResponse getErrorMessage();
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Success.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/Success.java
@@ -29,7 +29,7 @@ public class Success<SuccessType> implements Result<SuccessType> {
 
   @Override
   public <T> T map(Function<SuccessType, T> successFunction,
-      Function<ClientProtocol.ErrorResponse, T> errorFunction) {
+      Function<BasicTypes.ErrorResponse, T> errorFunction) {
     return successFunction.apply(successResponse);
   }
 
@@ -39,7 +39,7 @@ public class Success<SuccessType> implements Result<SuccessType> {
   }
 
   @Override
-  public ClientProtocol.ErrorResponse getErrorMessage() {
+  public BasicTypes.ErrorResponse getErrorMessage() {
     throw new RuntimeException("This is a not Failure result");
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetAllRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetAllRequestOperationHandler.java
@@ -14,15 +14,10 @@
  */
 package org.apache.geode.protocol.protobuf.operations;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.operations.OperationHandler;
 import org.apache.geode.protocol.protobuf.BasicTypes;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
 import org.apache.geode.protocol.protobuf.Failure;
 import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.geode.protocol.protobuf.Result;
@@ -31,6 +26,10 @@ import org.apache.geode.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.serialization.SerializationService;
 import org.apache.geode.serialization.exception.UnsupportedEncodingTypeException;
 import org.apache.geode.serialization.registry.exception.CodecNotRegisteredForTypeException;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class GetAllRequestOperationHandler
     implements OperationHandler<RegionAPI.GetAllRequest, RegionAPI.GetAllResponse> {
@@ -42,7 +41,7 @@ public class GetAllRequestOperationHandler
     Region region = cache.getRegion(regionName);
     if (region == null) {
       return Failure
-          .of(ClientProtocol.ErrorResponse.newBuilder().setMessage("Region not found").build());
+          .of(BasicTypes.ErrorResponse.newBuilder().setMessage("Region not found").build());
     }
 
     try {
@@ -58,10 +57,10 @@ public class GetAllRequestOperationHandler
       }
       return Success.of(RegionAPI.GetAllResponse.newBuilder().addAllEntries(entries).build());
     } catch (UnsupportedEncodingTypeException ex) {
-      return Failure.of(
-          ClientProtocol.ErrorResponse.newBuilder().setMessage("Encoding not supported.").build());
+      return Failure
+          .of(BasicTypes.ErrorResponse.newBuilder().setMessage("Encoding not supported.").build());
     } catch (CodecNotRegisteredForTypeException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder()
           .setMessage("Codec error in protobuf deserialization.").build());
     }
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetRegionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetRegionRequestOperationHandler.java
@@ -18,7 +18,6 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.operations.OperationHandler;
 import org.apache.geode.protocol.protobuf.BasicTypes;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
 import org.apache.geode.protocol.protobuf.Failure;
 import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.geode.protocol.protobuf.Result;
@@ -37,7 +36,7 @@ public class GetRegionRequestOperationHandler
 
     Region region = cache.getRegion(regionName);
     if (region == null) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder()
           .setMessage("No region exists for name: " + regionName).build());
     }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/GetRequestOperationHandler.java
@@ -18,7 +18,6 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.operations.OperationHandler;
 import org.apache.geode.protocol.protobuf.BasicTypes;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
 import org.apache.geode.protocol.protobuf.Failure;
 import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.geode.protocol.protobuf.Result;
@@ -38,7 +37,7 @@ public class GetRequestOperationHandler
     Region region = cache.getRegion(regionName);
     if (region == null) {
       return Failure
-          .of(ClientProtocol.ErrorResponse.newBuilder().setMessage("Region not found").build());
+          .of(BasicTypes.ErrorResponse.newBuilder().setMessage("Region not found").build());
     }
 
     try {
@@ -53,10 +52,10 @@ public class GetRequestOperationHandler
           ProtobufUtilities.createEncodedValue(serializationService, resultValue);
       return Success.of(RegionAPI.GetResponse.newBuilder().setResult(encodedValue).build());
     } catch (UnsupportedEncodingTypeException ex) {
-      return Failure.of(
-          ClientProtocol.ErrorResponse.newBuilder().setMessage("Encoding not supported.").build());
+      return Failure
+          .of(BasicTypes.ErrorResponse.newBuilder().setMessage("Encoding not supported.").build());
     } catch (CodecNotRegisteredForTypeException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder()
           .setMessage("Codec error in protobuf deserialization.").build());
     }
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/PutRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/PutRequestOperationHandler.java
@@ -18,7 +18,6 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.operations.OperationHandler;
 import org.apache.geode.protocol.protobuf.BasicTypes;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
 import org.apache.geode.protocol.protobuf.Failure;
 import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.geode.protocol.protobuf.Result;
@@ -37,7 +36,7 @@ public class PutRequestOperationHandler
     String regionName = request.getRegionName();
     Region region = cache.getRegion(regionName);
     if (region == null) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder()
           .setMessage("Region passed by client did not exist: " + regionName).build());
     }
 
@@ -50,18 +49,16 @@ public class PutRequestOperationHandler
         region.put(decodedKey, decodedValue);
         return Success.of(RegionAPI.PutResponse.newBuilder().build());
       } catch (ClassCastException ex) {
-        return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+        return Failure.of(BasicTypes.ErrorResponse.newBuilder()
             .setMessage("invalid key or value type for region " + regionName + ",passed key: "
                 + entry.getKey().getEncodingType() + " value: "
                 + entry.getValue().getEncodingType())
             .build());
       }
     } catch (UnsupportedEncodingTypeException ex) {
-      return Failure
-          .of(ClientProtocol.ErrorResponse.newBuilder().setMessage(ex.getMessage()).build());
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder().setMessage(ex.getMessage()).build());
     } catch (CodecNotRegisteredForTypeException ex) {
-      return Failure
-          .of(ClientProtocol.ErrorResponse.newBuilder().setMessage(ex.getMessage()).build());
+      return Failure.of(BasicTypes.ErrorResponse.newBuilder().setMessage(ex.getMessage()).build());
     }
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/RemoveRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/operations/RemoveRequestOperationHandler.java
@@ -14,13 +14,10 @@
  */
 package org.apache.geode.protocol.protobuf.operations;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.operations.OperationHandler;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
+import org.apache.geode.protocol.protobuf.BasicTypes;
 import org.apache.geode.protocol.protobuf.Failure;
 import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.geode.protocol.protobuf.Result;
@@ -30,6 +27,8 @@ import org.apache.geode.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.serialization.SerializationService;
 import org.apache.geode.serialization.exception.UnsupportedEncodingTypeException;
 import org.apache.geode.serialization.registry.exception.CodecNotRegisteredForTypeException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RemoveRequestOperationHandler
     implements OperationHandler<RegionAPI.RemoveRequest, RegionAPI.RemoveResponse> {
@@ -43,7 +42,7 @@ public class RemoveRequestOperationHandler
     Region region = cache.getRegion(regionName);
     if (region == null) {
       return Failure
-          .of(ClientProtocol.ErrorResponse.newBuilder().setMessage("Region not found").build());
+          .of(BasicTypes.ErrorResponse.newBuilder().setMessage("Region not found").build());
     }
 
     try {

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/utilities/ProtobufResponseUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/utilities/ProtobufResponseUtilities.java
@@ -14,13 +14,12 @@
  */
 package org.apache.geode.protocol.protobuf.utilities;
 
-import java.util.Set;
-
+import org.apache.geode.cache.Region;
+import org.apache.geode.protocol.protobuf.BasicTypes;
+import org.apache.geode.protocol.protobuf.RegionAPI;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.cache.Region;
-import org.apache.geode.protocol.protobuf.ClientProtocol;
-import org.apache.geode.protocol.protobuf.RegionAPI;
+import java.util.Set;
 
 /**
  * This class contains helper functions for generating ClientProtocol.Response objects.
@@ -31,22 +30,22 @@ import org.apache.geode.protocol.protobuf.RegionAPI;
 public abstract class ProtobufResponseUtilities {
 
   /**
-   * This creates response object containing a ClientProtocol.ErrorResponse, and also logs the
-   * passed error message and exception (if present) to the provided logger.
+   * This creates response object containing a BasicTypes.ErrorResponse, and also logs the passed
+   * error message and exception (if present) to the provided logger.
    *
    * @param errorMessage - description of the error
    * @param logger - logger to write the error message to
    * @param ex - exception which should be logged
    * @return An error response containing the first three parameters.
    */
-  public static ClientProtocol.ErrorResponse createAndLogErrorResponse(String errorMessage,
+  public static BasicTypes.ErrorResponse createAndLogErrorResponse(String errorMessage,
       Logger logger, Exception ex) {
     if (ex != null) {
       logger.error(errorMessage, ex);
     } else {
       logger.error(errorMessage);
     }
-    return ClientProtocol.ErrorResponse.newBuilder().setMessage(errorMessage).build();
+    return BasicTypes.ErrorResponse.newBuilder().setMessage(errorMessage).build();
   }
 
   /**

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/utilities/ProtobufUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/utilities/ProtobufUtilities.java
@@ -15,7 +15,6 @@
 package org.apache.geode.protocol.protobuf.utilities;
 
 import com.google.protobuf.ByteString;
-
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.protocol.protobuf.BasicTypes;
@@ -31,7 +30,7 @@ import org.apache.geode.serialization.registry.exception.CodecNotRegisteredForTy
  * This class contains helper functions for assistance in creating protobuf objects. This class is
  * mainly focused on helper functions which can be used in building BasicTypes for use in other
  * messages or those used to create the top level Message objects.
- *
+ * <p>
  * Helper functions specific to creating ClientProtocol.Responses can be found at
  * {@link ProtobufResponseUtilities} Helper functions specific to creating ClientProtocol.Requests
  * can be found at {@link ProtobufRequestUtilities}
@@ -170,7 +169,6 @@ public abstract class ProtobufUtilities {
   }
 
   /**
-   *
    * @param region
    * @return a Protobuf BasicTypes.Region message that represents the {@link Region}
    */

--- a/geode-protobuf/src/main/java/org/apache/geode/serialization/codec/BooleanCodec.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/serialization/codec/BooleanCodec.java
@@ -14,10 +14,10 @@
  */
 package org.apache.geode.serialization.codec;
 
-import java.nio.ByteBuffer;
-
 import org.apache.geode.serialization.SerializationType;
 import org.apache.geode.serialization.TypeCodec;
+
+import java.nio.ByteBuffer;
 
 public class BooleanCodec implements TypeCodec<Boolean> {
   @Override

--- a/geode-protobuf/src/main/proto/basicTypes.proto
+++ b/geode-protobuf/src/main/proto/basicTypes.proto
@@ -63,3 +63,13 @@ message Region {
 message Server {
     string url = 1;
 }
+
+message ErrorResponse {
+    int32 errorCode = 1;
+    string message = 2;
+}
+
+message KeyedErrorResponse {
+    EncodedValue key = 1;
+    ErrorResponse error = 2;
+}

--- a/geode-protobuf/src/main/proto/clientProtocol.proto
+++ b/geode-protobuf/src/main/proto/clientProtocol.proto
@@ -78,11 +78,6 @@ message Response {
     }
 }
 
-message ErrorResponse {
-    int32 errorCode = 1;
-    string message = 2;
-}
-
 message MetaData {
     int32 numberOfMetadata = 1;
     map<int32, google.protobuf.Any> metaDataEntries = 2;

--- a/geode-protobuf/src/main/proto/region_API.proto
+++ b/geode-protobuf/src/main/proto/region_API.proto
@@ -42,7 +42,7 @@ message PutAllRequest {
 }
 
 message PutAllResponse {
-    // message presence indicates success.
+    repeated KeyedErrorResponse failedKeys = 1;
 }
 
 message GetAllRequest {

--- a/geode-protobuf/src/test/java/org/apache/geode/protocol/protobuf/operations/PutRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/protocol/protobuf/operations/PutRequestOperationHandlerJUnitTest.java
@@ -14,20 +14,6 @@
  */
 package org.apache.geode.protocol.protobuf.operations;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.nio.charset.Charset;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
 import org.apache.geode.cache.Region;
 import org.apache.geode.protocol.protobuf.BasicTypes;
 import org.apache.geode.protocol.protobuf.Failure;
@@ -41,6 +27,19 @@ import org.apache.geode.serialization.registry.exception.CodecAlreadyRegisteredF
 import org.apache.geode.serialization.registry.exception.CodecNotRegisteredForTypeException;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.nio.charset.Charset;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @Category(UnitTest.class)
 public class PutRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTest {


### PR DESCRIPTION
@kohlmu-pivotal @pivotal-amurmann @galen-pivotal @bschuchardt @hiteshk25 

* We will now dispatch incoming protobuf PutAlls as a series of put operations
* The PutAllResponse will contain a set of failed keys and the error they failed with

Signed-off-by: Galen O'Sullivan <gosullivan@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
