### PR TITLE
GEODE-3113: Modify HARegionQueue test to use Awaitility vs. timeouts

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -21,11 +21,13 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.ha.HARegionQueue.MapWrapper;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.logging.log4j.Logger;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -286,13 +288,11 @@ public class HARQAddOperationJUnitTest {
           "ThreadIdentifier removed itself through expiry even though data was lying in the queue",
           eventsMap.get(threadId));
 
-      // wait for some more time to allow expiry on data
-      Thread.sleep(16000);
-
       // After the expiry of the data , AvaialbleIds size should be 0,
       // entry
       // removed from Region, LastDispatchedWrapperSet should have size 0.
-      assertEquals(0, regionqueue.getRegion().entrySet(false).size());
+      Awaitility.await().atMost(60, TimeUnit.SECONDS)
+          .until(() -> assertEquals(0, regionqueue.getRegion().entrySet(false).size()));
       assertEquals(0, regionqueue.getAvalaibleIds().size());
       assertNull(regionqueue.getCurrentCounterSet(id1));
 


### PR DESCRIPTION
* Modify test to use Awaitility (at most 60 seconds) vs. sleeps prior to checking expiration

@upthewaterspout @nabarunnag

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
