### PR TITLE
GEODE-3206 : Corrected order of lucene search results based on score.

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneSearchResults.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneSearchResults.java
@@ -55,7 +55,11 @@ public class LuceneSearchResults<K, V> implements Comparable<LuceneSearchResults
 
   @Override
   public int compareTo(final LuceneSearchResults searchResults) {
-    return Float.compare(getScore(), searchResults.getScore());
+    // Lucene search result is compared on score of result. Higher the score more relevant the
+    // result.
+    // This comparator is used to list results, order will be higher to lower on score. (Ref.
+    // GEODE-3206)
+    return Float.compare(getScore(), searchResults.getScore()) * -1;
   }
 
   public boolean getExeptionFlag() {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -27,6 +27,28 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
@@ -47,27 +69,6 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.test.junit.categories.UnitTest;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.core.KeywordAnalyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 
 /**
  * The LuceneIndexCommandsJUnitTest class is a test suite of test cases testing the contract and
@@ -275,9 +276,9 @@ public class LuceneIndexCommandsJUnitTest {
 
     TabularResultData data = (TabularResultData) result.getResultData();
 
-    assertEquals(Arrays.asList("C", "B", "A"), data.retrieveAllValues("key"));
+    assertEquals(Arrays.asList("A", "B", "C"), data.retrieveAllValues("key"));
     assertEquals(Arrays.asList("Result1", "Result1", "Result1"), data.retrieveAllValues("value"));
-    assertEquals(Arrays.asList("1.1", "1.2", "1.3"), data.retrieveAllValues("score"));
+    assertEquals(Arrays.asList("1.3", "1.2", "1.1"), data.retrieveAllValues("score"));
   }
 
   @Ignore
@@ -366,7 +367,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     TabularResultData data = (TabularResultData) result.getResultData();
 
-    assertEquals(Arrays.asList("C", "B", "A"), data.retrieveAllValues("key"));
+    assertEquals(Arrays.asList("A", "B", "C"), data.retrieveAllValues("key"));
   }
 
   @Test


### PR DESCRIPTION
* Lucene results with higher score value are more relevant than lower once.
  Used descending comparator for lucene search result based on score,
  so most relevant results will be listed first.

* Added test case to verify the changed order.

* Modified expected result from test case, as the order of result is
  changed to match relevancy of result searched.

* Optimized imports with new style file.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
