### PR TITLE
GEODE-3314: Fix DLockService token leak.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRequestProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRequestProcessor.java
@@ -202,18 +202,12 @@ public class DLockRequestProcessor extends ReplyProcessor21 {
     Assert.assertTrue(lockId > -1, "lockId is < 0: " + this);
     this.request.lockId = lockId;
 
-    // setDoneProcessing(false);
-
     // local grantor... don't use messaging... fake it
     if (isLockGrantor()) {
       if (isDebugEnabled_DLS) {
         logger.trace(LogMarker.DLS, "DLockRequestProcessor processing lock request directly");
       }
       this.request.setSender(this.dm.getDistributionManagerId());
-      /*
-       * if (svc.isDestroyed()) { return false; }
-       */
-      // svc.checkDestroyed();
 
       // calls processor (this) process...
       this.request.processLocally(this.dm);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockService.java
@@ -1388,7 +1388,6 @@ public class DLockService extends DistributedLockService {
       throw new InterruptedException();
     }
 
-    boolean abnormalExit = true;
     boolean safeExit = true;
     try { // try-block for abnormalExit and safeExit
 
@@ -1716,7 +1715,6 @@ public class DLockService extends DistributedLockService {
         logger.trace(LogMarker.DLS, "{}, name: {} - exiting lock() returning {}", this, name,
             gotLock);
       }
-      abnormalExit = false;
       return gotLock;
     } // try-block for abnormalExit and safeExit
 
@@ -1929,12 +1927,12 @@ public class DLockService extends DistributedLockService {
           checkDestroyed();
           LockGrantorId theLockGrantorId = getLockGrantorId();
           try {
+            synchronized (this.lockGrantorIdLock) {
+              unlocked = token.releaseLock(lockId, rThread);
+            }
             released = callReleaseProcessor(theLockGrantorId.getLockGrantorMember(), name,
                 lockBatch, lockId);
-            synchronized (this.lockGrantorIdLock) {
-              token.releaseLock(lockId, rThread);
-              unlocked = true;
-            }
+
           } catch (LockGrantorDestroyedException e) { // part of fix for bug 35239
             // loop back around to get next lock grantor
           } catch (LockServiceDestroyedException e) { // part of fix for bug 35239

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
@@ -132,12 +132,10 @@ public class DLockServiceJUnitTest {
       futures.add(executorService.submit(this::putTestKey));
     }
 
-    futures.stream().forEach(future -> {
+    futures.forEach(future -> {
       try {
         future.get();
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      } catch (ExecutionException e) {
+      } catch (InterruptedException | ExecutionException e) {
         e.printStackTrace();
       }
     });
@@ -154,7 +152,6 @@ public class DLockServiceJUnitTest {
 
   private void putTestKey() {
     for (int i = 0; i < 1000; i++) {
-      System.out.println("Put number " + i + " thread " + Thread.currentThread().getName());
       testRegion.put("testKey", "testValue");
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.locks;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.internal.cache.DistributedRegion;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+
+@Category(UnitTest.class)
+public class DLockServiceJUnitTest {
+  private Cache cache;
+  private ExecutorService executorService;
+  private DistributedRegion testRegion;
+
+  @Before
+  public void setUp() {
+    Properties properties = new Properties();
+    properties.setProperty(MCAST_PORT, "0");
+
+    cache = new CacheFactory(properties).create();
+    testRegion = (DistributedRegion) cache.createRegionFactory(RegionShortcut.REPLICATE)
+        .setScope(Scope.GLOBAL)
+        .setEntryTimeToLive(new ExpirationAttributes(1, ExpirationAction.DESTROY))
+        .create("testRegion");
+    testRegion.becomeLockGrantor();
+
+    executorService = Executors.newFixedThreadPool(5);
+  }
+
+  @After
+  public void tearDown() {
+    cache.close();
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void basicDLockUsage() throws InterruptedException, ExecutionException, TimeoutException {
+    Lock lock = testRegion.getDistributedLock("testLockName");
+    lock.lockInterruptibly();
+
+    Future<Boolean> future = executorService.submit(() -> lock.tryLock());
+    assertFalse("should not be able to get lock from another thread",
+        future.get(5, TimeUnit.SECONDS));
+
+    assertTrue("Lock is reentrant", lock.tryLock());
+    // now locked twice.
+
+    future = executorService.submit(() -> lock.tryLock());
+    assertFalse("should not be able to get lock from another thread",
+        future.get(5, TimeUnit.SECONDS));
+
+    lock.unlock();
+
+    future = executorService.submit(() -> lock.tryLock());
+    assertFalse("should not be able to get lock from another thread", future.get());
+
+    lock.unlock();
+
+    future = executorService.submit(() -> {
+      boolean locked = lock.tryLock();
+      if (!locked) {
+        return false;
+      }
+      lock.unlock();
+      return true;
+    });
+    assertTrue("Another thread can now take out the lock", future.get(5, TimeUnit.SECONDS));
+
+    DLockService lockService = (DLockService) testRegion.getLockService();
+    Collection<DLockToken> tokens = lockService.getTokens();
+
+    for (DLockToken token : tokens) {
+      assertEquals(0, token.getUsageCount());
+    }
+  }
+
+  @Test
+  public void singleThreadWithCache() {
+    putTestKey();
+
+    DLockService lockService = (DLockService) testRegion.getLockService();
+    Collection<DLockToken> tokens = lockService.getTokens();
+
+    assertEquals(1, tokens.size());
+
+    for (DLockToken token : tokens) {
+      assertEquals(0, token.getUsageCount());
+    }
+  }
+
+  @Test
+  public void multipleThreadsWithCache() {
+    LinkedList<Future> futures = new LinkedList<>();
+    for (int i = 0; i < 5; i++) {
+      futures.add(executorService.submit(this::putTestKey));
+    }
+
+    futures.stream().forEach(future -> {
+      try {
+        future.get();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      } catch (ExecutionException e) {
+        e.printStackTrace();
+      }
+    });
+
+    DLockService lockService = (DLockService) testRegion.getLockService();
+    Collection<DLockToken> tokens = lockService.getTokens();
+
+    assertTrue(tokens.size() < 2);
+
+    for (DLockToken token : tokens) {
+      assertEquals(0, token.getUsageCount());
+    }
+  }
+
+  private void putTestKey() {
+    for (int i = 0; i < 1000; i++) {
+      System.out.println("Put number " + i + " thread " + Thread.currentThread().getName());
+      testRegion.put("testKey", "testValue");
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceLeakTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceLeakTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.cache.ExpirationAttributes;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.internal.cache.DistributedRegion;
-import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +43,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 
-@Category(UnitTest.class)
-public class DLockServiceJUnitTest {
+@Category(IntegrationTest.class)
+public class DLockServiceLeakTest {
   private Cache cache;
   private ExecutorService executorService;
   private DistributedRegion testRegion;


### PR DESCRIPTION
And add a test so that we don't do that again.

We had been unlocking the DLock on the remote server before freeing the
local `DLockToken`. This meant that the local token got reused by
another thread acquiring the same lock and the count went up and up and
up (due to some logic that wouldn't decrease the count if it no longer
owned the token).

Tokens should no longer have usageCounts that climb over time, which
means they should be released normally by freeResources.


Signed-off-by: Bruce Schuchardt <bschuchardt@pivotal.io>

@bschuchardt @kohlmu-pivotal @hiteshk25 @WireBaron @pivotal-amurmann 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
