### PR TITLE
GEODE-3329: Changed logging output of modify_war script

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/session/tests/GenericAppServerContainer.java
+++ b/geode-assembly/src/test/java/org/apache/geode/session/tests/GenericAppServerContainer.java
@@ -39,6 +39,7 @@ import org.junit.Assume;
  */
 public class GenericAppServerContainer extends ServerContainer {
   private final File modifyWarScript;
+  private final File modifyWarScriptLog;
 
   private static final String DEFAULT_GENERIC_APPSERVER_WAR_DIR = "/tmp/cargo_wars/";
 
@@ -57,6 +58,10 @@ public class GenericAppServerContainer extends ServerContainer {
     // Setup modify war script file so that it is executable and easily findable
     modifyWarScript = new File(install.getModulePath() + "/bin/modify_war");
     modifyWarScript.setExecutable(true);
+
+    // Setup modify_war script logging file
+    modifyWarScriptLog = new File(logDir + "/warScript.log");
+    modifyWarScriptLog.createNewFile();
 
     // Ignore tests that are running on windows, since they can't run the modify war script
     Assume.assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"));
@@ -116,7 +121,7 @@ public class GenericAppServerContainer extends ServerContainer {
    * {@link #buildCommand()}
    *
    * The modified WAR file is sent to {@link #warFile}.
-   * 
+   *
    * @throws IOException If the command executed returns with a non-zero exit code.
    */
   private void modifyWarFile() throws IOException, InterruptedException {
@@ -126,6 +131,9 @@ public class GenericAppServerContainer extends ServerContainer {
     builder.inheritIO();
     // Setup the environment builder with the command
     builder.command(buildCommand());
+    // Redirect the command line logging to a file
+    builder.redirectError(modifyWarScriptLog);
+    builder.redirectOutput(modifyWarScriptLog);
     logger.info("Running command: " + String.join(" ", builder.command()));
 
     // Run the command


### PR DESCRIPTION
Changed the modify_war script so that its output and error streams write to a log file instead of to standard out.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
