### PR TITLE
GEODE-3306: Remove whitespace StringBuffers/nodes created by Apache X…

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -142,6 +142,8 @@ dependencies {
   testCompile 'com.pholser:junit-quickcheck-core:' + project.'junit-quickcheck.version'
   testCompile 'com.pholser:junit-quickcheck-generators:' + project.'junit-quickcheck.version'
   testCompile 'com.pholser:junit-quickcheck-guava:' + project.'junit-quickcheck.version'
+
+  testRuntime 'xerces:xercesImpl:' + project.'xercesImpl.version'
 }
 
 def generatedResources = "$buildDir/generated-resources/main"

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
@@ -37,6 +37,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.geode.cache.util.GatewayConflictResolver;
 import org.apache.logging.log4j.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -2600,8 +2601,7 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
     // that contain only whitespace; see GEODE-3306
     while (!stack.empty()) {
       Object o = stack.peek();
-      if (o instanceof StringBuffer
-          && ((StringBuffer) o).toString().replaceAll("\\s", "").equals("")) {
+      if (o instanceof StringBuffer && StringUtils.isBlank(((StringBuffer) o).toString())) {
         stack.pop();
       } else {
         break;
@@ -2888,8 +2888,7 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
     // that contain only whitespace; see GEODE-3306
     while (!stack.empty()) {
       Object o = stack.peek();
-      if (o instanceof StringBuffer
-          && ((StringBuffer) o).toString().replaceAll("\\s", "").equals("")) {
+      if (o instanceof StringBuffer && StringUtils.isBlank(((StringBuffer) o).toString())) {
         stack.pop();
       } else {
         break;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
@@ -2596,6 +2596,18 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
 
   public void startElement(String namespaceURI, String localName, String qName, Attributes atts)
       throws SAXException {
+    // This while loop pops all StringBuffers at the top of the stack
+    // that contain only whitespace; see GEODE-3306
+    while (!stack.empty()) {
+      Object o = stack.peek();
+      if (o instanceof StringBuffer
+          && ((StringBuffer) o).toString().replaceAll("\\s", "").equals("")) {
+        stack.pop();
+      } else {
+        break;
+      }
+    }
+
     if (qName.equals(CACHE)) {
       startCache(atts);
     } else if (qName.equals(CLIENT_CACHE)) {
@@ -2872,6 +2884,18 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
   }
 
   public void endElement(String namespaceURI, String localName, String qName) throws SAXException {
+    // This while loop pops all StringBuffers at the top of the stack
+    // that contain only whitespace; see GEODE-3306
+    while (!stack.empty()) {
+      Object o = stack.peek();
+      if (o instanceof StringBuffer
+          && ((StringBuffer) o).toString().replaceAll("\\s", "").equals("")) {
+        stack.pop();
+      } else {
+        break;
+      }
+    }
+
     try {
       // logger.debug("endElement namespaceURI=" + namespaceURI
       // + "; localName = " + localName + "; qName = " + qName);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -113,8 +115,23 @@ public class CacheXmlParserJUnitTest {
     when(dm.getSystem()).thenReturn(system);
     InternalDistributedSystem.connect(nonDefault);
 
-    CacheXmlParser.parse(getClass()
-        .getResourceAsStream("CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml"));
+    Cache cache = new CacheFactory()
+        .set("cache-xml-file", "CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml")
+        .create(InternalDistributedSystem.connect(nonDefault));
+    cache.close();
+  }
+
+  /**
+   * Test that {@link CacheXmlParser} can parse the test cache.xml file, using the Apache Xerces XML
+   * parser.
+   * 
+   * @since Geode 1.3
+   */
+  @Test
+  public void testCacheXmlParserWithSimplePoolXerces() {
+    System.setProperty("javax.xml.parsers.SAXParserFactory",
+        "org.apache.xerces.jaxp.SAXParserFactoryImpl");
+    testCacheXmlParserWithSimplePool();
   }
 
   /**
@@ -135,6 +152,19 @@ public class CacheXmlParserJUnitTest {
     } finally {
       Locale.setDefault(previousLocale);
     }
+  }
+
+  /**
+   * Test that {@link CacheXmlParser} falls back to DTD parsing when locale language is not English,
+   * using the Apache Xerces XML parser.
+   * 
+   * @since Geode 1.3
+   */
+  @Test
+  public void testDTDFallbackWithNonEnglishLocalXerces() {
+    System.setProperty("javax.xml.parsers.SAXParserFactory",
+        "org.apache.xerces.jaxp.SAXParserFactoryImpl");
+    testDTDFallbackWithNonEnglishLocal();
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -113,7 +113,6 @@ public class CacheXmlParserJUnitTest {
     InternalDistributedSystem system =
         InternalDistributedSystem.newInstanceForTesting(dm, nonDefault);
     when(dm.getSystem()).thenReturn(system);
-    InternalDistributedSystem.connect(nonDefault);
 
     Cache cache = new CacheFactory()
         .set("cache-xml-file", "CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml")

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -133,7 +133,7 @@ public class CacheXmlParserJUnitTest {
    */
   @Test
   public void testCacheXmlParserWithSimplePoolXerces() {
-    String prevParserFactory = System.setProperty("javax.xml.parsers.SAXParserFactory",
+    System.setProperty("javax.xml.parsers.SAXParserFactory",
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
 
     testCacheXmlParserWithSimplePool();
@@ -167,7 +167,7 @@ public class CacheXmlParserJUnitTest {
    */
   @Test
   public void testDTDFallbackWithNonEnglishLocalXerces() {
-    String prevParserFactory = System.setProperty("javax.xml.parsers.SAXParserFactory",
+    System.setProperty("javax.xml.parsers.SAXParserFactory",
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
 
     testDTDFallbackWithNonEnglishLocal();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -29,7 +29,9 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -48,6 +50,9 @@ import java.util.Properties;
  */
 @Category(UnitTest.class)
 public class CacheXmlParserJUnitTest {
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   private static final String NAMESPACE_URI =
       "urn:java:org.apache.geode.internal.cache.xmlcache.MockXmlParser";
@@ -132,12 +137,6 @@ public class CacheXmlParserJUnitTest {
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
 
     testCacheXmlParserWithSimplePool();
-
-    if (prevParserFactory != null) {
-      System.setProperty("javax.xml.parsers.SAXParserFactory", prevParserFactory);
-    } else {
-      System.clearProperty("javax.xml.parsers.SAXParserFactory");
-    }
   }
 
   /**
@@ -172,12 +171,6 @@ public class CacheXmlParserJUnitTest {
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
 
     testDTDFallbackWithNonEnglishLocal();
-
-    if (prevParserFactory != null) {
-      System.setProperty("javax.xml.parsers.SAXParserFactory", prevParserFactory);
-    } else {
-      System.clearProperty("javax.xml.parsers.SAXParserFactory");
-    }
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -110,18 +110,11 @@ public class CacheXmlParserJUnitTest {
     assertNotNull("Did not find simple config.xml file", getClass()
         .getResourceAsStream("CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml"));
 
-    DM dm = mock(DM.class);
-
     Properties nonDefault = new Properties();
     nonDefault.setProperty(MCAST_PORT, "0"); // loner
 
-    InternalDistributedSystem system =
-        InternalDistributedSystem.newInstanceForTesting(dm, nonDefault);
-    when(dm.getSystem()).thenReturn(system);
-
-    Cache cache = new CacheFactory()
-        .set("cache-xml-file", "CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml")
-        .create(InternalDistributedSystem.connect(nonDefault));
+    ClientCache cache = new ClientCacheFactory(nonDefault).set("cache-xml-file",
+        "xmlcache/CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml").create();
     cache.close();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.java
@@ -128,9 +128,16 @@ public class CacheXmlParserJUnitTest {
    */
   @Test
   public void testCacheXmlParserWithSimplePoolXerces() {
-    System.setProperty("javax.xml.parsers.SAXParserFactory",
+    String prevParserFactory = System.setProperty("javax.xml.parsers.SAXParserFactory",
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
+
     testCacheXmlParserWithSimplePool();
+
+    if (prevParserFactory != null) {
+      System.setProperty("javax.xml.parsers.SAXParserFactory", prevParserFactory);
+    } else {
+      System.clearProperty("javax.xml.parsers.SAXParserFactory");
+    }
   }
 
   /**
@@ -161,9 +168,16 @@ public class CacheXmlParserJUnitTest {
    */
   @Test
   public void testDTDFallbackWithNonEnglishLocalXerces() {
-    System.setProperty("javax.xml.parsers.SAXParserFactory",
+    String prevParserFactory = System.setProperty("javax.xml.parsers.SAXParserFactory",
         "org.apache.xerces.jaxp.SAXParserFactoryImpl");
+
     testDTDFallbackWithNonEnglishLocal();
+
+    if (prevParserFactory != null) {
+      System.setProperty("javax.xml.parsers.SAXParserFactory", prevParserFactory);
+    } else {
+      System.clearProperty("javax.xml.parsers.SAXParserFactory");
+    }
   }
 
   /**

--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -99,3 +99,4 @@ tomcat6.version = 6.0.37
 tomcat7.version = 7.0.73
 tomcat8.version = 8.5.9
 commons-validator.version = 1.6
+xercesImpl.version = 2.11.0


### PR DESCRIPTION
…erces

This commit makes Geode compatible with the official Apache Xerces
implementation, which calls `characters()` when it reads ignorable
whitespace in `cache.xml`.

The while loop is required to handle comments in `cache.xml`, i.e.
a comment with whitespace before and after will generate two
empty StringBuffers (one for each set of whitespace before and after)
on the parse stack. The while loop removes all "consecutive" whitespace
StringBuffers from the top of the stack.

---

Tested with https://github.com/darrenfoong/geode-parser-poc/blob/master/src/test/java/server/ServerTest.java

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
