### PR TITLE
GEODE-3266: Refactoring PDXCommands

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -12,21 +12,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package org.apache.geode.management.internal.cli.commands;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.Collection;
 
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.internal.cache.CacheConfig;
-import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
@@ -39,17 +35,13 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
-import org.apache.geode.pdx.internal.EnumInfo;
-import org.apache.geode.pdx.internal.PdxType;
-import org.apache.geode.security.ResourcePermission.Operation;
-import org.apache.geode.security.ResourcePermission.Resource;
+import org.apache.geode.security.ResourcePermission;
 
-public class PDXCommands implements GfshCommand {
-
-
+public class ConfigurePDXCommand implements GfshCommand {
   @CliCommand(value = CliStrings.CONFIGURE_PDX, help = CliStrings.CONFIGURE_PDX__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
-  @ResourceOperation(resource = Resource.CLUSTER, operation = Operation.MANAGE)
+  @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
+      operation = ResourcePermission.Operation.MANAGE)
   public Result configurePDX(
       @CliOption(key = CliStrings.CONFIGURE_PDX__READ__SERIALIZED,
           help = CliStrings.CONFIGURE_PDX__READ__SERIALIZED__HELP) Boolean readSerialized,
@@ -141,55 +133,6 @@ public class PDXCommands implements GfshCommand {
     } catch (Exception e) {
       return ResultBuilder.createGemFireErrorResult(e.getMessage());
     }
-
     return result;
-  }
-
-  @CliCommand(value = CliStrings.PDX_RENAME, help = CliStrings.PDX_RENAME__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
-  public Result pdxRename(@CliOption(key = CliStrings.PDX_RENAME_OLD, mandatory = true,
-      help = CliStrings.PDX_RENAME_OLD__HELP) String oldClassName,
-
-      @CliOption(key = CliStrings.PDX_RENAME_NEW, mandatory = true,
-          help = CliStrings.PDX_RENAME_NEW__HELP) String newClassName,
-
-      @CliOption(key = CliStrings.PDX_DISKSTORE, mandatory = true,
-          help = CliStrings.PDX_DISKSTORE__HELP) String diskStore,
-
-      @CliOption(key = CliStrings.PDX_DISKDIR, mandatory = true,
-          help = CliStrings.PDX_DISKDIR__HELP) String[] diskDirs) {
-
-    try {
-      final File[] dirs = new File[diskDirs.length];
-      for (int i = 0; i < diskDirs.length; i++) {
-        dirs[i] = new File((diskDirs[i]));
-      }
-
-      Collection<Object> results =
-          DiskStoreImpl.pdxRename(diskStore, dirs, oldClassName, newClassName);
-
-      if (results.isEmpty()) {
-        return ResultBuilder
-            .createGemFireErrorResult(CliStrings.format(CliStrings.PDX_RENAME__EMPTY));
-      }
-
-      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      PrintStream printStream = new PrintStream(outputStream);
-      for (Object p : results) {
-        if (p instanceof PdxType) {
-          ((PdxType) p).toStream(printStream, false);
-        } else {
-          ((EnumInfo) p).toStream(printStream);
-        }
-      }
-      String resultString =
-          CliStrings.format(CliStrings.PDX_RENAME__SUCCESS, outputStream.toString());
-      return ResultBuilder.createInfoResult(resultString);
-
-    } catch (Exception e) {
-      return ResultBuilder.createGemFireErrorResult(
-          CliStrings.format(CliStrings.PDX_RENAME__ERROR, e.getMessage()));
-    }
-
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Collection;
+
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+
+import org.apache.geode.internal.cache.DiskStoreImpl;
+import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.ResultBuilder;
+import org.apache.geode.pdx.internal.EnumInfo;
+import org.apache.geode.pdx.internal.PdxType;
+
+public class PDXRenameCommand implements GfshCommand {
+  @CliCommand(value = CliStrings.PDX_RENAME, help = CliStrings.PDX_RENAME__HELP)
+  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  public Result pdxRename(@CliOption(key = CliStrings.PDX_RENAME_OLD, mandatory = true,
+      help = CliStrings.PDX_RENAME_OLD__HELP) String oldClassName,
+
+      @CliOption(key = CliStrings.PDX_RENAME_NEW, mandatory = true,
+          help = CliStrings.PDX_RENAME_NEW__HELP) String newClassName,
+
+      @CliOption(key = CliStrings.PDX_DISKSTORE, mandatory = true,
+          help = CliStrings.PDX_DISKSTORE__HELP) String diskStore,
+
+      @CliOption(key = CliStrings.PDX_DISKDIR, mandatory = true,
+          help = CliStrings.PDX_DISKDIR__HELP) String[] diskDirs) {
+
+    try {
+      final File[] dirs = new File[diskDirs.length];
+      for (int i = 0; i < diskDirs.length; i++) {
+        dirs[i] = new File((diskDirs[i]));
+      }
+
+      Collection<Object> results =
+          DiskStoreImpl.pdxRename(diskStore, dirs, oldClassName, newClassName);
+
+      if (results.isEmpty()) {
+        return ResultBuilder
+            .createGemFireErrorResult(CliStrings.format(CliStrings.PDX_RENAME__EMPTY));
+      }
+
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      PrintStream printStream = new PrintStream(outputStream);
+      for (Object p : results) {
+        if (p instanceof PdxType) {
+          ((PdxType) p).toStream(printStream, false);
+        } else {
+          ((EnumInfo) p).toStream(printStream);
+        }
+      }
+      String resultString =
+          CliStrings.format(CliStrings.PDX_RENAME__SUCCESS, outputStream.toString());
+      return ResultBuilder.createInfoResult(resultString);
+
+    } catch (Exception e) {
+      return ResultBuilder.createGemFireErrorResult(
+          CliStrings.format(CliStrings.PDX_RENAME__ERROR, e.getMessage()));
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/PdxCommandsController.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/PdxCommandsController.java
@@ -14,20 +14,22 @@
  */
 package org.apache.geode.management.internal.web.controllers;
 
-import org.apache.geode.internal.lang.StringUtils;
-import org.apache.geode.management.internal.cli.i18n.CliStrings;
-import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import org.apache.geode.internal.lang.StringUtils;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+
 /**
  * The PdxCommandsController class implements GemFire Management REST API web service endpoints for
  * Gfsh PDX Commands.
  *
- * @see org.apache.geode.management.internal.cli.commands.PDXCommands
+ * @see org.apache.geode.management.internal.cli.commands.PDXRenameCommand
+ * @see org.apache.geode.management.internal.cli.commands.ConfigurePDXCommand
  * @see org.apache.geode.management.internal.web.controllers.AbstractCommandsController
  * @see org.springframework.stereotype.Controller
  * @see org.springframework.web.bind.annotation.RequestMapping


### PR DESCRIPTION
[View the JIRA ticket here.](https://issues.apache.org/jira/browse/GEODE-3266)

`PDXCommands` has been split into `PDXRenameCommand` and `ConfigurePDXCommand`. There didn't appear to be any associated tests for these commands, but see [GEODE-1359](https://issues.apache.org/jira/browse/GEODE-1359) for updates to other command tests.

**TESTING STATUS: Precheckin completed successfully!**

- [x] JIRA ticket referenced

- [x] PR rebased

- [x] Single, squashed commit

- [x] `gradlew build` runs cleanly

- [ ] No tests appeared to need updating, but see [GEODE-1359](https://issues.apache.org/jira/browse/GEODE-1359) for updates to other command tests