### PR TITLE
GEODE-3268: Refactoring RegionCommands

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
@@ -16,7 +16,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -234,7 +233,7 @@ public class DescribeRegionCommand implements GfshCommand {
 
       for (String attributeName : attributes) {
         String attributeValue = attributesMap.get(attributeName);
-        String type, memName;
+        String type;
 
         if (!isTypeAdded) {
           type = attributeType;
@@ -249,46 +248,39 @@ public class DescribeRegionCommand implements GfshCommand {
 
   private void writeFixedPartitionAttributesToTable(TabularResultData table,
       List<FixedPartitionAttributesInfo> fpaList, String member, boolean isMemberNameAdded) {
-
-    if (fpaList != null) {
-      boolean isTypeAdded = false;
-      final String blank = "";
-
-      Iterator<FixedPartitionAttributesInfo> fpaIter = fpaList.iterator();
-      String type, memName;
-
-      while (fpaIter.hasNext()) {
-        FixedPartitionAttributesInfo fpa = fpaIter.next();
-        StringBuilder fpaBuilder = new StringBuilder();
-        fpaBuilder.append(fpa.getPartitionName());
-        fpaBuilder.append(',');
-
-        if (fpa.isPrimary()) {
-          fpaBuilder.append("Primary");
-        } else {
-          fpaBuilder.append("Secondary");
-        }
-        fpaBuilder.append(',');
-        fpaBuilder.append(fpa.getNumBuckets());
-
-        if (!isTypeAdded) {
-          type = "";
-          isTypeAdded = true;
-        } else {
-          type = blank;
-        }
-
-        if (!isMemberNameAdded) {
-          memName = member;
-          isMemberNameAdded = true;
-        } else {
-          memName = blank;
-        }
-
-        writeAttributeToTable(table, memName, type, "Fixed Partition", fpaBuilder.toString());
-      }
+    if (fpaList == null) {
+      return;
     }
 
+    boolean isTypeAdded = false;
+    final String blank = "";
+    String memName;
+
+    for (FixedPartitionAttributesInfo fpa : fpaList) {
+      StringBuilder fpaBuilder = new StringBuilder();
+      fpaBuilder.append(fpa.getPartitionName());
+      fpaBuilder.append(',');
+
+      if (fpa.isPrimary()) {
+        fpaBuilder.append("Primary");
+      } else {
+        fpaBuilder.append("Secondary");
+      }
+      fpaBuilder.append(',');
+      fpaBuilder.append(fpa.getNumBuckets());
+
+      if (!isTypeAdded) {
+        isTypeAdded = true;
+      }
+
+      if (!isMemberNameAdded) {
+        memName = member;
+        isMemberNameAdded = true;
+      } else {
+        memName = blank;
+      }
+      writeAttributeToTable(table, memName, "", "Fixed Partition", fpaBuilder.toString());
+    }
   }
 
   private boolean writeAttributesToTable(TabularResultData table, String attributeType,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+
+import org.apache.geode.cache.execute.FunctionInvocationTargetException;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.ConverterHint;
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.CliUtil;
+import org.apache.geode.management.internal.cli.domain.RegionInformation;
+import org.apache.geode.management.internal.cli.functions.GetRegionsFunction;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.ResultBuilder;
+import org.apache.geode.management.internal.cli.result.TabularResultData;
+import org.apache.geode.management.internal.security.ResourceOperation;
+import org.apache.geode.security.ResourcePermission;
+
+public class ListRegionCommand implements GfshCommand {
+  private static final GetRegionsFunction getRegionsFunction = new GetRegionsFunction();
+
+  @CliCommand(value = {CliStrings.LIST_REGION}, help = CliStrings.LIST_REGION__HELP)
+  @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
+  @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
+      operation = ResourcePermission.Operation.READ)
+  public Result listRegion(
+      @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
+          optionContext = ConverterHint.MEMBERGROUP,
+          help = CliStrings.LIST_REGION__GROUP__HELP) String[] group,
+      @CliOption(key = {CliStrings.MEMBER, CliStrings.MEMBERS},
+          optionContext = ConverterHint.MEMBERIDNAME,
+          help = CliStrings.LIST_REGION__MEMBER__HELP) String[] memberNameOrId) {
+    Result result = null;
+    try {
+      Set<RegionInformation> regionInfoSet = new LinkedHashSet<>();
+      ResultCollector<?, ?> rc;
+      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId);
+
+      if (targetMembers.isEmpty()) {
+        return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      }
+
+      TabularResultData resultData = ResultBuilder.createTabularResultData();
+      rc = CliUtil.executeFunction(getRegionsFunction, null, targetMembers);
+      ArrayList<?> resultList = (ArrayList<?>) rc.getResult();
+
+      if (resultList != null) {
+
+        for (Object resultObj : resultList) {
+          if (resultObj != null) {
+            if (resultObj instanceof Object[]) {
+              Object[] resultObjectArray = (Object[]) resultObj;
+              for (Object regionInfo : resultObjectArray) {
+                if (regionInfo instanceof RegionInformation) {
+                  regionInfoSet.add((RegionInformation) regionInfo);
+                }
+              }
+            }
+          }
+        }
+
+        Set<String> regionNames = new TreeSet<>();
+
+        for (RegionInformation regionInfo : regionInfoSet) {
+          regionNames.add(regionInfo.getName());
+          Set<String> subRegionNames = regionInfo.getSubRegionNames();
+
+          regionNames.addAll(subRegionNames);
+        }
+
+        for (String regionName : regionNames) {
+          resultData.accumulate("List of regions", regionName);
+        }
+
+        if (!regionNames.isEmpty()) {
+          result = ResultBuilder.buildResult(resultData);
+
+        } else {
+          result = ResultBuilder.createInfoResult(CliStrings.LIST_REGION__MSG__NOT_FOUND);
+        }
+      }
+    } catch (FunctionInvocationTargetException e) {
+      result = ResultBuilder.createGemFireErrorResult(CliStrings
+          .format(CliStrings.COULD_NOT_EXECUTE_COMMAND_TRY_AGAIN, CliStrings.LIST_REGION));
+    } catch (Exception e) {
+      result = ResultBuilder
+          .createGemFireErrorResult(CliStrings.LIST_REGION__MSG__ERROR + " : " + e.getMessage());
+    }
+    return result;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/RegionCommandsController.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/RegionCommandsController.java
@@ -26,11 +26,12 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
 
 /**
- * The RegionCommands class implements GemFire Management REST API web service endpoints for the
- * Gfsh Region Commands.
+ * The ListRegionCommand and DescribeRegionCommand classes implement GemFire Management REST API web
+ * service endpoints for the Gfsh Region Commands.
  * <p/>
  * 
- * @see org.apache.geode.management.internal.cli.commands.RegionCommands
+ * @see org.apache.geode.management.internal.cli.commands.ListRegionCommand
+ * @see org.apache.geode.management.internal.cli.commands.DescribeRegionCommand
  * @see org.apache.geode.management.internal.web.controllers.AbstractCommandsController
  * @see org.springframework.stereotype.Controller
  * @see org.springframework.web.bind.annotation.PathVariable

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/RegionCommandsController.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/RegionCommandsController.java
@@ -14,9 +14,6 @@
  */
 package org.apache.geode.management.internal.web.controllers;
 
-import org.apache.geode.internal.lang.StringUtils;
-import org.apache.geode.management.internal.cli.i18n.CliStrings;
-import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
+
+import org.apache.geode.internal.lang.StringUtils;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 
 /**
  * The ListRegionCommand and DescribeRegionCommand classes implement GemFire Management REST API web

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
@@ -278,8 +278,5 @@ public class TestCommand {
 
     // ShellCommand
     createTestCommand("disconnect");
-
-    // Misc commands
-    // createTestCommand("shutdown", clusterManage);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
@@ -245,7 +245,7 @@ public class TestCommand {
 
     createTestCommand("list async-event-queues", clusterRead);
 
-    // RegionCommands
+    // DescribeRegionCommand, ListRegionCommand
     createTestCommand("describe region --name=value", clusterRead);
     createTestCommand("list regions", clusterRead);
 


### PR DESCRIPTION
[View the JIRA ticket here.](https://issues.apache.org/jira/browse/GEODE-3268)

`RegionCommands` was a big class that contained too many commands (each class should only contain one command). These commands have been split into their own individual command classes.

**TESTING STATUS: Precheckin all green!**

- [x] JIRA ticket referenced

- [x] PR rebased

- [x] Initial commit is single and squashed

- [x] `gradlew build` runs cleanly

- [ ] Unit tests will be updated with [GEODE-1359](https://issues.apache.org/jira/browse/GEODE-1359))