### PR TITLE
GEODE-3270: Refactoring (renaming) StatusCommands

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/shell/GfshExitCodeStatusClusterConfigServiceCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/shell/GfshExitCodeStatusClusterConfigServiceCommandTest.java
@@ -46,7 +46,7 @@ import org.apache.geode.test.junit.categories.AcceptanceTest;
 
 @Category(AcceptanceTest.class)
 @RunWith(JUnitParamsRunner.class)
-public class GfshExitCodeStatusCommandsTest {
+public class GfshExitCodeStatusClusterConfigServiceCommandTest {
   private static File toolsJar;
   private static final ThreePhraseGenerator nameGenerator = new ThreePhraseGenerator();
   private static final String memberControllerName = "member-controller";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
@@ -14,6 +14,12 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.shell.core.annotation.CliCommand;
+
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
@@ -31,15 +37,9 @@ import org.apache.geode.management.internal.configuration.domain.SharedConfigura
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
-import org.springframework.shell.core.CommandMarker;
-import org.springframework.shell.core.annotation.CliCommand;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-public class StatusCommands implements GfshCommand {
-  static final FetchSharedConfigurationStatusFunction fetchSharedConfigStatusFunction =
+public class StatusClusterConfigServiceCommand implements GfshCommand {
+  private static final FetchSharedConfigurationStatusFunction fetchSharedConfigStatusFunction =
       new FetchSharedConfigurationStatusFunction();
 
   @SuppressWarnings("unchecked")

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/TestCommand.java
@@ -249,7 +249,7 @@ public class TestCommand {
     createTestCommand("describe region --name=value", clusterRead);
     createTestCommand("list regions", clusterRead);
 
-    // StatusCommands
+    // StatusClusterConfigServiceCommand
     createTestCommand("status cluster-config-service", clusterRead);
 
     // Shell Commands


### PR DESCRIPTION
[View the JIRA ticket here.](https://issues.apache.org/jira/browse/GEODE-3270)

`StatusCommands` was a class that already contained a single command. A better-fitting name for the class is `StatusClusterConfigServiceCommand`.

**TESTING STATUS: Precheckin in progress**

- [x] JIRA ticket referenced

- [x] PR rebased

- [x] Initial commit is single and squashed

- [x] `gradlew build` runs cleanly