### PR TITLE
GEODE-3407: fix deadlock between JMX and reconnect

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -57,6 +57,7 @@ import org.apache.geode.management.ClientHealthStatus;
 import org.apache.geode.management.ClientQueueDetail;
 import org.apache.geode.management.ServerLoadData;
 import org.apache.geode.management.internal.ManagementConstants;
+import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor;
 import org.apache.geode.management.internal.beans.stats.StatType;
 import org.apache.geode.management.internal.beans.stats.StatsAverageLatency;
 import org.apache.geode.management.internal.beans.stats.StatsKey;
@@ -101,7 +102,7 @@ public class CacheServerBridge extends ServerBridge {
     }
   }
 
-  public CacheServerBridge(CacheServer cacheServer, InternalCache cache) {
+  public CacheServerBridge(final InternalCache cache, final CacheServer cacheServer) {
     super(cacheServer);
     this.cacheServer = cacheServer;
     this.cache = cache;
@@ -110,7 +111,18 @@ public class CacheServerBridge extends ServerBridge {
     initializeCacheServerStats();
   }
 
-  // Dummy constructor for testing purpose only TODO why is this public then?
+  // For testing only
+  public CacheServerBridge(final InternalCache cache, final CacheServer cacheServer,
+      final AcceptorImpl acceptor, final MBeanStatsMonitor monitor) {
+    super(acceptor, monitor);
+    this.cacheServer = cacheServer;
+    this.cache = cache;
+    this.qs = cache.getQueryService();
+
+    initializeCacheServerStats();
+  }
+
+  // For testing only
   public CacheServerBridge() {
     super();
     initializeCacheServerStats();
@@ -648,7 +660,7 @@ public class CacheServerBridge extends ServerBridge {
   }
 
   public int getNumSubscriptions() {
-    Map clientProxyMembershipIDMap = InternalClientMembership.getClientQueueSizes();
+    Map clientProxyMembershipIDMap = InternalClientMembership.getClientQueueSizes(cache);
     return clientProxyMembershipIDMap.keySet().size();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
@@ -633,7 +633,7 @@ public class ManagementAdapter {
       return;
     }
 
-    CacheServerBridge cacheServerBridge = new CacheServerBridge(cacheServer, internalCache);
+    CacheServerBridge cacheServerBridge = new CacheServerBridge(internalCache, cacheServer);
     cacheServerBridge.setMemberMBeanBridge(memberMBeanBridge);
 
     CacheServerMBean cacheServerMBean = new CacheServerMBean(cacheServerBridge);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ServerBridge.java
@@ -29,7 +29,6 @@ public class ServerBridge {
 
   protected MBeanStatsMonitor monitor;
 
-
   protected StatsRate getRequestRate;
 
   protected StatsRate putRequestRate;
@@ -38,13 +37,20 @@ public class ServerBridge {
 
   protected StatsAverageLatency putRequestAvgLatency;
 
-
   protected AcceptorImpl acceptor;
 
+  public ServerBridge(final CacheServer cacheServer) {
+    this((CacheServerImpl) cacheServer,
+        new MBeanStatsMonitor(ManagementStrings.SERVER_MONITOR.toLocalizedString()));
+  }
 
-  public ServerBridge(CacheServer cacheServer) {
-    this.monitor = new MBeanStatsMonitor(ManagementStrings.SERVER_MONITOR.toLocalizedString());
-    this.acceptor = ((CacheServerImpl) cacheServer).getAcceptor();
+  public ServerBridge(final CacheServerImpl cacheServer, final MBeanStatsMonitor monitor) {
+    this(cacheServer.getAcceptor(), monitor);
+  }
+
+  public ServerBridge(final AcceptorImpl acceptor, final MBeanStatsMonitor monitor) {
+    this.monitor = monitor;
+    this.acceptor = acceptor;
     initializeStats();
     startMonitor();
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/CacheServerBridgeClientMembershipRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/CacheServerBridgeClientMembershipRegressionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
+import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
+import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+/**
+ * Regression test that confirms bug GEODE-3407.
+ *
+ * <p>
+ * GEODE-3407: JMX and membership may deadlock on CacheFactory.getAnyInstance
+ */
+@Category(UnitTest.class)
+public class CacheServerBridgeClientMembershipRegressionTest {
+
+  private final AtomicBoolean after = new AtomicBoolean();
+  private final AtomicBoolean before = new AtomicBoolean();
+
+  private CacheServerBridge cacheServerBridge;
+
+  private ExecutorService synchronizing;
+  private ExecutorService blocking;
+  private CountDownLatch latch;
+
+  private InternalCache cache;
+  private CacheServerImpl cacheServer;
+  private AcceptorImpl acceptor;
+  private MBeanStatsMonitor monitor;
+
+  @Before
+  public void setUp() throws Exception {
+    this.synchronizing = Executors.newSingleThreadExecutor();
+    this.blocking = Executors.newSingleThreadExecutor();
+    this.latch = new CountDownLatch(1);
+
+    this.cache = mock(InternalCache.class);
+    this.cacheServer = mock(CacheServerImpl.class);
+    this.acceptor = mock(AcceptorImpl.class);
+    this.monitor = mock(MBeanStatsMonitor.class);
+
+    when(cache.getQueryService()).thenReturn(mock(QueryService.class));
+    when(acceptor.getStats()).thenReturn(mock(CacheServerStats.class));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (latch.getCount() > 0) {
+      latch.countDown();
+    }
+  }
+
+  @Test
+  public void getNumSubscriptionsDeadlocksOnCacheFactory() throws Exception {
+    givenCacheFactoryIsSynchronized();
+    givenCacheServerBridge();
+
+    blocking.execute(() -> {
+      try {
+        before.set(true);
+
+        // getNumSubscriptions -> getClientQueueSizes -> synchronizes on CacheFactory
+        cacheServerBridge.getNumSubscriptions();
+
+      } catch (CacheClosedException ignored) {
+      } finally {
+        after.set(true);
+      }
+    });
+
+    await().atMost(10, SECONDS).until(() -> before.get());
+
+    // if deadlocked, then this line will throw ConditionTimeoutException
+    await().atMost(10, SECONDS).until(() -> assertThat(after.get()).isTrue());
+  }
+
+  private void givenCacheFactoryIsSynchronized() {
+    synchronizing.execute(() -> {
+      synchronized (CacheFactory.class) {
+        try {
+          latch.await(2, MINUTES);
+        } catch (InterruptedException e) {
+          throw new AssertionError(e);
+        }
+      }
+    });
+  }
+
+  private void givenCacheServerBridge() {
+    cacheServerBridge = new CacheServerBridge(cache, cacheServer, acceptor, monitor);
+  }
+
+}


### PR DESCRIPTION
Change InternalClientMembership to not synchronize on CacheFactory
by accepting Cache parameter from CacheServerBridge.

New regression test confirms bug and this fix.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
