### PR TITLE
GEODE-3328 Properties to set Key/Trust Store Type for SSL configurati…

### DIFF
--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -101,6 +101,9 @@ any protocol that is enabled by default in the configured JSSE provider.</dd>
 <dt>**ssl-truststore, ssl-truststore-password**</dt>
 <dd>The path to the trust store and the trust store password, specified as strings</dd>
 
+<dt>**ssl-keystore-type, ssl-truststore-type**</dt>
+<dd>The types of the key store and trust store, specified as strings. The default for both is "JKS", indicating a Java key store or trust store.</dd>
+
 ### Example: secure communications throughout
 
 To implement secure SSL communications throughout an entire distributed system, each process should

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -653,6 +653,13 @@ Any security-related (properties that begin with <code class="ph codeph">securit
 <td></td>
 </tr>
 
+<tr>
+<td>ssl-keystore-type, ssl-truststore-type</td>
+<td>Strings. Type of key store or trust store. "JKS" indicates Java. One common alternative is "pkcs12".</td>
+<td>S, L</td>
+<td>JKS</td>
+</tr>
+
 <tr class="even">
 <td>start-dev-rest-api</td>
 <td>If set to true, then the developer REST API service will be started when cache is created. REST service can be configured using <code class="ph codeph">http-service-port</code> and <code class="ph codeph">http-service-bind-address</code> properties.</td>


### PR DESCRIPTION
…on - add to docs

Added documentation for ssl-keystore-type and ssl-truststore-type to the user manual in two locations: Implementing SSL and the Properties Reference. 
