### PR TITLE
GEODE-3300: Complete and expose parallel export feature for use

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/snapshot/RegionSnapshotService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/snapshot/RegionSnapshotService.java
@@ -31,10 +31,22 @@ import org.apache.geode.pdx.PdxSerializer;
  * RegionSnapshot snapshot = region.getSnapshotService();
  * 
  * // export the snapshot, every region in the cache will be exported
- * snapshot.save(new File("snapshot"), SnapshotOptions.GEMFIRE);
+ * snapshot.save(new File("snapshot.gfd"), SnapshotOptions.GEMFIRE);
  * 
  * // import the snapshot file, updates any existing entries in the region
- * snapshot.load(new File("snapshot"), SnapshotOptions.GEMFIRE);
+ * snapshot.load(new File("snapshot.gfd"), SnapshotOptions.GEMFIRE);
+ * </pre>
+ *
+ *
+ * When parallel export is used, the file name will be modified to include a unique identifier for
+ * the member that created the file, so providing a file location of "snapshot.gfd" would result in
+ * creation of multiple files with the format "snapshot-unique_id.gfd". When loading files from a
+ * parallel export, a directory can be given instead of a single file and all snapshot files in that
+ * directory will be loaded.
+ * 
+ * <pre>
+ * // import directory of snapshot files
+ * snapshot.load(new File("snapshotDir"), SnapshotOptions.GEMFIRE);
  * </pre>
  * 
  * The default behavior is to perform all I/O operations on the node where the snapshot operations
@@ -53,7 +65,7 @@ import org.apache.geode.pdx.PdxSerializer;
  * SnapshotOptions<Object, Object> options = snapshot.createOptions();
  * options.setFilter(filter);
  * 
- * snapshot.save(new File("snapshot"), SnapshotFormat.GEMFIRE, options);
+ * snapshot.save(new File("snapshot.gfd"), SnapshotFormat.GEMFIRE, options);
  * </pre>
  * 
  * Note that the snapshot does not provide a consistency guarantee. Updates to data during the
@@ -68,6 +80,12 @@ import org.apache.geode.pdx.PdxSerializer;
  * @since GemFire 7.0
  */
 public interface RegionSnapshotService<K, V> {
+
+  /**
+   * File extension for snapshot files
+   */
+  public static final String SNAPSHOT_FILE_EXTENSION = ".gfd";
+
   /**
    * Creates a <code>SnapshotOptions</code> object configured with default settings. The options can
    * be used to configure snapshot behavior.
@@ -79,7 +97,7 @@ public interface RegionSnapshotService<K, V> {
   /**
    * Exports the region data into the snapshot file.
    * 
-   * @param snapshot the snapshot file
+   * @param snapshot the snapshot file (must end in .gfd)
    * @param format the snapshot format
    * 
    * @throws IOException error writing snapshot
@@ -89,7 +107,7 @@ public interface RegionSnapshotService<K, V> {
   /**
    * Exports the region data into the snapshot file by applying user-configured options.
    * 
-   * @param snapshot the snapshot file
+   * @param snapshot the snapshot file (must end in .gfd)
    * @param format the snapshot format
    * @param options the snapshot options
    * 
@@ -98,13 +116,16 @@ public interface RegionSnapshotService<K, V> {
   void save(File snapshot, SnapshotFormat format, SnapshotOptions<K, V> options) throws IOException;
 
   /**
-   * Imports the snapshot file into the specified region.
+   * Imports the snapshot file into the specified region. The snapshot parameter can be either a
+   * single snapshot file or a directory containing snapshot files. If a single file, it must end in
+   * the snapshot file extension (.gfd) to be imported. If a directory, only files in the directory
+   * that end in .gfd will be loaded.
    * <p>
    * Prior to loading data, the region should have been created and any necessary serializers
    * (either {@link DataSerializer} or {@link PdxSerializer}) and {@link Instantiator}s should have
    * been registered.
    * 
-   * @param snapshot the snapshot file
+   * @param snapshot the snapshot file (ending in .gfd) or a directory of .gfd snapshot files
    * @param format the snapshot file format
    * 
    * @throws IOException Unable to import data
@@ -113,13 +134,16 @@ public interface RegionSnapshotService<K, V> {
   void load(File snapshot, SnapshotFormat format) throws IOException, ClassNotFoundException;
 
   /**
-   * Imports the snapshot file into the specified region by applying user- configured options.
+   * Imports the snapshot file into the specified region by applying user-configured options. The
+   * snapshot parameter can be either a single snapshot file or a directory containing snapshot
+   * files. If a single file, it must end in the snapshot file extension (.gfd) to be imported. If a
+   * directory, only files in the directory that end in .gfd will be loaded.
    * <p>
    * Prior to loading data, the region should have been created and any necessary serializers
    * (either {@link DataSerializer} or {@link PdxSerializer}) and {@link Instantiator}s should have
    * been registered.
    * 
-   * @param snapshot the snapshot file
+   * @param snapshot the snapshot file (ending in .gfd) or a directory of .gfd snapshot files
    * @param format the snapshot file format
    * @param options the snapshot options
    * 

--- a/geode-core/src/main/java/org/apache/geode/cache/snapshot/SnapshotOptions.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/snapshot/SnapshotOptions.java
@@ -16,6 +16,8 @@ package org.apache.geode.cache.snapshot;
 
 import java.io.Serializable;
 
+import org.apache.geode.internal.cache.snapshot.SnapshotFileMapper;
+
 /**
  * Provides a way to configure the behavior of snapshot operations. The default options are:
  * <dl>
@@ -34,7 +36,7 @@ public interface SnapshotOptions<K, V> extends Serializable {
    * 
    * @since GemFire 7.0
    */
-  public enum SnapshotFormat {
+  enum SnapshotFormat {
     /** an optimized binary format specific to GemFire */
     GEMFIRE
   }
@@ -71,4 +73,32 @@ public interface SnapshotOptions<K, V> extends Serializable {
    * @return whether loading a snapshot causes callbacks to be invoked
    */
   boolean shouldInvokeCallbacks();
+
+  /**
+   * Returns true if the snapshot operation will proceed in parallel.
+   *
+   * @return true if the parallel mode has been enabled
+   *
+   * @since Geode 1.3
+   */
+  boolean isParallelMode();
+
+  /**
+   * Enables parallel mode for snapshot export, which will cause each member of a partitioned region
+   * to save its local data set (ignoring redundant copies) to a separate snapshot file.
+   *
+   * <p>
+   * Parallelizing snapshot operations may yield significant performance improvements for large data
+   * sets. This is particularly true when each member is writing to separate physical disks.
+   * <p>
+   * This flag is ignored for replicated regions.
+   *
+   * @param parallel true if the snapshot operations will be performed in parallel
+   * @return the snapshot options
+   *
+   * @see SnapshotFileMapper
+   *
+   * @since Geode 1.3
+   */
+  SnapshotOptions<K, V> setParallelMode(boolean parallel);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ParallelSnapshotFileMapper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ParallelSnapshotFileMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.snapshot;
+
+import java.io.File;
+
+import org.apache.logging.log4j.LogManager;
+
+import org.apache.geode.cache.snapshot.RegionSnapshotService;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+
+public class ParallelSnapshotFileMapper implements SnapshotFileMapper {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public File mapExportPath(DistributedMember member, File snapshot) {
+    String baseName = getBaseName(snapshot);
+    String memberUniqueId = createUniqueId((InternalDistributedMember) member);
+    String fullName =
+        baseName + "-" + memberUniqueId + RegionSnapshotService.SNAPSHOT_FILE_EXTENSION;
+    return new File(snapshot.getParentFile(), fullName);
+  }
+
+
+  @Override
+  public File[] mapImportPath(DistributedMember member, File snapshot) {
+    // parallel import is not yet supported
+    throw new UnsupportedOperationException();
+  }
+
+  private String getBaseName(File snapshot) {
+    String filename = snapshot.getName();
+    int suffixLocation = filename.indexOf(RegionSnapshotService.SNAPSHOT_FILE_EXTENSION);
+    if (suffixLocation < 0) {
+      throw new IllegalArgumentException(
+          "Snapshot file '" + filename + "' missing backup file extension (.gfd)");
+    }
+    return filename.substring(0, suffixLocation);
+  }
+
+  /**
+   * Combines the ip address and port of a distributed member to create a unique identifier for the
+   * member. As this string will be used in file names, the periods (ipv4) and colons (ipv6) are
+   * stripped out.
+   * 
+   * @param member the member to create a unique id for
+   * @return a String based on the ip address and host of the member
+   */
+  private String createUniqueId(InternalDistributedMember member) {
+    String address = member.getInetAddress().getHostAddress();
+    String alphanumericAddress = address.replaceAll("\\.|:", "");
+    int port = member.getPort();
+    return alphanumericAddress + port;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -338,6 +338,10 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
 
   private void exportOnMember(File snapshot, SnapshotFormat format, SnapshotOptions<K, V> options)
       throws IOException {
+    if (!snapshot.getName().endsWith(SNAPSHOT_FILE_EXTENSION)) {
+      throw new IllegalArgumentException("Failure to export snapshot: "
+          + snapshot.getCanonicalPath() + " is not a valid .gfd file");
+    }
     LocalRegion local = getLocalRegion(region);
     Exporter<K, V> exp = createExporter(region, options);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl.java
@@ -66,53 +66,21 @@ public class SnapshotOptionsImpl<K, V> implements SnapshotOptions<K, V> {
     return this.invokeCallbacks;
   }
 
-  /**
-   * Enables parallel mode for snapshot operations. This will cause each member of a partitioned
-   * region to save its local data set (ignoring redundant copies) to a separate snapshot file.
-   * During a parallel import, each member may read from one or more snapshot files created during a
-   * parallel export.
-   * <p>
-   * Parallelizing snapshot operations may yield significant performance improvements for large data
-   * sets. This is particularly true when each member is reading from or writing to separate
-   * physical disks.
-   * <p>
-   * This flag is ignored for replicated regions.
-   * <p>
-   * If the mapper is not set explicitly, a default mapping implementation is used that assumes each
-   * member can access a non-shared disk volume. The default mapper provides the following behavior:
-   * <dl>
-   * <dt>export</dt>
-   * <dd>use the supplied path</dd>
-   * <dt>import</dt>
-   * <dd>if the supplied path is a file, use that file</dd>
-   * <dd>if the supplied path is a directory, use all files in the directory</dd>
-   * </dl>
-   * If processes are colocated on the same machine and relative pathnames are not used, a custom
-   * mapper <b>must</b> be supplied to disambiguate filenames. This rule applies when writing to a
-   * shared network volume as well.
-   * 
-   * @param parallel true if the snapshot operations will be performed in parallel
-   * @return the snapshot options
-   * 
-   * @see SnapshotFileMapper
-   */
+
+  @Override
   public SnapshotOptions<K, V> setParallelMode(boolean parallel) {
     this.parallel = parallel;
     return this;
   }
 
-  /**
-   * Returns true if the snapshot operation will proceed in parallel.
-   * 
-   * @return true if the parallel mode has been enabled
-   */
+  @Override
   public boolean isParallelMode() {
     return parallel;
   }
 
   /**
    * Overrides the default file mapping for parallel import and export operations.
-   * 
+   *
    * @param mapper the custom mapper, or null to use the default mapping
    * @return the snapshot options
    * @see #setParallelMode(boolean)
@@ -124,11 +92,15 @@ public class SnapshotOptionsImpl<K, V> implements SnapshotOptions<K, V> {
 
   /**
    * Returns the snapshot file mapper for parallel import and export.
-   * 
+   *
    * @return the mapper
    * @see #setParallelMode(boolean)
    */
   public SnapshotFileMapper getMapper() {
-    return (mapper == null) ? RegionSnapshotServiceImpl.LOCAL_MAPPER : mapper;
+    if (mapper == null) {
+      mapper = isParallelMode() ? new ParallelSnapshotFileMapper()
+          : RegionSnapshotServiceImpl.LOCAL_MAPPER;
+    }
+    return mapper;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl.java
@@ -103,4 +103,13 @@ public class SnapshotOptionsImpl<K, V> implements SnapshotOptions<K, V> {
     }
     return mapper;
   }
+
+  @Override
+  public String toString() {
+    StringBuffer buf = new StringBuffer();
+    buf.append("SnapshotOptionsImpl@").append(System.identityHashCode(this)).append(": ")
+        .append("parallel=").append(parallel).append("; invokeCallbacks=").append(invokeCallbacks)
+        .append("; filter=").append(filter).append("; mapper=").append(mapper);
+    return buf.toString();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/CacheSnapshotJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/CacheSnapshotJUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.snapshot;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.util.Map.Entry;
 
 import org.junit.Test;
@@ -80,19 +79,11 @@ public class CacheSnapshotJUnitTest extends SnapshotTestCase {
       }
     }
 
-    SnapshotFilter<Object, Object> even = new SnapshotFilter<Object, Object>() {
-      @Override
-      public boolean accept(Entry<Object, Object> entry) {
-        return ((Integer) entry.getKey()) % 2 == 0;
-      }
-    };
+    SnapshotFilter<Object, Object> even =
+        (SnapshotFilter<Object, Object>) entry -> ((Integer) entry.getKey()) % 2 == 0;
 
-    SnapshotFilter<Object, Object> odd = new SnapshotFilter<Object, Object>() {
-      @Override
-      public boolean accept(Entry<Object, Object> entry) {
-        return ((Integer) entry.getKey()) % 2 == 1;
-      }
-    };
+    SnapshotFilter<Object, Object> odd =
+        (SnapshotFilter<Object, Object>) entry -> ((Integer) entry.getKey()) % 2 == 1;
 
     // save even entries
     CacheSnapshotService css = cache.getSnapshotService();
@@ -108,12 +99,7 @@ public class CacheSnapshotJUnitTest extends SnapshotTestCase {
     }
 
     // load odd entries
-    File[] snapshots = snaps.listFiles(new FileFilter() {
-      @Override
-      public boolean accept(File pathname) {
-        return pathname.getName().startsWith("snapshot-");
-      }
-    });
+    File[] snapshots = snaps.listFiles(pathname -> pathname.getName().startsWith("snapshot-"));
 
     options = css.createOptions().setFilter(odd);
     css.load(snapshots, SnapshotFormat.GEMFIRE, options);

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/RegionSnapshotJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/RegionSnapshotJUnitTest.java
@@ -280,6 +280,6 @@ public class RegionSnapshotJUnitTest extends SnapshotTestCase {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    f = new File(snaps, "test.snapshot");
+    f = new File(snaps, "test.snapshot.gfd");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotByteArrayDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotByteArrayDUnitTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.test.dunit.SerializableCallable;
 
 @Category(DistributedTest.class)
 public class SnapshotByteArrayDUnitTest extends JUnit4CacheTestCase {
-  private final File snap = new File("snapshot-ops");
+  private final File snap = new File("snapshot-ops.gfd");
 
   public SnapshotByteArrayDUnitTest() {
     super();

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotDUnitTest.java
@@ -20,6 +20,7 @@ import org.apache.geode.cache.asyncqueue.AsyncEvent;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueueFactory;
+
 import org.awaitility.Awaitility;
 import org.junit.experimental.categories.Category;
 import org.junit.Test;
@@ -119,7 +120,7 @@ public class SnapshotDUnitTest extends JUnit4CacheTestCase {
     CacheSnapshotService service = getCache().getSnapshotService();
     service.save(dir, SnapshotFormat.GEMFIRE);
 
-    // update regions with data to be overwritten by import
+    // update regions with data to be overwritten by importdir
     updateRegions();
 
     SerializableCallable callbacks = new SerializableCallable() {

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotPerformanceDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotPerformanceDUnitTest.java
@@ -77,7 +77,7 @@ public class SnapshotPerformanceDUnitTest extends JUnit4CacheTestCase {
   }
 
   private void doExport(Region<Integer, MyObject> region) throws Exception {
-    File f = new File(getDiskDirs()[0], region.getName());
+    File f = new File(getDiskDirs()[0], region.getName() + ".gfd");
 
     long start = System.currentTimeMillis();
     region.getSnapshotService().save(f, SnapshotFormat.GEMFIRE);
@@ -96,7 +96,7 @@ public class SnapshotPerformanceDUnitTest extends JUnit4CacheTestCase {
   }
 
   private void doImport(Region<Integer, MyObject> region) throws Exception {
-    File f = new File(getDiskDirs()[0], region.getName());
+    File f = new File(getDiskDirs()[0], region.getName() + ".gfd");
 
     long start = System.currentTimeMillis();
     region.getSnapshotService().load(f, SnapshotFormat.GEMFIRE);

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/TestSnapshotFileMapper.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/TestSnapshotFileMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.snapshot;
+
+import java.io.File;
+
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.snapshot.SnapshotFileMapper;
+import org.apache.geode.test.dunit.VM;
+
+public class TestSnapshotFileMapper implements SnapshotFileMapper {
+  private volatile boolean shouldExplode;
+
+  public void setShouldExplode(boolean shouldExplode) {
+    this.shouldExplode = shouldExplode;
+  }
+
+  @Override
+  public File mapExportPath(DistributedMember member, File snapshot) {
+    if (shouldExplode) {
+      throw new RuntimeException();
+    }
+    return new File(snapshot.getParentFile(), mapFilename(snapshot));
+  }
+
+  @Override
+  public File[] mapImportPath(DistributedMember member, File snapshot) {
+    if (shouldExplode) {
+      throw new RuntimeException();
+    }
+
+    File f = new File(snapshot.getParentFile(), mapFilename(snapshot));
+    return new File[] {f};
+  }
+
+  private String mapFilename(File snapshot) {
+    String filename = snapshot.getName();
+    int suffixLocation = filename.indexOf(RegionSnapshotService.SNAPSHOT_FILE_EXTENSION);
+    return filename.substring(0, suffixLocation) + "-" + VM.getCurrentVMNum()
+        + RegionSnapshotService.SNAPSHOT_FILE_EXTENSION;
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/WanSnapshotJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/WanSnapshotJUnitTest.java
@@ -46,7 +46,7 @@ public class WanSnapshotJUnitTest extends SnapshotTestCase {
       region.put(i, new MyObject(i, "clienttest " + i));
     }
 
-    File snapshot = new File("wan.snapshot");
+    File snapshot = new File("wan.snapshot.gfd");
     region.getSnapshotService().save(snapshot, SnapshotFormat.GEMFIRE);
     region.clear();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
@@ -123,7 +123,7 @@ public class GFSnapshotDUnitTest extends JUnit4DistributedTestCase {
   private void iterateOverSnapshot(final String snapshotFilePath)
       throws IOException, ClassNotFoundException {
 
-    File mySnapshot = new File(snapshotFilePath + "/snapshot-TestRegion");
+    File mySnapshot = new File(snapshotFilePath + "/snapshot-TestRegion.gfd");
     SnapshotIterator<Integer, TestObject> snapshotIterator = SnapshotReader.read(mySnapshot);
 
     Map<Integer, TestObject> result = new TreeMap<>();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/snapshot/ParallelSnapshotFileMapperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/snapshot/ParallelSnapshotFileMapperTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.snapshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class ParallelSnapshotFileMapperTest {
+  private static final int PORT = 1234;
+  private static final String BASE_LOCATION = "/test/snapshot";
+  private static final String FILE_TYPE = ".gfd";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private SnapshotFileMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ParallelSnapshotFileMapper();
+  }
+
+  @Test
+  public void mapExportPathWithIpv4() throws UnknownHostException {
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    when(member.getInetAddress()).thenReturn(InetAddress.getByName("127.0.0.1"));
+    when(member.getPort()).thenReturn(PORT);
+    File mappedFile = mapper.mapExportPath(member, new File(BASE_LOCATION + FILE_TYPE));
+    File expectedFile = new File(BASE_LOCATION + "-" + 1270011234 + FILE_TYPE);
+    assertEquals(expectedFile, mappedFile);
+  }
+
+  @Test
+  public void mapExportPathWithIpv6() throws UnknownHostException {
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    when(member.getInetAddress()).thenReturn(InetAddress.getByName("2001:db8::2"));
+    when(member.getPort()).thenReturn(PORT);
+    File mappedFile = mapper.mapExportPath(member, new File(BASE_LOCATION + FILE_TYPE));
+    // db8 == db800000
+    File expectedFile = new File(BASE_LOCATION + "-" + "2001db80000021234" + FILE_TYPE);
+    assertEquals(expectedFile, mappedFile);
+  }
+
+  @Test
+  public void mapImportPathIsUnsupported() throws Exception {
+    thrown.expect(UnsupportedOperationException.class);
+    mapper.mapImportPath(null, null);
+  }
+
+  @Test
+  public void filesWithoutCorrectExtensionGiveUsefulException() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    mapper.mapExportPath(null, new File(BASE_LOCATION));
+  }
+}

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedSerializables.txt
@@ -249,7 +249,6 @@ org/apache/geode/internal/SystemAdmin$CombinedResources,false
 org/apache/geode/internal/admin/CompoundEntrySnapshot,true,5776382582897895718,allUserAttributes:java/util/Set,allValues:java/util/Set,hitRatio:float,hitRatioSum:double,hitResponders:long,lastAccessTime:long,lastModifiedTime:long,name:java/lang/Object,numHits:long,numMisses:long
 org/apache/geode/internal/admin/CompoundRegionSnapshot,true,6295026394298398004,allCacheLoaders:java/util/Set,allCacheWriters:java/util/Set,allCapControllers:java/util/Set,allConcLevels:java/util/Set,allCustomIdle:java/util/HashSet,allCustomTtl:java/util/HashSet,allDataPolicies:java/util/Set,allEntryIdleTimeout:java/util/Set,allEntryTtl:java/util/Set,allInitialCaps:java/util/Set,allKeyConstraints:java/util/Set,allListeners:java/util/Set,allLoadFactors:java/util/Set,allRegionIdleTimeout:java/util/Set,allRegionTtl:java/util/Set,allScopes:java/util/Set,allStatsEnabled:java/util/Set,allUserAttributes:java/util/Set,allValueConstraints:java/util/Set,hitRatio:float,hitRatioSum:double,hitResponders:long,lastAccessTime:long,lastModifiedTime:long,name:java/lang/String,numHits:long,numMisses:long
 org/apache/geode/internal/admin/StatAlert,true,5725457607122449170,definitionId:int,time:java/util/Date,values:java/lang/Number[]
-org/apache/geode/internal/admin/remote/DistributionLocatorId,true,6587390186971937865,bindAddress:java/lang/String,host:java/net/InetAddress,hostnameForClients:java/lang/String,peerLocator:boolean,port:int,serverLocator:boolean
 org/apache/geode/internal/admin/remote/EntryValueNodeImpl,false,fields:org/apache/geode/internal/admin/remote/EntryValueNodeImpl[],name:java/lang/String,primitive:boolean,primitiveVal:java/lang/Object,type:java/lang/String
 org/apache/geode/internal/cache/BucketAdvisor$SetFromMap,true,2454657854757543876,m:java/util/Map
 org/apache/geode/internal/cache/BucketNotFoundException,true,2898657229184289911
@@ -328,6 +327,7 @@ org/apache/geode/internal/cache/persistence/OplogType,false,prefix:java/lang/Str
 org/apache/geode/internal/cache/persistence/PersistentMemberState,false
 org/apache/geode/internal/cache/snapshot/ClientExporter$ClientArgs,true,1,options:org/apache/geode/cache/snapshot/SnapshotOptions,prSingleHop:boolean,region:java/lang/String
 org/apache/geode/internal/cache/snapshot/ClientExporter$ProxyExportFunction,true,1
+org/apache/geode/internal/cache/snapshot/DefaultSnapshotFileMapper,false
 org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl$1,true,1
 org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl$ParallelArgs,true,1,file:java/io/File,format:org/apache/geode/cache/snapshot/SnapshotOptions$SnapshotFormat,options:org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl
 org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl$ParallelExportFunction,false

--- a/geode-cq/src/test/java/org/apache/geode/cache/snapshot/ClientSnapshotDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/snapshot/ClientSnapshotDUnitTest.java
@@ -71,7 +71,7 @@ public class ClientSnapshotDUnitTest extends JUnit4CacheTestCase {
     SerializableCallable export = new SerializableCallable() {
       @Override
       public Object call() throws Exception {
-        File f = new File(getDiskDirs()[0], "client-export.snapshot");
+        File f = new File(getDiskDirs()[0], "client-export.snapshot.gfd");
         Region<Integer, MyObject> r = getCache().getRegion("clienttest");
 
         r.getSnapshotService().save(f, SnapshotFormat.GEMFIRE);
@@ -104,7 +104,7 @@ public class ClientSnapshotDUnitTest extends JUnit4CacheTestCase {
     SerializableCallable export = new SerializableCallable() {
       @Override
       public Object call() throws Exception {
-        File f = new File(getDiskDirs()[0], "client-import.snapshot");
+        File f = new File(getDiskDirs()[0], "client-import.snapshot.gfd");
         Region<Integer, MyObject> r = getCache().getRegion("clienttest");
 
         r.getSnapshotService().save(f, SnapshotFormat.GEMFIRE);
@@ -135,7 +135,7 @@ public class ClientSnapshotDUnitTest extends JUnit4CacheTestCase {
             r.getRegionService().getQueryService().newCq("SELECT * FROM /clienttest", af.create());
         cq.execute();
 
-        File f = new File(getDiskDirs()[0], "client-import.snapshot");
+        File f = new File(getDiskDirs()[0], "client-import.snapshot.gfd");
         r.getSnapshotService().load(f, SnapshotFormat.GEMFIRE);
 
         return cqtest.get();
@@ -174,7 +174,7 @@ public class ClientSnapshotDUnitTest extends JUnit4CacheTestCase {
       region.put(i, new MyObject(i, "clienttest " + i));
     }
 
-    File f = new File(getDiskDirs()[0], "client-callback.snapshot");
+    File f = new File(getDiskDirs()[0], "client-callback.snapshot.gfd");
     region.getSnapshotService().save(f, SnapshotFormat.GEMFIRE);
 
     for (int i = 0; i < count; i++) {
@@ -232,7 +232,7 @@ public class ClientSnapshotDUnitTest extends JUnit4CacheTestCase {
         r.put(1, new MyObject(1, "invalidate"));
         r.invalidate(1);
 
-        File f = new File(getDiskDirs()[0], "client-invalidate.snapshot");
+        File f = new File(getDiskDirs()[0], "client-invalidate.snapshot.gfd");
         r.getSnapshotService().save(f, SnapshotFormat.GEMFIRE);
         r.getSnapshotService().load(f, SnapshotFormat.GEMFIRE);
 


### PR DESCRIPTION
This change exposes parallel export of snapshots. It provides a filename mapper for parallel exports that gives each snapshot file a unique names based on the host it was created on. It also enforces to use of the .gfd extension for snapshot files and allows for a directory of snapshot files to be imported together. Once this change is merged, additional work is required to update gfsh to support the commands necessary to allow users to make use of the parallel export feature.