### PR TITLE
GEODE-3055: Should use a conservative fix to only catch the Partition…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -21,6 +21,7 @@ import org.apache.geode.cache.Region.Entry;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.persistence.PartitionOfflineException;
 import org.apache.geode.cache.query.QueryInvalidException;
 import org.apache.geode.cache.query.internal.QCompiler;
 import org.apache.geode.cache.query.internal.index.IndexCreationData;
@@ -493,7 +494,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
 
       return result;
 
-    } catch (RuntimeException validationException) {
+    } catch (PartitionOfflineException validationException) {
       // GEODE-3055
       PartitionedRegion leader = ColocationHelper.getLeaderRegion(this.partitionedRegion);
       boolean isLeader = leader.equals(this.partitionedRegion);


### PR DESCRIPTION
…OfflineEx

to remove the leader region bucket.

Previous fix to catch all RuntimeException is too aggressive.

@upthewaterspout @dschneider-pivotal @agingade 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
