### PR TITLE
GEODE-3474: protobuf auth with ExampleSecurityManager

### DIFF
--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/ProtobufSimpleAuthenticator.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/ProtobufSimpleAuthenticator.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.protocol.protobuf;
 
+import org.apache.geode.management.internal.security.ResourceConstants;
 import org.apache.geode.security.StreamAuthenticator;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.SecurityManager;
@@ -37,8 +38,8 @@ public class ProtobufSimpleAuthenticator implements StreamAuthenticator {
     }
 
     Properties properties = new Properties();
-    properties.setProperty("username", authenticationRequest.getUsername());
-    properties.setProperty("password", authenticationRequest.getPassword());
+    properties.setProperty(ResourceConstants.USER_NAME, authenticationRequest.getUsername());
+    properties.setProperty(ResourceConstants.PASSWORD, authenticationRequest.getPassword());
 
     try {
       Object principal = securityManager.authenticate(properties);


### PR DESCRIPTION
It looks like we were using the wrong constants for the username and password strings; ExampleSecurityManager uses some defined constants that look more canonical.


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
