### PR TITLE
Don't download geode 1.2 every time a build runs

### DIFF
--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -43,11 +43,13 @@ def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   task "downloadZipFile${source}" (type: Download) {
     src "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/$geodeVersion/apache-geode-${geodeVersion}.tar.gz"
     dest new File(buildDir, "apache-geode-${geodeVersion}.tar.gz")
+    overwrite false
   }
 
   task "downloadSHA${source}" (type: Download) {
     src "https://www.apache.org/dist/geode/${geodeVersion}/apache-geode-${geodeVersion}.tar.gz.sha256"
     dest new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256")
+    overwrite false
   }
 
 


### PR DESCRIPTION
Setting the overwrite flag on the download tasks to false so that we
don't download the old version of geode for every build.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@boglesby @metatype 
