### PR TITLE
Keeping old versions around even during a clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ out/
 *.rej
 *.orig
 geode-pulse/screenshots/
+geode-old-versions/old-versions

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -38,39 +38,46 @@ def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   dependencies.add "${source}Compile", "org.apache.geode:geode-cq:$geodeVersion"
   dependencies.add "${source}Compile", "org.apache.geode:geode-rebalancer:$geodeVersion"
 
-  project.ext.installs.setProperty(source, "$buildDir/apache-geode-${geodeVersion}")
-
-  task "downloadZipFile${source}" (type: Download) {
-    src "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/$geodeVersion/apache-geode-${geodeVersion}.tar.gz"
-    def destFile = new File(buildDir, "apache-geode-${geodeVersion}.tar.gz")
-    dest destFile
-    onlyIf {!destFile.exists()}
-  }
-
-  task "downloadSHA${source}" (type: Download) {
-    src "https://www.apache.org/dist/geode/${geodeVersion}/apache-geode-${geodeVersion}.tar.gz.sha256"
-    def destFile =  new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256")
-    dest destFile
-    onlyIf {!destFile.exists()}
-  }
-
-
-  task "verifyGeode${source}" (type: de.undercouch.gradle.tasks.download.Verify, dependsOn: [tasks["downloadSHA${source}"], tasks["downloadZipFile${source}"]]) {
-    src tasks["downloadZipFile${source}"].dest
-    algorithm "SHA-256"
-    doFirst {
-      checksum new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256").text.split(' ')[0]
-    }
-  }
-
-  task "downloadAndUnzipFile${source}" (dependsOn: "verifyGeode${source}", type: Copy) {
-    from tarTree(tasks["downloadZipFile${source}"].dest)
-    into buildDir
-  }
+  String oldVersionDir = "old-versions"
 
   if (downloadInstall) {
+
+    File installDir = file("$oldVersionDir/apache-geode-${geodeVersion}")
+    project.ext.installs.setProperty(source, installDir.absolutePath)
+
+    task "downloadZipFile${source}" (type: Download) {
+      src "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/$geodeVersion/apache-geode-${geodeVersion}.tar.gz"
+      def destFile = new File(buildDir, "apache-geode-${geodeVersion}.tar.gz")
+      dest destFile
+      onlyIf {!installDir.exists()}
+    }
+
+    task "downloadSHA${source}" (type: Download) {
+      src "https://www.apache.org/dist/geode/${geodeVersion}/apache-geode-${geodeVersion}.tar.gz.sha256"
+      def destFile =  new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256")
+      dest destFile
+      onlyIf {!installDir.exists()}
+    }
+
+
+    task "verifyGeode${source}" (type: de.undercouch.gradle.tasks.download.Verify, dependsOn: [tasks["downloadSHA${source}"], tasks["downloadZipFile${source}"]]) {
+      src tasks["downloadZipFile${source}"].dest
+      algorithm "SHA-256"
+      doFirst {
+        checksum new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256").text.split(' ')[0]
+      }
+      onlyIf {!installDir.exists()}
+    }
+
+    task "downloadAndUnzipFile${source}" (dependsOn: "verifyGeode${source}", type: Copy) {
+      from tarTree(tasks["downloadZipFile${source}"].dest)
+      into file('old-versions')
+      onlyIf {!installDir.exists()}
+    }
+
     createGeodeClasspathsFile.dependsOn tasks["downloadAndUnzipFile${source}"]
   }
+
 }
 
 def generatedResources = "$buildDir/generated-resources/main"

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -45,6 +45,9 @@ rat {
     'geode-examples/gradlew*/**',
     'geode-examples/gradle/wrapper/**',
 
+    //Downloaded old versions
+    'geode-old-versions/old-versions/**',
+
     // IDE
     'etc/eclipse-java-google-style.xml',
     'etc/intellij-java-modified-google-style.xml',


### PR DESCRIPTION
Putting old versions of geode in a separate directory so they are not
removed during a clean.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@jhuynh1 @kohlmu-pivotal 