### PR TITLE
GEODE-3506: improve validation/error checking for process file control

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/FileProcessController.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/FileProcessController.java
@@ -149,7 +149,7 @@ class FileProcessController implements ProcessController {
 
     String lines = statusRef.get();
     if (isBlank(lines)) {
-      throw new IllegalStateException("Failed to read status file");
+      throw new IllegalStateException("Status file '" + statusFile + "' is blank");
     }
     return lines;
   }


### PR DESCRIPTION
We only ever hit this failure once and I don't think it's a flaky test. This could actually be one more (last remaining?) root cause of "start locator" or "start server" hanging-while-printing-dots in GFSH. 

I've added what I consider to be excessive validation and error checking but it should point us at the cause if this check in FileProcessController ever fails again:

    if (isBlank(lines)) {
      throw new IllegalStateException("Status file '" + statusFile + "' is blank");
    }

In addition to this PR, we should consider adding more direct test coverage for ServiceState and its subclasses as well as more unit tests of the Launcher using mocks.