### PR TITLE
GEODE-3131: Increasing the time

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
@@ -355,8 +355,8 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void testRefCountForNormalAndGIIPut() throws Exception {
     // slow start for dispatcher
-    serverVM0.invoke(() -> ConflationDUnitTest.setIsSlowStart("30000"));
-    serverVM1.invoke(() -> ConflationDUnitTest.setIsSlowStart("30000"));
+    serverVM0.invoke(() -> ConflationDUnitTest.setIsSlowStart("240000"));
+    serverVM1.invoke(() -> ConflationDUnitTest.setIsSlowStart("240000"));
 
     createClientCache(getServerHostName(Host.getHost(0)), new Integer(PORT1), new Integer(PORT2),
         "1");


### PR DESCRIPTION
	* Increasing the time elapsed before the dispatchers are started.
	* All validations must be done before the dispatcher start dispatching.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
