### PR TITLE
GEODE-3522: create via load needs to add event to AEQ under same lock…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1304,6 +1304,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       throws TimeoutException, CacheWriterException {
     beginLocalWrite(event);
     try {
+      if (getPartitionedRegion().isParallelWanEnabled()) {
+        handleWANEvent(event);
+      }
       event.setInvokePRCallbacks(true);
       forceSerialized(event);
       return super.basicPutEntry(event, lastModified);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2197,12 +2197,6 @@ public class DistributedRegion extends LocalRegion implements CacheDistributionA
     validateKey(event.getKey());
     // this next step also distributes the object to other processes, if necessary
     try {
-      // set the tail key so that the event is passed to GatewaySender queues.
-      // if the tailKey is not set, the event gets filtered out in ParallelGatewaySenderQueue
-      if (this instanceof BucketRegion) {
-        if (((BucketRegion) this).getPartitionedRegion().isParallelWanEnabled())
-          ((BucketRegion) this).handleWANEvent(event);
-      }
       re = basicPutEntry(event, lastModified);
 
       // Update client event with latest version tag from re.


### PR DESCRIPTION
… as update to local region

* create via load was invoking handleWANEvent prior to obtaining a lock, which allowed rebalance to
  shift the primary between AEQ update and data region update.
* moved call to handleWANEvent from DistributedRegion to BucketRegion to synchronize these two actions.

@upthewaterspout, @boglesby

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
