### PR TITLE
GEODE-2719 : Deprecated setTotalMaxMemory and getTotalMaxMemory and updated their javadocs.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributes.java
@@ -79,7 +79,10 @@ public interface PartitionAttributes<K, V> {
    * Integer.MAX_VALUE.
    * 
    * @return maximum size of the partitioned region, in megabytes
+   *
+   * @deprecated since Geode 1.2.2
    */
+  @Deprecated
   public long getTotalMaxMemory();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributes.java
@@ -80,7 +80,7 @@ public interface PartitionAttributes<K, V> {
    * 
    * @return maximum size of the partitioned region, in megabytes
    *
-   * @deprecated since Geode 1.2.2
+   * @deprecated since Geode 1.3.0
    */
   @Deprecated
   public long getTotalMaxMemory();

--- a/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributesFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributesFactory.java
@@ -193,7 +193,10 @@ public class PartitionAttributesFactory<K, V> {
    * <p>
    * <em>This setting must be the same in all processes using the Region.</em> The default value is
    * Integer.MAX_VALUE.
+   *
+   * @deprecated since Geode 1.2.2
    */
+  @Deprecated
   public PartitionAttributesFactory<K, V> setTotalMaxMemory(long mb) {
     this.partitionAttributes.setTotalMaxMemory(mb);
     return this;

--- a/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributesFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/PartitionAttributesFactory.java
@@ -194,7 +194,7 @@ public class PartitionAttributesFactory<K, V> {
    * <em>This setting must be the same in all processes using the Region.</em> The default value is
    * Integer.MAX_VALUE.
    *
-   * @deprecated since Geode 1.2.2
+   * @deprecated since Geode 1.3.0
    */
   @Deprecated
   public PartitionAttributesFactory<K, V> setTotalMaxMemory(long mb) {


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
