### PR TITLE
GEODE-3544:JSON parsing failed for short data type & base class setter method is not used when key having base class property in it

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/JsonUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/JsonUtil.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.management.internal.cli.json.GfJsonArray;
 import org.apache.geode.management.internal.cli.json.GfJsonException;
@@ -149,7 +150,7 @@ public class JsonUtil {
     try {
       GfJsonObject jsonObject = new GfJsonObject(jsonString);
       objectFromJson = klass.newInstance();
-      Method[] declaredMethods = klass.getDeclaredMethods();
+      Method[] declaredMethods = klass.getMethods();
       Map<String, Method> methodsMap = new HashMap<String, Method>();
       for (Method method : declaredMethods) {
         methodsMap.put(method.getName(), method);
@@ -168,7 +169,8 @@ public class JsonUtil {
 
             Object value = jsonObject.get(key);
             if (isPrimitiveOrWrapper(parameterType)) {
-              value = getPrimitiveOrWrapperValue(parameterType, value);
+              value = ConvertUtils.convert(getPrimitiveOrWrapperValue(parameterType, value),
+                  parameterType);
             }
             // Bug #51175
             else if (isArray(parameterType)) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Bug3544JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Bug3544JUnitTest.java
@@ -35,10 +35,6 @@ import org.junit.experimental.categories.Category;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/**
- * TODO: Add additional tests for all methods in DataCommandFunction.
- *
- */
 @Category(IntegrationTest.class)
 public class Bug3544JUnitTest {
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Bug3544JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Bug3544JUnitTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.internal.cli.domain.DataCommandResult;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * TODO: Add additional tests for all methods in DataCommandFunction.
+ *
+ */
+@Category(IntegrationTest.class)
+public class Bug3544JUnitTest {
+
+  private static Cache cache;
+
+  private static Region region1;
+
+  private static final String PARTITIONED_REGION = "emp_region";
+  private static String emp_key;
+
+  static class EmpProfile implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private long data;
+
+    public EmpProfile() {
+
+    }
+
+    public EmpProfile(long in_data) {
+      this.data = in_data;
+    }
+
+    public long getData() {
+      return data;
+    }
+
+    public void setData(long data) {
+      this.data = data;
+    }
+  }
+  public static class EmpData extends EmpProfile {
+    private short empId;
+    private Integer empNumber;
+    private long empAccount;
+
+    public EmpData() {
+      super();
+    }
+
+    public EmpData(long in_data, short in_empId, Integer in_empNumber, long in_empAccount) {
+      super(in_data);
+
+      this.empId = in_empId;
+      this.empNumber = in_empNumber;
+      this.empAccount = in_empAccount;
+
+    }
+
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (other instanceof EmpData) {
+        return this.getEmpId() == (((EmpData) other).getEmpId());
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "data:" + getData() + "," + "empId" + getEmpId();
+    }
+
+    public short getEmpId() {
+      return empId;
+    }
+
+    public void setEmpId(short empId) {
+      this.empId = empId;
+    }
+
+    public Integer getEmpNumber() {
+      return empNumber;
+    }
+
+    public void setEmpNumber(Integer empNumber) {
+      this.empNumber = empNumber;
+    }
+
+    public long getEmpAccount() {
+      return empAccount;
+    }
+
+    public void setEmpAccount(long empAccount) {
+      this.empAccount = empAccount;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + (int) (empNumber ^ (empNumber >>> 32));
+      result = (int) (prime * result + empAccount);
+      result = prime * result + empId;
+      return result;
+    }
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    cache = new CacheFactory().set(MCAST_PORT, "0").create();
+    RegionFactory factory = cache.createRegionFactory(RegionShortcut.PARTITION);
+    region1 = factory.create(PARTITIONED_REGION);
+    EmpData emp_data_key = new EmpData(1, (short) 1, 1, 1);
+    region1.put(emp_data_key, "value_1");
+    ObjectMapper mapper = new ObjectMapper();
+    emp_key = mapper.writeValueAsString(emp_data_key);
+
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    cache.close();
+    cache = null;
+  }
+
+  /*
+   * This test addresses GEODE-3544
+   */
+  @Test
+  public void testLocateKeyIsObject() throws Exception {
+    DataCommandFunction dataCmdFn = new DataCommandFunction();
+
+    DataCommandResult result = dataCmdFn.locateEntry(emp_key, EmpData.class.getName(),
+        String.class.getName(), PARTITIONED_REGION, false);
+
+    assertNotNull(result);
+    result.aggregate(null);
+    List<DataCommandResult.KeyInfo> keyInfos = result.getLocateEntryLocations();
+    assertEquals(1, keyInfos.size());
+  }
+
+  @Test
+  public void testLocateKeyIsEmpData() throws Exception {
+    DataCommandFunction dataCmdFn = new DataCommandFunction();
+
+    DataCommandResult result = dataCmdFn.locateEntry(emp_key, EmpData.class.getName(),
+        String.class.getName(), PARTITIONED_REGION, false);
+
+    assertNotNull(result);
+    result.aggregate(null);
+    List<DataCommandResult.KeyInfo> keyInfos = result.getLocateEntryLocations();
+    assertEquals(1, keyInfos.size());
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Geode3544JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/Geode3544JUnitTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -36,7 +37,7 @@ import org.junit.experimental.categories.Category;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Category(IntegrationTest.class)
-public class Bug3544JUnitTest {
+public class Geode3544JUnitTest {
 
   private static Cache cache;
 
@@ -124,12 +125,7 @@ public class Bug3544JUnitTest {
 
     @Override
     public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + (int) (empNumber ^ (empNumber >>> 32));
-      result = (int) (prime * result + empAccount);
-      result = prime * result + empId;
-      return result;
+      return Objects.hash(empAccount, empNumber, empId);
     }
   }
 
@@ -156,19 +152,6 @@ public class Bug3544JUnitTest {
    */
   @Test
   public void testLocateKeyIsObject() throws Exception {
-    DataCommandFunction dataCmdFn = new DataCommandFunction();
-
-    DataCommandResult result = dataCmdFn.locateEntry(emp_key, EmpData.class.getName(),
-        String.class.getName(), PARTITIONED_REGION, false);
-
-    assertNotNull(result);
-    result.aggregate(null);
-    List<DataCommandResult.KeyInfo> keyInfos = result.getLocateEntryLocations();
-    assertEquals(1, keyInfos.size());
-  }
-
-  @Test
-  public void testLocateKeyIsEmpData() throws Exception {
     DataCommandFunction dataCmdFn = new DataCommandFunction();
 
     DataCommandResult result = dataCmdFn.locateEntry(emp_key, EmpData.class.getName(),


### PR DESCRIPTION
JSON parsing failed for short data type & base class setter method is not used
when key having base class  property in it

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X] Is your initial contribution a single, squashed commit?

- [ X] Does `gradlew build` run cleanly?

- [ X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
