### PR TITLE
GEODE-3550: Improve snapshot filter testing

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/snapshot/SnapshotTestCase.java
@@ -67,7 +67,7 @@ public class SnapshotTestCase {
 
   Map<Integer, MyObject> createExpected(SerializationType type) {
     Map<Integer, MyObject> expected = new HashMap<>();
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 100; i++) {
       expected.put(i, regionGenerator.createData(type, i, "The number is " + i));
     }
     return expected;


### PR DESCRIPTION
Make more explicit testing that filters work on both imports and exports and improve test speed by decreasing data size used.
