### PR TITLE
GEODE-3555: proper new client protocol closure with more than max conns.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/CommunicationMode.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/CommunicationMode.java
@@ -101,6 +101,14 @@ public enum CommunicationMode {
   }
 
   /**
+   * non-protobuf (legacy) protocols expect a refusal message before a connection is closed. This is
+   * unintelligible to protobuf protocol clients.
+   */
+  public boolean expectsConnectionRefusalMessage() {
+    return this != ProtobufClientServerProtocol;
+  }
+
+  /**
    * The modeNumber is the byte written on-wire that indicates this connection mode
    */
   private byte modeNumber;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1471,12 +1471,14 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
             LocalizedStrings.AcceptorImpl_REJECTED_CONNECTION_FROM_0_BECAUSE_CURRENT_CONNECTION_COUNT_OF_1_IS_GREATER_THAN_OR_EQUAL_TO_THE_CONFIGURED_MAX_OF_2,
             new Object[] {socket.getInetAddress(), Integer.valueOf(curCnt),
                 Integer.valueOf(this.maxConnections)}));
-        try {
-          ServerHandShakeProcessor.refuse(socket.getOutputStream(),
-              LocalizedStrings.AcceptorImpl_EXCEEDED_MAX_CONNECTIONS_0
-                  .toLocalizedString(Integer.valueOf(this.maxConnections)));
-        } catch (Exception ex) {
-          logger.debug("rejection message failed", ex);
+        if (mode.expectsConnectionRefusalMessage()) {
+          try {
+            ServerHandShakeProcessor.refuse(socket.getOutputStream(),
+                LocalizedStrings.AcceptorImpl_EXCEEDED_MAX_CONNECTIONS_0
+                    .toLocalizedString(Integer.valueOf(this.maxConnections)));
+          } catch (Exception ex) {
+            logger.debug("rejection message failed", ex);
+          }
         }
         closeSocket(socket);
         return;

--- a/geode-protobuf/src/test/java/org/apache/geode/protocol/RoundTripCacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/protocol/RoundTripCacheConnectionJUnitTest.java
@@ -56,15 +56,16 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.GenericProtocolServerConnection;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.protocol.exception.InvalidProtocolMessageException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.protocol.protobuf.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
+import org.apache.geode.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.protocol.protobuf.ProtobufSerializationService;
 import org.apache.geode.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.protocol.protobuf.utilities.ProtobufUtilities;
@@ -144,7 +145,7 @@ public class RoundTripCacheConnectionJUnitTest {
     }
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
 
     serializationService = new ProtobufSerializationService();
   }
@@ -178,7 +179,7 @@ public class RoundTripCacheConnectionJUnitTest {
     Socket socket = new Socket("localhost", cacheServerPort);
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     Set<BasicTypes.Entry> putEntries = new HashSet<>();
@@ -220,7 +221,7 @@ public class RoundTripCacheConnectionJUnitTest {
     Socket socket = new Socket("localhost", cacheServerPort);
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     Set<BasicTypes.Entry> putEntries = new HashSet<>();
@@ -290,6 +291,59 @@ public class RoundTripCacheConnectionJUnitTest {
   }
 
   @Test
+  public void testNewProtocolRespectsMaxConnectionLimit() throws IOException, InterruptedException {
+    cache.close();
+
+    CacheFactory cacheFactory = new CacheFactory();
+    Cache cache = cacheFactory.create();
+
+    CacheServer cacheServer = cache.addCacheServer();
+    final int cacheServerPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    cacheServer.setPort(cacheServerPort);
+    cacheServer.setMaxConnections(16);
+    cacheServer.setMaxThreads(16);
+    cacheServer.start();
+
+    AcceptorImpl acceptor = ((CacheServerImpl) cacheServer).getAcceptor();
+
+    Socket[] sockets = new Socket[16];
+
+    for (int i = 0; i < 16; i++) {
+      Socket socket = new Socket("localhost", cacheServerPort);
+      sockets[i] = socket;
+      Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+      socket.getOutputStream()
+          .write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+    }
+
+    try (Socket socket = new Socket("localhost", cacheServerPort)) {
+      Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+      socket.getOutputStream()
+          .write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+      assertEquals(-1, socket.getInputStream().read());
+    }
+
+    for (Socket currentSocket : sockets) {
+      currentSocket.close();
+    }
+
+    Awaitility.await().atMost(5, TimeUnit.SECONDS)
+        .until(() -> acceptor.getClientServerCnxCount() == 0);
+
+    for (int i = 0; i < 16; i++) {
+      Socket socket = new Socket("localhost", cacheServerPort);
+      sockets[i] = socket;
+      Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+      socket.getOutputStream()
+          .write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+    }
+
+    for (Socket currentSocket : sockets) {
+      currentSocket.close();
+    }
+  }
+
+  @Test
   public void testNewProtocolGetRegionNamesCallSucceeds() throws Exception {
     int correlationId = TEST_GET_CORRELATION_ID; // reuse this value for this test
 
@@ -316,7 +370,7 @@ public class RoundTripCacheConnectionJUnitTest {
     Socket socket = new Socket("localhost", cacheServerPort);
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     ClientProtocol.Message getRegionMessage = MessageUtil.makeGetRegionRequestMessage(TEST_REGION,


### PR DESCRIPTION
Don't send an old client message when closing new client connections.

This test also tests GEODE-3077.

Signed-off-by: Galen O'Sullivan <gosullivan@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
