### PR TITLE
GEODE-3557: remove calls to GemFireCacheImpl getInstance

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
@@ -93,7 +93,7 @@ public class FinishBackupRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     HashSet<PersistentID> persistentIds;
     if (cache == null || cache.getBackupManager() == null) {
       persistentIds = new HashSet<PersistentID>();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
@@ -66,7 +66,7 @@ public class FlushToDiskRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     if (cache != null) {
       cache.listDiskStoresIncludingRegionOwned().forEach(DiskStore::flush);
     }

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
@@ -80,7 +80,7 @@ public class PrepareBackupRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     HashSet<PersistentID> persistentIds;
     if (cache == null) {
       persistentIds = new HashSet<>();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
@@ -30,6 +30,7 @@ import org.apache.geode.distributed.internal.locks.ElderState;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.InternalCache;
 
 /**
  * This interface defines the services provided by any class that is a distribution manager.
@@ -462,4 +463,8 @@ public interface DM extends ReplySender {
   public void releaseUDPMessagingForCurrentThread();
 
   int getDMType();
+
+  InternalCache getCache();
+
+  void setCache(InternalCache instance);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
@@ -45,6 +45,7 @@ import org.apache.geode.internal.admin.remote.AdminConsoleDisconnectMessage;
 import org.apache.geode.internal.admin.remote.RemoteGfManagerAgent;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.cache.InitialImageOperation;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThreadGroup;
@@ -3937,6 +3938,8 @@ public class DistributionManager implements DM {
   /* -----------------------------Health Monitor------------------------------ */
   private final ConcurrentMap hmMap = new ConcurrentHashMap();
 
+  private InternalCache cache;
+
   /**
    * Returns the health monitor for this distribution manager and owner.
    * 
@@ -4805,5 +4808,15 @@ public class DistributionManager implements DM {
       }
       return result;
     }
+  }
+
+  @Override
+  public void setCache(InternalCache instance) {
+    this.cache = instance;
+  }
+
+  @Override
+  public InternalCache getCache() {
+    return this.cache;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -3091,4 +3091,8 @@ public class InternalDistributedSystem extends DistributedSystem
 
     Throwable generateCreationStack(final DistributionConfig config);
   }
+
+  public void setCache(InternalCache instance) {
+    this.dm.setCache(instance);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -26,6 +26,7 @@ import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.i18n.LogWriterI18n;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.InternalLogWriter;
 
@@ -1248,6 +1249,7 @@ public class LonerDistributionManager implements DM {
   }
 
   private final Stopper stopper = new Stopper();
+  private InternalCache cache;
 
   public CancelCriterion getCancelCriterion() {
     return stopper;
@@ -1374,5 +1376,15 @@ public class LonerDistributionManager implements DM {
   public boolean isSharedConfigurationServiceEnabledForDS() {
     // return false for loner
     return false;
+  }
+
+  @Override
+  public InternalCache getCache() {
+    return this.cache;
+  }
+
+  @Override
+  public void setCache(InternalCache instance) {
+    this.cache = instance;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
@@ -82,7 +82,7 @@ public class CompactRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     HashSet<PersistentID> compactedStores = new HashSet<>();
     if (cache != null && !cache.isClosed()) {
       for (DiskStore store : cache.listDiskStoresIncludingRegionOwned()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/MissingPersistentIDsRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/MissingPersistentIDsRequest.java
@@ -81,7 +81,7 @@ public class MissingPersistentIDsRequest extends CliLegacyMessage {
   protected AdminResponse createResponse(DistributionManager dm) {
     Set<PersistentID> missingIds = new HashSet<>();
     Set<PersistentID> localPatterns = new HashSet<>();
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     if (cache != null && !cache.isClosed()) {
       PersistentMemberManager mm = cache.getPersistentMemberManager();
       Map<String, Set<PersistentMemberID>> waitingRegions = mm.getWaitingRegions();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/PrepareRevokePersistentIDRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/PrepareRevokePersistentIDRequest.java
@@ -91,7 +91,7 @@ public class PrepareRevokePersistentIDRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     if (cache != null && !cache.isClosed()) {
       PersistentMemberManager mm = cache.getPersistentMemberManager();
       if (this.cancel) {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RevokePersistentIDRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RevokePersistentIDRequest.java
@@ -75,7 +75,7 @@ public class RevokePersistentIDRequest extends CliLegacyMessage {
 
   @Override
   protected AdminResponse createResponse(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     if (cache != null && !cache.isClosed()) {
       PersistentMemberManager mm = cache.getPersistentMemberManager();
       mm.revokeMember(this.pattern);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
@@ -178,7 +178,7 @@ public class ShutdownAllRequest extends AdminRequest {
     if (isToShutdown) {
       boolean isSuccess = false;
       try {
-        GemFireCacheImpl.getInstance().shutDownAll();
+        dm.getCache().shutDownAll();
         isSuccess = true;
       } catch (VirtualMachineError err) {
         SystemFailure.initiateFailure(err);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AddCacheServerProfileMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AddCacheServerProfileMessage.java
@@ -44,7 +44,7 @@ public class AddCacheServerProfileMessage extends SerialDistributionMessage
   protected void process(DistributionManager dm) {
     int oldLevel = LocalRegion.setThreadInitLevelRequirement(LocalRegion.BEFORE_INITIAL_IMAGE);
     try {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       // will be null if not initialized
       if (cache != null && !cache.isClosed()) {
         operateOnCache(cache);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -768,8 +768,7 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
         } else {
           if (lclRgn == null) {
             handleCacheDistributionAdvisee(
-                PartitionedRegionHelper.getProxyBucketRegion(GemFireCacheImpl.getInstance(),
-                    adviseePath, false),
+                PartitionedRegionHelper.getProxyBucketRegion(dm.getCache(), adviseePath, false),
                 adviseePath, removeProfile, exchangeProfiles, false, replyProfiles);
           } else {
             if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXCommitMessage.java
@@ -73,7 +73,7 @@ public class DistTXCommitMessage extends TXMessage {
       logger.debug("DistTXCommitMessage.operateOnTx: Tx {}", txId);
     }
 
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     TXManagerImpl txMgr = cache.getTXMgr();
     final TXStateProxy txStateProxy = txMgr.getTXState();
     TXCommitMessage cmsg = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXPrecommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXPrecommitMessage.java
@@ -76,7 +76,7 @@ public class DistTXPrecommitMessage extends TXMessage {
 
   @Override
   protected boolean operateOnTx(TXId txId, DistributionManager dm) throws RemoteOperationException {
-    GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     TXManagerImpl txMgr = cache.getTXMgr();
 
     if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXRollbackMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXRollbackMessage.java
@@ -75,7 +75,7 @@ public class DistTXRollbackMessage extends TXMessage {
       logger.debug("Dist TX: Rollback: {}", txId);
     }
 
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     TXManagerImpl txMgr = cache.getTXMgr();
     final TXStateProxy txState = txMgr.getTXState();
     boolean rollbackSuccessful = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
@@ -102,11 +102,11 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
     }
   }
 
-  private TXStateProxy prepForTransaction() throws InterruptedException {
+  private TXStateProxy prepForTransaction(DistributionManager dm) throws InterruptedException {
     if (this.txUniqId == TXManagerImpl.NOTX) {
       return null;
     } else {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache == null) {
         // ignore and return, we are shutting down!
         return null;
@@ -141,7 +141,7 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
             .toLocalizedString(dm.getId()));
         return;
       }
-      dr = (DistributedRegion) GemFireCacheImpl.getInstance().getRegion(this.regionPath);
+      dr = (DistributedRegion) dm.getCache().getRegion(this.regionPath);
       if (dr == null) {
         // if the distributed system is disconnecting, don't send a reply saying
         // the partitioned region can't be found (bug 36585)
@@ -150,7 +150,7 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
         return; // reply sent in finally block below
       }
       thr = UNHANDLED_EXCEPTION;
-      tx = prepForTransaction();
+      tx = prepForTransaction(dm);
       sendReply = operateOnDistributedRegion(dm, dr); // need to take care of
                                                       // it...
       thr = null;
@@ -275,7 +275,7 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
    * check to see if the cache is closing
    */
   private boolean checkCacheClosing(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     return cache == null || cache.getCancelCriterion().isCancelInProgress();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -1814,7 +1814,7 @@ public class FilterProfile implements DataSerializableFixedID {
     @Override
     protected void process(DistributionManager dm) {
       try {
-        CacheDistributionAdvisee r = findRegion();
+        CacheDistributionAdvisee r = findRegion(dm);
         if (r == null) {
           if (logger.isDebugEnabled()) {
             logger.debug("Region not found, so ignoring filter profile update: {}", this);
@@ -1920,11 +1920,10 @@ public class FilterProfile implements DataSerializableFixedID {
       }
     }
 
-    private CacheDistributionAdvisee findRegion() {
+    private CacheDistributionAdvisee findRegion(DistributionManager dm) {
       CacheDistributionAdvisee result = null;
-      InternalCache cache;
       try {
-        cache = GemFireCacheImpl.getInstance();
+        InternalCache cache = dm.getCache();
         if (cache != null) {
           LocalRegion lr = cache.getRegionByPathForProcessing(regionName);
           if (lr instanceof CacheDistributionAdvisee) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FindRemoteTXMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FindRemoteTXMessage.java
@@ -96,7 +96,7 @@ public class FindRemoteTXMessage extends HighPriorityDistributionMessage
         logger.debug("processing {}", this);
       }
       FindRemoteTXMessageReply reply = new FindRemoteTXMessageReply();
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache != null) {
         TXManagerImpl mgr = (TXManagerImpl) cache.getCacheTransactionManager();
         mgr.waitForCompletingTransaction(txId); // in case there is a lost commit going on

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FindVersionTagOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FindVersionTagOperation.java
@@ -121,7 +121,7 @@ public class FindVersionTagOperation {
     protected void process(DistributionManager dm) {
       VersionTag result = null;
       try {
-        LocalRegion r = findRegion();
+        LocalRegion r = findRegion(dm);
         if (r == null) {
           if (logger.isDebugEnabled()) {
             logger.debug("Region not found, so ignoring version tag request: {}", this);
@@ -155,10 +155,9 @@ public class FindVersionTagOperation {
       }
     }
 
-    private LocalRegion findRegion() {
-      InternalCache cache;
+    private LocalRegion findRegion(DistributionManager dm) {
       try {
-        cache = GemFireCacheImpl.getInstance();
+        InternalCache cache = dm.getCache();
         if (cache != null) {
           return cache.getRegionByPathForProcessing(regionName);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -759,7 +759,10 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         if (instance == null) {
           instance = new GemFireCacheImpl(isClient, pf, system, cacheConfig, asyncEventListeners,
               typeRegistry);
+          system.setCache(instance);
           instance.initialize();
+        } else {
+          system.setCache(instance);
         }
         return instance;
       }
@@ -1706,6 +1709,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     }
   }
 
+  @Override
   public void shutDownAll() {
     if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -314,4 +314,6 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
   SecurityService getSecurityService();
 
   boolean hasPersistentRegion();
+
+  void shutDownAll();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/JtaAfterCompletionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/JtaAfterCompletionMessage.java
@@ -74,7 +74,7 @@ public class JtaAfterCompletionMessage extends TXMessage {
 
   @Override
   protected boolean operateOnTx(TXId txId, DistributionManager dm) throws RemoteOperationException {
-    TXManagerImpl txMgr = GemFireCacheImpl.getInstance().getTXMgr();
+    TXManagerImpl txMgr = dm.getCache().getTXMgr();
     if (logger.isDebugEnabled()) {
       logger.debug("JTA: Calling afterCompletion for :{}", txId);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/JtaBeforeCompletionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/JtaBeforeCompletionMessage.java
@@ -56,7 +56,7 @@ public class JtaBeforeCompletionMessage extends TXMessage {
 
   @Override
   protected boolean operateOnTx(TXId txId, DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     TXManagerImpl txMgr = cache.getTXMgr();
     if (logger.isDebugEnabled()) {
       logger.debug("JTA: Calling beforeCompletion for :{}", txId);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/MemberFunctionStreamingMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/MemberFunctionStreamingMessage.java
@@ -115,11 +115,11 @@ public class MemberFunctionStreamingMessage extends DistributionMessage
     fromData(in);
   }
 
-  private TXStateProxy prepForTransaction() throws InterruptedException {
+  private TXStateProxy prepForTransaction(DistributionManager dm) throws InterruptedException {
     if (this.txUniqId == TXManagerImpl.NOTX) {
       return null;
     } else {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache == null) {
         // ignore and return, we are shutting down!
         return null;
@@ -157,10 +157,10 @@ public class MemberFunctionStreamingMessage extends DistributionMessage
     FunctionStats stats =
         FunctionStats.getFunctionStats(this.functionObject.getId(), dm.getSystem());
     TXStateProxy tx = null;
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
 
     try {
-      tx = prepForTransaction();
+      tx = prepForTransaction(dm);
       ResultSender resultSender = new MemberFunctionResultSender(dm, this, this.functionObject);
       Set<Region> regions = new HashSet<Region>();
       if (this.regionPathSet != null) {
@@ -354,7 +354,7 @@ public class MemberFunctionStreamingMessage extends DistributionMessage
    * check to see if the cache is closing
    */
   private boolean checkCacheClosing(DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     return (cache == null || cache.getCancelCriterion().isCancelInProgress());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -1210,7 +1210,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
 
     @Override
     protected void process(DistributionManager dm) {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache != null) {
         TXManagerImpl mgr = cache.getTXMgr();
         mgr.removeTransactions(this.txIds, false);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXMessage.java
@@ -73,7 +73,7 @@ public abstract class TXMessage extends SerialDistributionMessage
       if (logger.isDebugEnabled()) {
         logger.debug("processing {}", this);
       }
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (checkCacheClosing(cache) || checkDSClosing(cache.getInternalDistributedSystem())) {
         thr = new CacheClosedException(LocalizedStrings.PartitionMessage_REMOTE_CACHE_IS_CLOSED_0
             .toLocalizedString(dm.getId()));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteCommitMessage.java
@@ -73,7 +73,7 @@ public class TXRemoteCommitMessage extends TXMessage {
 
   @Override
   protected boolean operateOnTx(TXId txId, DistributionManager dm) throws RemoteOperationException {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     TXManagerImpl txMgr = cache.getTXMgr();
 
     if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteRollbackMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteRollbackMessage.java
@@ -57,7 +57,7 @@ public class TXRemoteRollbackMessage extends TXMessage {
 
   @Override
   protected boolean operateOnTx(TXId txId, DistributionManager dm) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = dm.getCache();
     if (cache == null) {
       throw new CacheClosedException(
           LocalizedStrings.CacheFactory_A_CACHE_HAS_NOT_YET_BEEN_CREATED.toLocalizedString());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceAdvisor.java
@@ -87,7 +87,7 @@ public class ResourceAdvisor extends DistributionAdvisor {
       Throwable thr = null;
       ResourceManagerProfile p = null;
       try {
-        final InternalCache cache = GemFireCacheImpl.getInstance();
+        final InternalCache cache = dm.getCache();
         if (cache != null && !cache.isClosed()) {
           final ResourceAdvisor ra = cache.getInternalResourceManager().getResourceAdvisor();
           if (this.profiles != null) {
@@ -339,9 +339,10 @@ public class ResourceAdvisor extends DistributionAdvisor {
     @Override
     public void processIncoming(DistributionManager dm, String adviseePath, boolean removeProfile,
         boolean exchangeProfiles, final List<Profile> replyProfiles) {
-      final GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+      final InternalCache cache = dm.getCache();
       if (cache != null && !cache.isClosed()) {
-        handleDistributionAdvisee(cache, removeProfile, exchangeProfiles, replyProfiles);
+        handleDistributionAdvisee((DistributionAdvisee) cache, removeProfile, exchangeProfiles,
+            replyProfiles);
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/QueueRemovalMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/QueueRemovalMessage.java
@@ -72,9 +72,7 @@ public class QueueRemovalMessage extends PooledDistributionMessage {
    */
   @Override
   protected void process(DistributionManager dm) {
-    final InternalCache cache;
-    // use GemFireCache.getInstance to avoid blocking during cache.xml processing.
-    cache = GemFireCacheImpl.getInstance();
+    final InternalCache cache = dm.getCache();
     if (cache != null) {
       Iterator iterator = this.messagesList.iterator();
       int oldLevel = LocalRegion.setThreadInitLevelRequirement(LocalRegion.BEFORE_INITIAL_IMAGE);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipViewRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipViewRequest.java
@@ -114,8 +114,8 @@ public class MembershipViewRequest extends DistributionMessage implements Messag
       if (region instanceof DistributedRegion) {
         persistenceAdvisor = ((DistributedRegion) region).getPersistenceAdvisor();
       } else if (region == null) {
-        Bucket proxy = PartitionedRegionHelper.getProxyBucketRegion(GemFireCacheImpl.getInstance(),
-            this.regionPath, false);
+        Bucket proxy =
+            PartitionedRegionHelper.getProxyBucketRegion(dm.getCache(), this.regionPath, false);
         if (proxy != null) {
           persistenceAdvisor = proxy.getPersistenceAdvisor();
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessage.java
@@ -107,8 +107,8 @@ public class PersistentStateQueryMessage extends HighPriorityDistributionMessage
       if (region instanceof DistributedRegion) {
         persistenceAdvisor = ((DistributedRegion) region).getPersistenceAdvisor();
       } else if (region == null) {
-        Bucket proxy = PartitionedRegionHelper.getProxyBucketRegion(GemFireCacheImpl.getInstance(),
-            this.regionPath, false);
+        Bucket proxy =
+            PartitionedRegionHelper.getProxyBucketRegion(dm.getCache(), this.regionPath, false);
         if (proxy != null) {
           persistenceAdvisor = proxy.getPersistenceAdvisor();
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PrepareNewPersistentMemberMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PrepareNewPersistentMemberMessage.java
@@ -97,8 +97,8 @@ public class PrepareNewPersistentMemberMessage extends HighPriorityDistributionM
       if (region instanceof DistributedRegion) {
         persistenceAdvisor = ((DistributedRegion) region).getPersistenceAdvisor();
       } else if (region == null) {
-        Bucket proxy = PartitionedRegionHelper.getProxyBucketRegion(GemFireCacheImpl.getInstance(),
-            this.regionPath, false);
+        Bucket proxy =
+            PartitionedRegionHelper.getProxyBucketRegion(dm.getCache(), this.regionPath, false);
         if (proxy != null) {
           persistenceAdvisor = proxy.getPersistenceAdvisor();
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/RemovePersistentMemberMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/RemovePersistentMemberMessage.java
@@ -101,8 +101,8 @@ public class RemovePersistentMemberMessage extends HighPriorityDistributionMessa
       if (region instanceof DistributedRegion) {
         persistenceAdvisor = ((DistributedRegion) region).getPersistenceAdvisor();
       } else if (region == null) {
-        Bucket proxy = PartitionedRegionHelper.getProxyBucketRegion(GemFireCacheImpl.getInstance(),
-            this.regionPath, false);
+        Bucket proxy =
+            PartitionedRegionHelper.getProxyBucketRegion(dm.getCache(), this.regionPath, false);
         if (proxy != null) {
           persistenceAdvisor = proxy.getPersistenceAdvisor();
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientBlacklistProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientBlacklistProcessor.java
@@ -97,7 +97,7 @@ public class ClientBlacklistProcessor extends ReplyProcessor21 {
     @Override
     protected void process(final DistributionManager dm) {
       try {
-        Cache c = GemFireCacheImpl.getInstance();
+        Cache c = dm.getCache();
         if (c != null) {
           List l = c.getCacheServers();
           if (l != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/RemoveClientFromBlacklistMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/RemoveClientFromBlacklistMessage.java
@@ -46,22 +46,7 @@ public class RemoveClientFromBlacklistMessage extends PooledDistributionMessage 
 
   @Override
   protected void process(DistributionManager dm) {
-    final Cache cache;
-    try {
-      // use GemFireCache.getInstance to avoid blocking during cache.xml
-      // processing.
-      cache = GemFireCacheImpl.getInstance();
-    } catch (Exception ignore) {
-      DistributedSystem ds = dm.getSystem();
-      if (ds != null) {
-        if (logger.isTraceEnabled()) {
-          logger.trace("The node does not contain cache & so QDM Message will return.", ignore);
-        }
-      }
-      return;
-    }
-
-    Cache c = GemFireCacheImpl.getInstance();
+    Cache c = dm.getCache();
     if (c != null) {
       List l = c.getCacheServers();
       if (l != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderAdvisor.java
@@ -688,7 +688,7 @@ public class GatewaySenderAdvisor extends DistributionAdvisor {
     @Override
     public void processIncoming(DistributionManager dm, String adviseePath, boolean removeProfile,
         boolean exchangeProfiles, final List<Profile> replyProfiles) {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache != null) {
         AbstractGatewaySender sender = (AbstractGatewaySender) cache.getGatewaySender(adviseePath);
         handleDistributionAdvisee(sender, removeProfile, exchangeProfiles, replyProfiles);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessage.java
@@ -73,8 +73,7 @@ public class ParallelQueueRemovalMessage extends PooledDistributionMessage {
   @Override
   protected void process(DistributionManager dm) {
     final boolean isDebugEnabled = logger.isDebugEnabled();
-    final InternalCache cache;
-    cache = GemFireCacheImpl.getInstance();
+    final InternalCache cache = dm.getCache();
     if (cache != null) {
       int oldLevel = LocalRegion.setThreadInitLevelRequirement(LocalRegion.BEFORE_INITIAL_IMAGE);
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -2209,4 +2209,9 @@ public class CacheCreation implements InternalCache {
   public boolean hasPersistentRegion() {
     throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
   }
+
+  @Override
+  public void shutDownAll() {
+    throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
@@ -174,7 +174,7 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
       Throwable thr = null;
       JmxManagerProfile p = null;
       try {
-        final InternalCache cache = GemFireCacheImpl.getInstance();
+        final InternalCache cache = dm.getCache();
         if (cache != null && !cache.isClosed()) {
           final JmxManagerAdvisor adv = cache.getJmxManagerAdvisor();
           p = this.profile;
@@ -327,7 +327,7 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
     @Override
     public void processIncoming(DistributionManager dm, String adviseePath, boolean removeProfile,
         boolean exchangeProfiles, final List<Profile> replyProfiles) {
-      final InternalCache cache = GemFireCacheImpl.getInstance();
+      final InternalCache cache = dm.getCache();
       if (cache != null && !cache.isClosed()) {
         handleDistributionAdvisee(cache.getJmxManagerAdvisor().getAdvisee(), removeProfile,
             exchangeProfiles, replyProfiles);

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/CheckTypeRegistryState.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/CheckTypeRegistryState.java
@@ -70,7 +70,7 @@ public class CheckTypeRegistryState extends HighPriorityDistributionMessage
   protected void process(DistributionManager dm) {
     ReplyException e = null;
     try {
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = dm.getCache();
       if (cache != null && !cache.isClosed()) {
         TypeRegistry pdxRegistry = cache.getPdxRegistry();
         if (pdxRegistry != null) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.cache.BucketAdvisor;
 import org.apache.geode.internal.cache.BucketRegionQueue;
 import org.apache.geode.internal.cache.BucketRegionQueueHelper;
@@ -274,7 +275,7 @@ public class ParallelQueueRemovalMessageJUnitTest {
   private void createAndProcessParallelQueueRemovalMessage() {
     ParallelQueueRemovalMessage message =
         new ParallelQueueRemovalMessage(createRegionToDispatchedKeysMap());
-    message.process(null);
+    message.process((DistributionManager) this.cache.getDistributionManager());
   }
 
   private HashMap<String, Map<Integer, List<Long>>> createRegionToDispatchedKeysMap() {

--- a/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
@@ -97,6 +97,7 @@ public class Fakes {
     when(distributionManager.getConfig()).thenReturn(config);
     when(distributionManager.getSystem()).thenReturn(system);
     when(distributionManager.getCancelCriterion()).thenReturn(systemCancelCriterion);
+    when(distributionManager.getCache()).thenReturn(cache);
 
     return cache;
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/DestroyLuceneIndexMessage.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/DestroyLuceneIndexMessage.java
@@ -66,7 +66,7 @@ public class DestroyLuceneIndexMessage extends PooledDistributionMessage
             + "; indexName=" + this.indexName);
       }
       try {
-        InternalCache cache = GemFireCacheImpl.getInstance();
+        InternalCache cache = dm.getCache();
         LuceneServiceImpl impl = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
         impl.destroyIndex(this.indexName, this.regionPath, false);
         if (logger.isDebugEnabled()) {


### PR DESCRIPTION
The DM now remembers the InternalCache that created it.
Changed places that had a dm to use its getCache method
instead of GemFireCacheImpl getInstance.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@nreich @agingade 