### PR TITLE
GEODE-3426: Ignore RestServersJUnitTest when default port is unavailable.

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/GeodeRestClient.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/GeodeRestClient.java
@@ -50,7 +50,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 public class GeodeRestClient {
-  public final static String CONTEXT = "/geode/v1";
+  public static final String CONTEXT = "/geode/v1";
 
   private int restPort = 0;
   private String bindAddress = null;

--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestServersJUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestServersJUnitTest.java
@@ -15,46 +15,54 @@
 
 package org.apache.geode.rest.internal.web;
 
+import static org.apache.geode.distributed.internal.DistributionConfig.DEFAULT_HTTP_SERVICE_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
-import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.test.dunit.rules.ServerStarterRule;
-import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.RestAPITest;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.test.dunit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.RestAPITest;
+
 @Category({IntegrationTest.class, RestAPITest.class})
 public class RestServersJUnitTest {
 
   @ClassRule
-  public static ServerStarterRule serverStarter =
-      new ServerStarterRule().withRestService(true).withAutoStart();
+  public static ServerStarterRule serverStarter = new ServerStarterRule().withRestService(true);
+
 
   private static GeodeRestClient restClient;
 
   @BeforeClass
   public static void before() throws Exception {
-    assertThat(serverStarter.getHttpPort()).isEqualTo(DistributionConfig.DEFAULT_HTTP_SERVICE_PORT);
+    assumeTrue(
+        "Default port was unavailable for testing.  Please ensure the testing environment is clean.",
+        AvailablePort.isPortAvailable(DEFAULT_HTTP_SERVICE_PORT, AvailablePort.SOCKET));
+    serverStarter.startServer();
+    assertThat(serverStarter.getHttpPort()).isEqualTo(DEFAULT_HTTP_SERVICE_PORT);
     restClient = new GeodeRestClient("localhost", serverStarter.getHttpPort());
   }
 
   @Test
   public void testGet() throws Exception {
     HttpResponse response = restClient.doGet("/", null, null);
-    assertThat(GeodeRestClient.getCode(response)).isEqualTo(200);
+    assertThat(GeodeRestClient.getCode(response)).isEqualTo(HttpStatus.SC_OK);
   }
 
   @Test
   public void testServerStartedOnDefaultPort() throws Exception {
     HttpResponse response = restClient.doGet("/servers", null, null);
+    assertThat(GeodeRestClient.getCode(response)).isEqualTo(HttpStatus.SC_OK);
     JSONArray body = GeodeRestClient.getJsonArray(response);
     assertThat(body.length()).isEqualTo(1);
-    assertThat(body.getString(0))
-        .isEqualTo("http://localhost:" + DistributionConfig.DEFAULT_HTTP_SERVICE_PORT);
+    assertThat(body.getString(0)).isEqualTo("http://localhost:" + DEFAULT_HTTP_SERVICE_PORT);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/categories/RestAPITest.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/categories/RestAPITest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.test.junit.categories;
 
 /**
- * A categor for REST API tests
+ * A category for REST API tests
  */
 public interface RestAPITest {
 }


### PR DESCRIPTION
This should correct the Jenkins nightly failures we have seen recently.

====

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
