### PR TITLE
GEODE-3185: Fixes CI failures in windows in org.apache.geode.internal…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/RestoreScript.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/RestoreScript.java
@@ -163,6 +163,7 @@ public class RestoreScript {
 
     public void writePreamble(PrintWriter writer) {
       writer.println("echo off");
+      writer.println("cd %~dp0");
     }
 
     public void writeComment(PrintWriter writer, String string) {


### PR DESCRIPTION
….cache.BackupJUnitTest

The windows restore script now cds to the directory containing the script.
This makes the windows restore script similar to the unix restore script
The restore script uses relative path names, so the cd is required for it to work.

@dschneider-pivotal @agingade @pivotal-eshu @kirklund @nreich 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
