### PR TITLE
GEODE-3580: patch test to avoid the current failure.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
@@ -26,6 +26,7 @@ import org.apache.geode.distributed.DistributedLockService;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.LockServiceDestroyedException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Host;
@@ -87,6 +88,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
+    TypeRegistry.init();
 
     // Make sure a deadlock from a previous test is cleared.
     disconnectAllFromDS();
@@ -108,6 +110,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
+    TypeRegistry.init();
     getSystem();
     InternalDistributedMember member1 = createCache(vm0);
     final InternalDistributedMember member2 = createCache(vm1);
@@ -177,6 +180,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
     getBlackboard().initBlackboard();
+    TypeRegistry.init();
 
     getSystem();
     AsyncInvocation async1 = lockTheDLocks(vm0, "one", "two");


### PR DESCRIPTION
When a cache has already been created and closed in the current JVM,
`TypeRegistry` will have a flag set that stops a distributed system from
sending messages. This means we can't connect to a distributed system,
even though there doesn't seem to be any reason to disallow it. This is
to stop the test failing; a real fix will come later.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
