### PR TITLE
GEODE-3619: fix diskTasksWaiting statistic

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -1342,6 +1342,7 @@ public class CachePerfStats {
   public void decDiskTasksWaiting() {
     this.stats.incInt(diskTasksWaitingId, -1);
   }
+
   public int getDiskTasksWaiting() {
     return this.stats.getInt(diskTasksWaitingId);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -1342,6 +1342,9 @@ public class CachePerfStats {
   public void decDiskTasksWaiting() {
     this.stats.incInt(diskTasksWaitingId, -1);
   }
+  public int getDiskTasksWaiting() {
+    return this.stats.getInt(diskTasksWaitingId);
+  }
 
   public void decDiskTasksWaiting(int count) {
     this.stats.incInt(diskTasksWaitingId, -count);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -2832,7 +2832,6 @@ public class DiskStoreImpl implements DiskStore {
      * missed. Notifications need not be sent if the thread is already compaction
      */
     public void run() {
-      getCache().getCachePerfStats().decDiskTasksWaiting();
       if (!this.scheduled)
         return;
       boolean compactedSuccessfully = false;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
@@ -2721,6 +2721,8 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     boolean compacted = ((LocalRegion) region).getDiskStore().forceCompaction();
     assertEquals(true, oplog.testConfirmCompacted());
     assertEquals(true, compacted);
+    CachePerfStats stats = ((InternalCache)cache).getCachePerfStats();
+    assertTrue("expected " + stats.getDiskTasksWaiting() + " to be >= 0", stats.getDiskTasksWaiting() >= 0);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
@@ -2721,8 +2721,9 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
     boolean compacted = ((LocalRegion) region).getDiskStore().forceCompaction();
     assertEquals(true, oplog.testConfirmCompacted());
     assertEquals(true, compacted);
-    CachePerfStats stats = ((InternalCache)cache).getCachePerfStats();
-    assertTrue("expected " + stats.getDiskTasksWaiting() + " to be >= 0", stats.getDiskTasksWaiting() >= 0);
+    CachePerfStats stats = ((InternalCache) cache).getCachePerfStats();
+    assertTrue("expected " + stats.getDiskTasksWaiting() + " to be >= 0",
+        stats.getDiskTasksWaiting() >= 0);
   }
 
   @Test


### PR DESCRIPTION
Compaction no longer does an extra decrement of the stat.
Unit test confirms the fix.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
