### PR TITLE
GEODE-3578: Only DATA:READ permissions are required for creating/clos…

### DIFF
--- a/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQ.java
@@ -76,8 +76,6 @@ public class CloseCQ extends BaseCQCommand {
       return;
     }
 
-    securityService.authorize(Resource.CLUSTER, Operation.MANAGE, Target.QUERY);
-
     // Process CQ close request
     try {
       // Append Client ID to CQ name
@@ -90,19 +88,23 @@ public class CloseCQ extends BaseCQCommand {
       }
       InternalCqQuery cqQuery = cqService.getCq(serverCqName);
 
-      AuthorizeRequest authzRequest = serverConnection.getAuthzRequest();
-      if (authzRequest != null) {
+      if (cqQuery != null) {
+        securityService.authorize(Resource.DATA, Operation.READ, cqQuery.getRegionName());
 
-        if (cqQuery != null) {
-          String queryStr = cqQuery.getQueryString();
-          Set cqRegionNames = new HashSet();
-          cqRegionNames.add(cqQuery.getRegionName());
-          authzRequest.closeCQAuthorize(cqName, queryStr, cqRegionNames);
+        AuthorizeRequest authzRequest = serverConnection.getAuthzRequest();
+        if (authzRequest != null) {
+
+          if (cqQuery != null) {
+            String queryStr = cqQuery.getQueryString();
+            Set cqRegionNames = new HashSet();
+            cqRegionNames.add(cqQuery.getRegionName());
+            authzRequest.closeCQAuthorize(cqName, queryStr, cqRegionNames);
+          }
+
         }
 
+        cqService.closeCq(cqName, id);
       }
-
-      cqService.closeCq(cqName, id);
       if (cqQuery != null)
         serverConnection.removeCq(cqName, cqQuery.isDurable());
     } catch (CqException cqe) {

--- a/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteCQ61.java
+++ b/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteCQ61.java
@@ -120,9 +120,9 @@ public class ExecuteCQ61 extends BaseCQCommand {
 
       // Authorization check
       AuthorizeRequest authzRequest = serverConnection.getAuthzRequest();
+      query = qService.newQuery(cqQueryString);
+      cqRegionNames = ((DefaultQuery) query).getRegionsInQuery(null);
       if (authzRequest != null) {
-        query = qService.newQuery(cqQueryString);
-        cqRegionNames = ((DefaultQuery) query).getRegionsInQuery(null);
         executeCQContext = authzRequest.executeCQAuthorize(cqName, cqQueryString, cqRegionNames);
         String newCqQueryString = executeCQContext.getQuery();
 
@@ -137,7 +137,8 @@ public class ExecuteCQ61 extends BaseCQCommand {
       }
 
       // auth check to see if user can create CQ or not
-      securityService.authorize(Resource.CLUSTER, Operation.MANAGE, Target.QUERY);
+      ((DefaultQuery) query).getRegionsInQuery(null).forEach((regionName) -> securityService
+          .authorize(Resource.DATA, Operation.READ, (String) regionName));
 
       // test hook to trigger vMotion during CQ registration
       if (CqServiceProvider.VMOTION_DURING_CQ_REGISTRATION_FLAG) {

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQTest.java
@@ -25,7 +25,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
-import org.apache.geode.security.ResourcePermission.Target;
 import org.apache.geode.test.dunit.rules.CQUnitTestRule;
 import org.apache.geode.test.junit.categories.UnitTest;
 
@@ -36,13 +35,13 @@ public class CloseCQTest {
   public CQUnitTestRule cqRule = new CQUnitTestRule();
 
   @Test
-  public void needClusterManageQueryToStopCQ() throws Exception {
+  public void needDataReadRegionToClose() throws Exception {
     CloseCQ closeCQ = mock(CloseCQ.class);
     doCallRealMethod().when(closeCQ).cmdExecute(cqRule.message, cqRule.connection,
         cqRule.securityService, 0);
 
     closeCQ.cmdExecute(cqRule.message, cqRule.connection, cqRule.securityService, 0);
 
-    verify(cqRule.securityService).authorize(Resource.CLUSTER, Operation.MANAGE, Target.QUERY);
+    verify(cqRule.securityService).authorize(Resource.DATA, Operation.READ, "regionName");
   }
 }

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteCQ61Test.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteCQ61Test.java
@@ -35,12 +35,12 @@ public class ExecuteCQ61Test {
   public CQUnitTestRule cqRule = new CQUnitTestRule();
 
   @Test
-  public void needClusterQueryManageToExecute() throws Exception {
+  public void needRegionRegionToExecute() throws Exception {
     ExecuteCQ61 executeCQ61 = mock(ExecuteCQ61.class);
     doCallRealMethod().when(executeCQ61).cmdExecute(cqRule.message, cqRule.connection,
         cqRule.securityService, 0);
 
     executeCQ61.cmdExecute(cqRule.message, cqRule.connection, cqRule.securityService, 0);
-    verify(cqRule.securityService).authorize(Resource.CLUSTER, Operation.MANAGE, Target.QUERY);
+    verify(cqRule.securityService).authorize(Resource.DATA, Operation.READ, "regionName");
   }
 }

--- a/geode-cq/src/test/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
@@ -70,9 +70,8 @@ public class ClientCQAuthDUnitTest {
       // Create the CqQuery (this is on the client side)
       CqQuery cq = qs.newCq("CQ1", query, cqa);
 
-      assertNotAuthorized(cq::execute, "CLUSTER:MANAGE:QUERY");
-      assertNotAuthorized(cq::executeWithInitialResults, "CLUSTER:MANAGE:QUERY");
-      assertNotAuthorized(cq::close, "CLUSTER:MANAGE:QUERY");
+      assertNotAuthorized(cq::execute, "DATA:READ:AuthRegion");
+      assertNotAuthorized(cq::executeWithInitialResults, "DATA:READ:AuthRegion");
       assertNotAuthorized(qs::getAllDurableCqsFromServer, "CLUSTER:READ");
     });
 


### PR DESCRIPTION
…ing a cq from a client

This diff includes a fix for GEODE-3576: Moved security check earlier in cq process, because it happened to be a byproduct of changing the to DATA:READ:regionName instead of CLUSTER:MANAGE:QUERY
