### PR TITLE
GEODE-3629: Old versions will be pulled from the Apache Maven Repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@
 buildscript {
   repositories {
     maven { url "https://plugins.gradle.org/m2/" }
+    maven {
+      url 'https://repository.apache.org/content/repositories/snapshots'
+    }
   }
 
   dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,6 @@
 buildscript {
   repositories {
     maven { url "https://plugins.gradle.org/m2/" }
-    maven {
-      url 'https://repository.apache.org/content/repositories/snapshots'
-    }
   }
 
   dependencies {

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -21,7 +21,7 @@ disableMavenPublishing()
 repositories {
   maven { url "https://plugins.gradle.org/m2/" }
   maven {
-    url 'https://repository.apache.org/content/repositories/snapshots'
+    url 'https://repository.apache.org/content/repositories/releases'
   }
 }
 

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -18,10 +18,6 @@
 
 disableMavenPublishing()
 
-repositories {
-  maven { url "https://plugins.gradle.org/m2/" }
-}
-
 project.ext.installs = new Properties();
 
 def addOldVersion(def source, def geodeVersion, def downloadInstall) {

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -20,9 +20,6 @@ disableMavenPublishing()
 
 repositories {
   maven { url "https://plugins.gradle.org/m2/" }
-  maven {
-    url 'https://repository.apache.org/content/repositories/releases'
-  }
 }
 
 project.ext.installs = new Properties();

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -15,12 +15,15 @@
  * limitations under the License.
  */
 
-plugins {
-  id "de.undercouch.download" version "3.2.0"
-}
 
-import de.undercouch.gradle.tasks.download.Download
 disableMavenPublishing()
+
+repositories {
+  maven { url "https://plugins.gradle.org/m2/" }
+  maven {
+    url 'https://repository.apache.org/content/repositories/snapshots'
+  }
+}
 
 project.ext.installs = new Properties();
 
@@ -38,40 +41,21 @@ def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   dependencies.add "${source}Compile", "org.apache.geode:geode-cq:$geodeVersion"
   dependencies.add "${source}Compile", "org.apache.geode:geode-rebalancer:$geodeVersion"
 
-  project.ext.installs.setProperty(source, "$buildDir/apache-geode-${geodeVersion}")
-
-  task "downloadZipFile${source}" (type: Download) {
-    src "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/$geodeVersion/apache-geode-${geodeVersion}.tar.gz"
-    def destFile = new File(buildDir, "apache-geode-${geodeVersion}.tar.gz")
-    dest destFile
-    onlyIf {!destFile.exists()}
-  }
-
-  task "downloadSHA${source}" (type: Download) {
-    src "https://www.apache.org/dist/geode/${geodeVersion}/apache-geode-${geodeVersion}.tar.gz.sha256"
-    def destFile =  new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256")
-    dest destFile
-    onlyIf {!destFile.exists()}
-  }
-
-
-  task "verifyGeode${source}" (type: de.undercouch.gradle.tasks.download.Verify, dependsOn: [tasks["downloadSHA${source}"], tasks["downloadZipFile${source}"]]) {
-    src tasks["downloadZipFile${source}"].dest
-    algorithm "SHA-256"
-    doFirst {
-      checksum new File(buildDir, "apache-geode-${geodeVersion}.tar.gz.sha256").text.split(' ')[0]
-    }
-  }
-
-  task "downloadAndUnzipFile${source}" (dependsOn: "verifyGeode${source}", type: Copy) {
-    from tarTree(tasks["downloadZipFile${source}"].dest)
-    into buildDir
-  }
-
   if (downloadInstall) {
-    createGeodeClasspathsFile.dependsOn tasks["downloadAndUnzipFile${source}"]
+    configurations.create("${source}OldInstall")
+
+    dependencies.add "${source}OldInstall", "org.apache.geode:apache-geode:$geodeVersion"
+
+    project.ext.installs.setProperty(source, "$buildDir/apache-geode-${geodeVersion}")
+    task "downloadAndUnzipFile${geodeVersion}"(type: Copy) {
+      from zipTree(configurations["${source}OldInstall"].singleFile)
+      into buildDir
+    }
+
+    createGeodeClasspathsFile.dependsOn tasks["downloadAndUnzipFile${geodeVersion}"]
   }
 }
+
 
 def generatedResources = "$buildDir/generated-resources/main"
 
@@ -90,7 +74,7 @@ task createGeodeClasspathsFile  {
   doLast {
     Properties versions = new Properties();
     project(':geode-old-versions').sourceSets.each {
-      versions.setProperty(it.name,it.runtimeClasspath.getAsPath()) 
+      versions.setProperty(it.name,it.runtimeClasspath.getAsPath())
     }
 
     classpathsFile.getParentFile().mkdirs();
@@ -112,7 +96,7 @@ task createGeodeClasspathsFile  {
   addOldVersion('test110', '1.1.0', false)
   addOldVersion('test111', '1.1.1', false)
   addOldVersion('test120', '1.2.0', true)
-
 }
+
 
 


### PR DESCRIPTION
Modified the geode-old-versions build to now pull down the from the maven repository instead of a mirror.  This zip should now be cached locally.