### PR TITLE
GEODE-3636: Fixing hang shutting down gateway sender with SSL

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionImpl.java
@@ -14,16 +14,6 @@
  */
 package org.apache.geode.cache.client.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.net.SocketException;
-import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.logging.log4j.Logger;
-
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.CancelException;
 import org.apache.geode.ForcedDisconnectException;
@@ -42,6 +32,16 @@ import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.log4j.LocalizedMessage;
 import org.apache.geode.internal.net.SocketCreator;
+import org.apache.logging.log4j.Logger;
+
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A single client to server connection.
@@ -184,8 +184,10 @@ public class ConnectionImpl implements Connection {
     }
     try {
       if (theSocket != null) {
-        theSocket.getOutputStream().flush();
-        theSocket.shutdownOutput();
+        if (!(theSocket instanceof SSLSocket)) {
+          theSocket.getOutputStream().flush();
+          theSocket.shutdownOutput();
+        }
         theSocket.close();
       }
     } catch (Exception e) {


### PR DESCRIPTION
The gateway sender shutdown code calls connection.destroy to interrupt the ack
reader thread. Connection.destroy was calling socket.shutDownOutput.
SSLSockets do not support socket.shutDownOutput() resulting in connections not
being destroyed. This left the AckReaderThread stuck on read holding a
readLock, which prevented the stopper thread from getting a writeLock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
