### PR TITLE
GEODE-3626: Fix relative path support for snapshots

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -333,7 +333,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
       throw new IllegalArgumentException("Failure to export snapshot: "
           + snapshot.getCanonicalPath() + " is not a valid .gfd file");
     }
-    File directory = snapshot.getParentFile();
+    File directory = snapshot.getAbsoluteFile().getParentFile();
     if (directory == null) {
       throw new IllegalArgumentException("Failure to export snapshot: "
           + snapshot.getCanonicalPath() + " is not a valid location");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ImportDataIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ImportDataIntegrationTest.java
@@ -19,7 +19,9 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.IntStream;
 
 import org.junit.Before;
@@ -80,6 +82,22 @@ public class ImportDataIntegrationTest {
     String importCommand = buildBaseImportCommand()
         .addOption(CliStrings.IMPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
     gfsh.executeAndVerifyCommand(importCommand);
+    assertThat(gfsh.getGfshOutput()).contains("Data imported from file");
+    validateImport("value");
+  }
+
+  @Test
+  public void testExportImportRelativePath() throws Exception {
+    String exportCommand = buildBaseExportCommand()
+        .addOption(CliStrings.EXPORT_DATA__FILE, SNAPSHOT_FILE).getCommandString();
+    gfsh.executeAndVerifyCommand(exportCommand);
+
+    loadRegion("");
+
+    String importCommand = buildBaseImportCommand()
+        .addOption(CliStrings.IMPORT_DATA__FILE, SNAPSHOT_FILE).getCommandString();
+    gfsh.executeAndVerifyCommand(importCommand);
+    Files.deleteIfExists(Paths.get(SNAPSHOT_FILE));
     assertThat(gfsh.getGfshOutput()).contains("Data imported from file");
     validateImport("value");
   }


### PR DESCRIPTION
A relative path provided for the location of a snapshot, where the relative path contained no parent would fail. This fix converts the path to absolute before finding the parent.

@jaredjstewart 