### PR TITLE
GEODE-3083: Fix geode-protobuf stats.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -83,9 +83,9 @@ public class ServerConnectionFactory {
   }
 
   private ClientProtocolMessageHandler getOrCreateClientProtocolMessageHandler(
-      StatisticsFactory statisticsFactory, Acceptor acceptor) {
+      StatisticsFactory statisticsFactory, String serverName) {
     if (protocolHandler == null) {
-      return initializeMessageHandler(statisticsFactory, acceptor.getServerName());
+      return initializeMessageHandler(statisticsFactory, serverName);
     }
     return protocolHandler;
   }
@@ -103,7 +103,8 @@ public class ServerConnectionFactory {
 
         return new GenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,
             socketBufferSize, communicationModeStr, communicationMode, acceptor,
-            getOrCreateClientProtocolMessageHandler(cache.getDistributedSystem(), acceptor),
+            getOrCreateClientProtocolMessageHandler(cache.getDistributedSystem(),
+                acceptor.getServerName()),
             securityService, findStreamAuthenticator(authenticationMode));
       }
     } else {

--- a/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/statistics/ProtobufClientStatisticsImpl.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/protocol/protobuf/statistics/ProtobufClientStatisticsImpl.java
@@ -64,8 +64,8 @@ public class ProtobufClientStatisticsImpl implements ProtobufClientStatistics {
     authenticationFailuresId = this.stats.nameToId("authenticationFailures");
     bytesReceivedId = this.stats.nameToId("bytesReceived");
     bytesSentId = this.stats.nameToId("bytesSent");
-    messagesReceivedId = this.stats.nameToId("bytesReceived");
-    messagesSentId = this.stats.nameToId("bytesSent");
+    messagesReceivedId = this.stats.nameToId("messagesReceived");
+    messagesSentId = this.stats.nameToId("messagesSent");
   }
 
   @Override

--- a/geode-protobuf/src/test/java/org/apache/geode/protocol/acceptance/LocatorConnectionDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/protocol/acceptance/LocatorConnectionDUnitTest.java
@@ -130,12 +130,6 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
     Properties properties = super.getDistributedSystemProperties();
     properties.put(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
     properties.put(ConfigurationProperties.STATISTIC_SAMPLE_RATE, "100");
-    String statFileName = getUniqueName() + ".gfs";
-    properties.put(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statFileName);
-    File statFile = new File(statFileName);
-    if (statFile.exists()) {
-      statFile.delete();
-    }
     return properties;
   }
 


### PR DESCRIPTION
- Enhance and rename test of basic messages and statistics to use the statistics directly.
- Fix protobuf client statistics to properly update messages sent and received statistics.
- Remove another use of stats file.

Signed-off-by: Galen O'Sullivan <gosullivan@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
