### PR TITLE
GEODE-3680 - Removing static cache lookup from lucene functions

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
@@ -53,10 +53,6 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 @SuppressWarnings("unused")
 public class LuceneCreateIndexFunction extends FunctionAdapter implements InternalEntity {
 
-  protected Cache getCache() {
-    return CacheFactory.getAnyInstance();
-  }
-
   public String getId() {
     return LuceneCreateIndexFunction.class.getName();
   }
@@ -65,7 +61,7 @@ public class LuceneCreateIndexFunction extends FunctionAdapter implements Intern
     String memberId = null;
     try {
       final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
-      final Cache cache = getCache();
+      final Cache cache = context.getCache();
       memberId = cache.getDistributedSystem().getDistributedMember().getId();
       LuceneService service = LuceneServiceProvider.get(cache);
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
@@ -44,10 +44,6 @@ import org.apache.geode.internal.InternalEntity;
 @SuppressWarnings("unused")
 public class LuceneDescribeIndexFunction extends FunctionAdapter implements InternalEntity {
 
-  protected Cache getCache() {
-    return CacheFactory.getAnyInstance();
-  }
-
   public String getId() {
     return LuceneDescribeIndexFunction.class.getName();
   }
@@ -55,7 +51,7 @@ public class LuceneDescribeIndexFunction extends FunctionAdapter implements Inte
   public void execute(final FunctionContext context) {
     LuceneIndexDetails result = null;
 
-    final Cache cache = getCache();
+    final Cache cache = context.getCache();
     final String serverName = cache.getDistributedSystem().getDistributedMember().getName();
     final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
     LuceneServiceImpl service = (LuceneServiceImpl) LuceneServiceProvider.get(cache);

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunction.java
@@ -32,12 +32,12 @@ public class LuceneDestroyIndexFunction implements Function, InternalEntity {
 
   public void execute(final FunctionContext context) {
     CliFunctionResult result = null;
-    String memberId = getCache().getDistributedSystem().getDistributedMember().getId();
+    String memberId = context.getCache().getDistributedSystem().getDistributedMember().getId();
     try {
       LuceneDestroyIndexInfo indexInfo = (LuceneDestroyIndexInfo) context.getArguments();
       String indexName = indexInfo.getIndexName();
       String regionPath = indexInfo.getRegionPath();
-      LuceneService service = LuceneServiceProvider.get(getCache());
+      LuceneService service = LuceneServiceProvider.get(context.getCache());
       if (indexName == null) {
         if (indexInfo.isDefinedDestroyOnly()) {
           ((LuceneServiceImpl) service).destroyDefinedIndexes(regionPath);
@@ -64,9 +64,5 @@ public class LuceneDestroyIndexFunction implements Function, InternalEntity {
   protected XmlEntity getXmlEntity(String indexName, String regionPath) {
     return new XmlEntity(CacheXml.REGION, "name", regionPath, LuceneXmlConstants.PREFIX,
         LuceneXmlConstants.NAMESPACE, LuceneXmlConstants.INDEX, "name", indexName);
-  }
-
-  protected Cache getCache() {
-    return CacheFactory.getAnyInstance();
   }
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -45,17 +45,13 @@ import org.apache.geode.internal.InternalEntity;
 @SuppressWarnings("unused")
 public class LuceneListIndexFunction extends FunctionAdapter implements InternalEntity {
 
-  protected Cache getCache() {
-    return CacheFactory.getAnyInstance();
-  }
-
   public String getId() {
     return LuceneListIndexFunction.class.getName();
   }
 
   public void execute(final FunctionContext context) {
     final Set<LuceneIndexDetails> indexDetailsSet = new HashSet<>();
-    final Cache cache = getCache();
+    final Cache cache = context.getCache();
     final String serverName = cache.getDistributedSystem().getDistributedMember().getName();
     LuceneServiceImpl service = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
     for (LuceneIndex index : service.getAllIndexes()) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
@@ -51,20 +51,16 @@ import org.apache.geode.internal.InternalEntity;
 @SuppressWarnings("unused")
 public class LuceneSearchIndexFunction<K, V> extends FunctionAdapter implements InternalEntity {
 
-  protected Cache getCache() {
-    return CacheFactory.getAnyInstance();
-  }
-
   public String getId() {
     return LuceneSearchIndexFunction.class.getName();
   }
 
   public void execute(final FunctionContext context) {
     Set<LuceneSearchResults> result = new HashSet<>();
-    final Cache cache = getCache();
+    final Cache cache = context.getCache();
     final LuceneQueryInfo queryInfo = (LuceneQueryInfo) context.getArguments();
 
-    LuceneService luceneService = LuceneServiceProvider.get(getCache());
+    LuceneService luceneService = LuceneServiceProvider.get(context.getCache());
     try {
       if (luceneService.getIndex(queryInfo.getIndexName(), queryInfo.getRegionPath()) == null) {
         throw new Exception("Index " + queryInfo.getIndexName() + " not found on region "

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
@@ -65,6 +65,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
     context = mock(FunctionContext.class);
     resultSender = mock(ResultSender.class);
     when(context.getResultSender()).thenReturn(resultSender);
+    when(context.getCache()).thenReturn(cache);
 
     XmlEntity xmlEntity = null;
     expectedResult = new CliFunctionResult(member, xmlEntity);
@@ -84,8 +85,6 @@ public class LuceneCreateIndexFunctionJUnitTest {
     when(context.getArguments()).thenReturn(indexInfo);
 
     LuceneCreateIndexFunction function = new LuceneCreateIndexFunction();
-    function = spy(function);
-    doReturn(cache).when(function).getCache();
     function.execute(context);
 
     ArgumentCaptor<Map> analyzersCaptor = ArgumentCaptor.forClass(Map.class);
@@ -110,8 +109,6 @@ public class LuceneCreateIndexFunctionJUnitTest {
     when(context.getArguments()).thenReturn(indexInfo);
 
     LuceneCreateIndexFunction function = new LuceneCreateIndexFunction();
-    function = spy(function);
-    doReturn(cache).when(function).getCache();
     function.execute(context);
 
     verify(factory).addField(eq("field1"));

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
@@ -53,11 +53,11 @@ public class LuceneDescribeIndexFunctionJUnitTest {
     ResultSender resultSender = mock(ResultSender.class);
     LuceneIndexInfo indexInfo = getMockLuceneInfo("index1");
     LuceneIndexImpl index1 = getMockLuceneIndex("index1");
-    LuceneDescribeIndexFunction function = spy(LuceneDescribeIndexFunction.class);
+    LuceneDescribeIndexFunction function = new LuceneDescribeIndexFunction();
 
     doReturn(indexInfo).when(context).getArguments();
     doReturn(resultSender).when(context).getResultSender();
-    doReturn(cache).when(function).getCache();
+    doReturn(cache).when(context).getCache();
     when(service.getIndex(indexInfo.getIndexName(), indexInfo.getRegionPath())).thenReturn(index1);
 
     function.execute(context);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunctionJUnitTest.java
@@ -49,6 +49,7 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     this.context = mock(FunctionContext.class);
     this.resultSender = mock(ResultSender.class);
     when(this.context.getResultSender()).thenReturn(this.resultSender);
+    when(this.context.getCache()).thenReturn(this.cache);
   }
 
   @Test
@@ -60,7 +61,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
     function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     function.execute(this.context);
     verify(this.service).destroyIndex(eq(indexName), eq(regionPath));
     verify(function).getXmlEntity(eq(indexName), eq(regionPath));
@@ -77,8 +77,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     LuceneDestroyIndexInfo indexInfo = new LuceneDestroyIndexInfo(indexName, regionPath, false);
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
-    function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     doThrow(new IllegalStateException()).when(this.service).destroyIndex(eq(indexName),
         eq(regionPath));
     function.execute(this.context);
@@ -93,7 +91,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
     function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     function.execute(this.context);
     verify(this.service).destroyDefinedIndex(eq(indexName), eq(regionPath));
     verify(this.service, never()).destroyIndex(eq(indexName), eq(regionPath));
@@ -110,8 +107,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     LuceneDestroyIndexInfo indexInfo = new LuceneDestroyIndexInfo(indexName, regionPath, true);
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
-    function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     doThrow(new IllegalStateException()).when(this.service).destroyDefinedIndex(eq(indexName),
         eq(regionPath));
     function.execute(this.context);
@@ -126,7 +121,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
     function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     function.execute(this.context);
     verify(this.service).destroyIndexes(eq(regionPath));
     verify(function).getXmlEntity(eq(null), eq(regionPath));
@@ -142,8 +136,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     LuceneDestroyIndexInfo indexInfo = new LuceneDestroyIndexInfo(null, regionPath, false);
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
-    function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     doThrow(new IllegalStateException()).when(this.service).destroyIndexes(eq(regionPath));
     function.execute(this.context);
     verifyFunctionResult(false);
@@ -157,7 +149,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
     function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     function.execute(this.context);
     verify(this.service).destroyDefinedIndexes(eq(regionPath));
     verify(this.service, never()).destroyIndexes(eq(regionPath));
@@ -173,8 +164,6 @@ public class LuceneDestroyIndexFunctionJUnitTest {
     LuceneDestroyIndexInfo indexInfo = new LuceneDestroyIndexInfo(null, regionPath, true);
     when(this.context.getArguments()).thenReturn(indexInfo);
     LuceneDestroyIndexFunction function = new LuceneDestroyIndexFunction();
-    function = spy(function);
-    doReturn(this.cache).when(function).getCache();
     doThrow(new IllegalStateException()).when(this.service).destroyDefinedIndexes(eq(regionPath));
     function.execute(this.context);
     verifyFunctionResult(false);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
@@ -57,6 +57,7 @@ public class LuceneListIndexFunctionJUnitTest {
     FunctionContext context = mock(FunctionContext.class);
     ResultSender resultSender = mock(ResultSender.class);
     when(context.getResultSender()).thenReturn(resultSender);
+    when(context.getCache()).thenReturn(cache);
 
     LuceneIndexImpl index1 = getMockLuceneIndex("index1");
     LuceneIndexImpl index2 = getMockLuceneIndex("index2");
@@ -71,8 +72,6 @@ public class LuceneListIndexFunctionJUnitTest {
     when(service.getAllIndexes()).thenReturn(allIndexes);
 
     LuceneListIndexFunction function = new LuceneListIndexFunction();
-    function = spy(function);
-    Mockito.doReturn(cache).when(function).getCache();
     function.execute(context);
 
     ArgumentCaptor<Set> resultCaptor = ArgumentCaptor.forClass(Set.class);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
@@ -58,11 +58,11 @@ public class LuceneSearchIndexFunctionJUnitTest {
     InternalLuceneService service = getMockLuceneService("A", "Value", "1.2");
     Region mockRegion = mock(Region.class);
 
-    LuceneSearchIndexFunction function = spy(LuceneSearchIndexFunction.class);
+    LuceneSearchIndexFunction function = new LuceneSearchIndexFunction();
 
     doReturn(queryInfo).when(context).getArguments();
     doReturn(resultSender).when(context).getResultSender();
-    doReturn(cache).when(function).getCache();
+    doReturn(cache).when(context).getCache();
 
     when(cache.getService(eq(InternalLuceneService.class))).thenReturn(service);
     when(cache.getRegion(queryInfo.getRegionPath())).thenReturn(mockRegion);


### PR DESCRIPTION
Removed the static lookup of a cache from gfsh related functions in the
lucene module.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
