### PR TITLE
GEODE-3578 Revise docs for CQ authorization level change

### DIFF
--- a/geode-docs/managing/security/implementing_authorization.html.md.erb
+++ b/geode-docs/managing/security/implementing_authorization.html.md.erb
@@ -103,8 +103,8 @@ a Client-Server interaction.
 | Region.destroy(key)                | DATA:WRITE:RegionName:Key           |
 | Region.put(key)                    | DATA:WRITE:RegionName:Key           |
 | Region.replace                     | DATA:WRITE:RegionName:Key           |
-| CqQuery.execute                    | DATA:READ:RegionName and CLUSTER:MANAGE:QUERY  |
-| CqQuery.executeWithInitialResults  | DATA:READ:RegionName and CLUSTER:MANAGE:QUERY  |
+| queryService.newCq                 | DATA:READ:RegionName                |
+| CqQuery.stop                       | DATA:READ                           |
 
 
 This table classifies the permissions assigned for `gfsh` operations.
@@ -232,6 +232,8 @@ This table classifies the permissions assigned for JMX operations.
 | CacheServerMXBean.closeAllContinuousQuery      | CLUSTER:MANAGE:QUERY      |
 | CacheServerMXBean.closeContinuousQuery         | CLUSTER:MANAGE:QUERY      |
 | CacheServerMXBean.executeContinuousQuery       | DATA:READ                 |
+| CqQuery.execute                    | DATA:READ:RegionName and CLUSTER:MANAGE:QUERY  |
+| CqQuery.executeWithInitialResults  | DATA:READ:RegionName and CLUSTER:MANAGE:QUERY  |
 | DiskStoreMXBean.flush                          | CLUSTER:MANAGE:DISK       |
 | DiskStoreMXBean.forceCompaction                | CLUSTER:MANAGE:DISK       |
 | DiskStoreMXBean.forceRoll                      | CLUSTER:MANAGE:DISK       |


### PR DESCRIPTION
@sbawaska @jinmeiliao @PurelyApplied @jaredjstewart @davebarnes97 @joeymcallister Please review.

Note that I also moved CqQuery execute() and executeWithInitialResults() methods to reside within the table for JMX operations, as they were misplaced.

