### PR TITLE
GEODE-3620: check for null argument to prevent NPE

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/io/MainWithChildrenRollingFileHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/io/MainWithChildrenRollingFileHandler.java
@@ -228,6 +228,9 @@ public class MainWithChildrenRollingFileHandler implements RollingFileHandler {
 
   private File[] findChildrenExcept(final File dir, final Pattern pattern, final File exception) {
     final String exceptionName = (exception == null) ? null : exception.getName();
+    if (dir == null) {
+      return new File[] {};
+    }
     return dir
         .listFiles((dir1, name) -> !name.equals(exceptionName) && pattern.matcher(name).matches());
   }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/LocatorServerStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/LocatorServerStartupRule.java
@@ -107,15 +107,17 @@ public class LocatorServerStartupRule extends ExternalResource implements Serial
 
   @Override
   protected void after() {
-    DUnitLauncher.closeAndCheckForSuspects();
+    try {
+      DUnitLauncher.closeAndCheckForSuspects();
+    } finally {
+      MemberStarterRule.disconnectDSIfAny();
+      IntStream.range(0, DUnitLauncher.NUM_VMS).forEach(this::stopVM);
 
-    MemberStarterRule.disconnectDSIfAny();
-    IntStream.range(0, DUnitLauncher.NUM_VMS).forEach(this::stopVM);
-
-    if (useTempWorkingDir()) {
-      tempWorkingDir.delete();
+      if (useTempWorkingDir()) {
+        tempWorkingDir.delete();
+      }
+      restoreSystemProperties.after();
     }
-    restoreSystemProperties.after();
   }
 
   public MemberVM<Locator> startLocatorVM(int index) throws Exception {


### PR DESCRIPTION
Added new tests.

Fixes problem in LocatorServerStartupRule where a faiulure due to
suspect strings caused dunit VM cleanup to be skipped.

Verified new tests with before and after fix runs.

Precheckin is running

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
