### PR TITLE
GEODE-3710 Make CodecAlreadyRegisteredForTypeException a RuntimeException

### DIFF
--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufSerializationService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufSerializationService.java
@@ -20,14 +20,13 @@ import org.apache.geode.internal.serialization.SerializationType;
 import org.apache.geode.internal.serialization.TypeCodec;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
 import org.apache.geode.internal.serialization.registry.SerializationCodecRegistry;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
 
 @Experimental
 public class ProtobufSerializationService implements SerializationService<BasicTypes.EncodingType> {
   private SerializationCodecRegistry serializationCodecRegistry = new SerializationCodecRegistry();
 
-  public ProtobufSerializationService() throws CodecAlreadyRegisteredForTypeException {}
+  public ProtobufSerializationService() {}
 
   @Override
   public byte[] encode(BasicTypes.EncodingType encodingTypeValue, Object value)

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessor.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessor.java
@@ -33,7 +33,6 @@ import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSe
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatisticsImpl;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 
 /**
  * This object handles an incoming stream containing protobuf messages. It parses the protobuf
@@ -47,7 +46,7 @@ public class ProtobufStreamProcessor implements ClientProtocolMessageHandler {
   private ProtobufClientStatistics statistics;
   private static final Logger logger = LogService.getLogger();
 
-  public ProtobufStreamProcessor() throws CodecAlreadyRegisteredForTypeException {
+  public ProtobufStreamProcessor() {
     protobufProtocolSerializer = new ProtobufProtocolSerializer();
     protobufOpsProcessor = new ProtobufOpsProcessor(new ProtobufSerializationService(),
         new OperationContextRegistry());

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
@@ -27,15 +27,14 @@ import org.apache.geode.internal.serialization.registry.exception.CodecNotRegist
 public class SerializationCodecRegistry {
   private HashMap<SerializationType, TypeCodec> codecRegistry = new HashMap<>();
 
-  public SerializationCodecRegistry() throws CodecAlreadyRegisteredForTypeException {
+  public SerializationCodecRegistry() {
     ServiceLoader<TypeCodec> typeCodecs = ServiceLoader.load(TypeCodec.class);
     for (TypeCodec typeCodec : typeCodecs) {
       register(typeCodec.getSerializationType(), typeCodec);
     }
   }
 
-  public synchronized void register(SerializationType serializationType, TypeCodec<?> typeCodec)
-      throws CodecAlreadyRegisteredForTypeException {
+  public synchronized void register(SerializationType serializationType, TypeCodec<?> typeCodec) {
     if (codecRegistry.containsKey(serializationType)) {
       throw new CodecAlreadyRegisteredForTypeException(
           "There is already a codec registered for type: " + serializationType);

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
@@ -25,7 +25,7 @@ import org.apache.geode.internal.serialization.registry.exception.CodecNotRegist
 
 @Experimental
 public class SerializationCodecRegistry {
-  private HashMap<SerializationType, TypeCodec> codecRegistry = new HashMap<>();
+  private final HashMap<SerializationType, TypeCodec> codecRegistry = new HashMap<>();
 
   public SerializationCodecRegistry() {
     ServiceLoader<TypeCodec> typeCodecs = ServiceLoader.load(TypeCodec.class);
@@ -34,7 +34,7 @@ public class SerializationCodecRegistry {
     }
   }
 
-  public synchronized void register(SerializationType serializationType, TypeCodec<?> typeCodec) {
+  private void register(SerializationType serializationType, TypeCodec<?> typeCodec) {
     if (codecRegistry.containsKey(serializationType)) {
       throw new CodecAlreadyRegisteredForTypeException(
           "There is already a codec registered for type: " + serializationType);

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/SerializationCodecRegistry.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.serialization.registry;
 import java.util.HashMap;
 import java.util.ServiceLoader;
 
+import org.apache.geode.GemFireConfigException;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.internal.serialization.SerializationType;
 import org.apache.geode.internal.serialization.TypeCodec;
@@ -29,8 +30,12 @@ public class SerializationCodecRegistry {
 
   public SerializationCodecRegistry() {
     ServiceLoader<TypeCodec> typeCodecs = ServiceLoader.load(TypeCodec.class);
-    for (TypeCodec typeCodec : typeCodecs) {
-      register(typeCodec.getSerializationType(), typeCodec);
+    try {
+      for (TypeCodec typeCodec : typeCodecs) {
+        register(typeCodec.getSerializationType(), typeCodec);
+      }
+    } catch (CodecAlreadyRegisteredForTypeException ex) {
+      throw new GemFireConfigException("Multiple implementations found for the same TypeCodec", ex);
     }
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/exception/CodecAlreadyRegisteredForTypeException.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/serialization/registry/exception/CodecAlreadyRegisteredForTypeException.java
@@ -21,7 +21,7 @@ import org.apache.geode.annotations.Experimental;
  * handler for.
  */
 @Experimental
-public class CodecAlreadyRegisteredForTypeException extends Exception {
+public class CodecAlreadyRegisteredForTypeException extends RuntimeException {
   public CodecAlreadyRegisteredForTypeException(String message) {
     super(message);
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
@@ -14,25 +14,12 @@
  */
 package org.apache.geode.internal.protocol;
 
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.server.CacheServer;
-import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.management.internal.security.ResourceConstants;
-import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
-import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
-import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
-import org.apache.geode.security.SecurityManager;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
-import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
-import org.junit.experimental.categories.Category;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,12 +28,25 @@ import java.net.Socket;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
+import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
+import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
+import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.geode.security.SecurityManager;
+import org.apache.geode.test.junit.categories.IntegrationTest;
 
 @Category(IntegrationTest.class)
 public class AuthenticationIntegrationTest {
@@ -62,8 +62,7 @@ public class AuthenticationIntegrationTest {
   private InputStream inputStream;
   private ProtobufProtocolSerializer protobufProtocolSerializer;
 
-  public void setUp(String authenticationMode)
-      throws IOException, CodecAlreadyRegisteredForTypeException {
+  public void setUp(String authenticationMode) throws IOException {
     Properties expectedAuthProperties = new Properties();
     expectedAuthProperties.setProperty(ResourceConstants.USER_NAME, TEST_USERNAME);
     expectedAuthProperties.setProperty(ResourceConstants.PASSWORD, TEST_PASSWORD);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthorizationIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthorizationIntegrationTest.java
@@ -42,15 +42,14 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
-import org.apache.geode.management.internal.security.ResourceConstants;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
+import org.apache.geode.management.internal.security.ResourceConstants;
 import org.apache.geode.security.ResourcePermission;
 import org.apache.geode.security.SecurityManager;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
 @Category(IntegrationTest.class)
@@ -80,7 +79,7 @@ public class AuthorizationIntegrationTest {
       new ResourcePermission(ResourcePermission.Resource.DATA, ResourcePermission.Operation.WRITE);
 
   @Before
-  public void setUp() throws IOException, CodecAlreadyRegisteredForTypeException {
+  public void setUp() throws IOException {
     Properties expectedAuthProperties = new Properties();
     expectedAuthProperties.setProperty(ResourceConstants.USER_NAME, TEST_USERNAME);
     expectedAuthProperties.setProperty(ResourceConstants.PASSWORD, TEST_PASSWORD);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/MessageUtil.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/MessageUtil.java
@@ -21,7 +21,6 @@ import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtil
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.serialization.SerializationService;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
 
 public class MessageUtil {
@@ -49,8 +48,7 @@ public class MessageUtil {
   public static ClientProtocol.Message makePutRequestMessage(
       SerializationService serializationService, String requestKey, String requestValue,
       String requestRegion, ClientProtocol.MessageHeader header)
-      throws CodecNotRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecAlreadyRegisteredForTypeException {
+      throws CodecNotRegisteredForTypeException, UnsupportedEncodingTypeException {
     BasicTypes.Entry entry = ProtobufUtilities.createEntry(
         ProtobufUtilities.createEncodedValue(serializationService, requestKey),
         ProtobufUtilities.createEncodedValue(serializationService, requestValue));
@@ -62,8 +60,7 @@ public class MessageUtil {
 
   public static ClientProtocol.Message makeGetRequestMessage(
       SerializationService serializationService, Object requestKey, String requestRegion,
-      ClientProtocol.MessageHeader header) throws CodecAlreadyRegisteredForTypeException,
-      UnsupportedEncodingTypeException, CodecNotRegisteredForTypeException {
+      ClientProtocol.MessageHeader header) throws Exception {
     ClientProtocol.Request request = ProtobufRequestUtilities.createGetRequest(requestRegion,
         ProtobufUtilities.createEncodedValue(serializationService, requestKey));
     return ProtobufUtilities.createProtobufMessage(header, request);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
@@ -59,17 +59,16 @@ import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.protocol.protobuf.BasicTypes;
-import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.internal.protocol.protobuf.BasicTypes;
+import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.serialization.SerializationService;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.util.test.TestUtil;
@@ -219,7 +218,7 @@ public class CacheConnectionJUnitTest {
   private void validateGetResponse(Socket socket,
       ProtobufProtocolSerializer protobufProtocolSerializer, Object expectedValue)
       throws InvalidProtocolMessageException, IOException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, CodecAlreadyRegisteredForTypeException {
+      CodecNotRegisteredForTypeException {
     ClientProtocol.Response response =
         deserializeResponse(socket, protobufProtocolSerializer, TEST_GET_CORRELATION_ID);
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheOperationsJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheOperationsJUnitTest.java
@@ -58,18 +58,17 @@ import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.protocol.protobuf.BasicTypes;
-import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.internal.protocol.protobuf.BasicTypes;
+import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.serialization.SerializationService;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.util.test.TestUtil;
@@ -304,7 +303,7 @@ public class CacheOperationsJUnitTest {
   private void validateGetResponse(Socket socket,
       ProtobufProtocolSerializer protobufProtocolSerializer, Object expectedValue)
       throws InvalidProtocolMessageException, IOException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, CodecAlreadyRegisteredForTypeException {
+      CodecNotRegisteredForTypeException {
     ClientProtocol.Response response =
         deserializeResponse(socket, protobufProtocolSerializer, TEST_GET_CORRELATION_ID);
 
@@ -356,9 +355,8 @@ public class CacheOperationsJUnitTest {
   }
 
   private void validateGetAllResponse(Socket socket,
-      ProtobufProtocolSerializer protobufProtocolSerializer)
-      throws InvalidProtocolMessageException, IOException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, CodecAlreadyRegisteredForTypeException {
+      ProtobufProtocolSerializer protobufProtocolSerializer) throws InvalidProtocolMessageException,
+      IOException, UnsupportedEncodingTypeException, CodecNotRegisteredForTypeException {
     ClientProtocol.Response response =
         deserializeResponse(socket, protobufProtocolSerializer, TEST_GET_CORRELATION_ID);
     assertEquals(ClientProtocol.Response.ResponseAPICase.GETALLRESPONSE,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetAllRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetAllRequestOperationHandlerJUnitTest.java
@@ -42,10 +42,9 @@ import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -78,9 +77,7 @@ public class GetAllRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processReturnsExpectedValuesForValidKeys()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsExpectedValuesForValidKeys() throws Exception {
     Result<RegionAPI.GetAllResponse> result = operationHandler.process(serializationServiceStub,
         generateTestRequest(true, false),
         new MessageExecutionContext(cacheStub, new NoOpAuthorizer(), new NoOpProtobufStatistics()));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,11 +35,9 @@ import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
-import org.apache.geode.test.dunit.Assert;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -64,8 +63,7 @@ public class GetRegionNamesRequestOperationHandlerJUnitTest extends OperationHan
   }
 
   @Test
-  public void processReturnsCacheRegions()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
+  public void processReturnsCacheRegions() throws UnsupportedEncodingTypeException,
       CodecNotRegisteredForTypeException, InvalidExecutionContextException {
     Result<RegionAPI.GetRegionNamesResponse> result = operationHandler.process(
         serializationServiceStub, ProtobufRequestUtilities.createGetRegionNamesRequest(),
@@ -87,9 +85,7 @@ public class GetRegionNamesRequestOperationHandlerJUnitTest extends OperationHan
   }
 
   @Test
-  public void processReturnsNoCacheRegions()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsNoCacheRegions() throws Exception {
     Cache emptyCache = mock(Cache.class);;
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRegionRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRegionRequestOperationHandlerJUnitTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,20 +31,15 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
-import org.apache.geode.internal.exception.InvalidExecutionContextException;
+import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
-import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.protobuf.Failure;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.security.server.NoOpAuthorizer;
-import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -62,9 +58,7 @@ public class GetRegionRequestOperationHandlerJUnitTest extends OperationHandlerJ
   }
 
   @Test
-  public void processReturnsCacheRegions()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsCacheRegions() throws Exception {
 
     RegionAttributes regionAttributesStub = mock(RegionAttributes.class);
     when(cacheStub.getRegion(TEST_REGION1)).thenReturn(region1Stub);
@@ -96,9 +90,7 @@ public class GetRegionRequestOperationHandlerJUnitTest extends OperationHandlerJ
   }
 
   @Test
-  public void processReturnsNoCacheRegions()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsNoCacheRegions() throws Exception {
     Cache emptyCache = mock(Cache.class);
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetRequestOperationHandlerJUnitTest.java
@@ -18,30 +18,26 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.UnsupportedEncodingException;
-
 import com.google.protobuf.ByteString;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
-import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Failure;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
-import org.apache.geode.test.dunit.Assert;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -70,9 +66,7 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void processReturnsTheEncodedValueFromTheRegion()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsTheEncodedValueFromTheRegion() throws Exception {
     RegionAPI.GetRequest getRequest = generateTestRequest(false, false, false);
     Result<RegionAPI.GetResponse> result = operationHandler.process(serializationServiceStub,
         getRequest,
@@ -86,9 +80,7 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void processReturnsUnsucessfulResponseForInvalidRegion()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsUnsucessfulResponseForInvalidRegion() throws Exception {
     RegionAPI.GetRequest getRequest = generateTestRequest(true, false, false);
     Result<RegionAPI.GetResponse> response = operationHandler.process(serializationServiceStub,
         getRequest,
@@ -100,9 +92,7 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void processReturnsKeyNotFoundWhenKeyIsNotFound()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsKeyNotFoundWhenKeyIsNotFound() throws Exception {
     RegionAPI.GetRequest getRequest = generateTestRequest(false, true, false);
     Result<RegionAPI.GetResponse> response = operationHandler.process(serializationServiceStub,
         getRequest,
@@ -112,9 +102,7 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void processReturnsLookupFailureWhenKeyFoundWithNoValue()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsLookupFailureWhenKeyFoundWithNoValue() throws Exception {
     RegionAPI.GetRequest getRequest = generateTestRequest(false, false, true);
     Result<RegionAPI.GetResponse> response = operationHandler.process(serializationServiceStub,
         getRequest,
@@ -124,10 +112,7 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void processReturnsErrorWhenUnableToDecodeRequest()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, UnsupportedEncodingException,
-      InvalidExecutionContextException {
+  public void processReturnsErrorWhenUnableToDecodeRequest() throws Exception {
     CodecNotRegisteredForTypeException exception =
         new CodecNotRegisteredForTypeException("error finding codec for type");
     when(serializationServiceStub.decode(any(), any())).thenThrow(exception);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/PutAllRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/PutAllRequestOperationHandlerJUnitTest.java
@@ -31,7 +31,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
-import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Result;
@@ -39,10 +38,9 @@ import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.junit.categories.UnitTest;
 
@@ -71,9 +69,7 @@ public class PutAllRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processInsertsMultipleValidEntriesInCache()
-      throws UnsupportedEncodingTypeException, CodecNotRegisteredForTypeException,
-      CodecAlreadyRegisteredForTypeException, InvalidExecutionContextException {
+  public void processInsertsMultipleValidEntriesInCache() throws Exception {
     PutAllRequestOperationHandler operationHandler = new PutAllRequestOperationHandler();
 
     Result<RegionAPI.PutAllResponse> result = operationHandler.process(serializationServiceStub,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/PutRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/PutRequestOperationHandlerJUnitTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.UnsupportedEncodingException;
-
 import com.google.protobuf.ByteString;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,20 +30,18 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
-import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Failure;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -66,9 +62,7 @@ public class PutRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void test_puttingTheEncodedEntryIntoRegion()
-      throws UnsupportedEncodingTypeException, CodecNotRegisteredForTypeException,
-      CodecAlreadyRegisteredForTypeException, InvalidExecutionContextException {
+  public void test_puttingTheEncodedEntryIntoRegion() throws Exception {
     PutRequestOperationHandler operationHandler = new PutRequestOperationHandler();
     Result<RegionAPI.PutResponse> result = operationHandler.process(serializationServiceStub,
         generateTestRequest(),
@@ -81,9 +75,7 @@ public class PutRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void test_invalidEncodingType() throws CodecAlreadyRegisteredForTypeException,
-      UnsupportedEncodingTypeException, CodecNotRegisteredForTypeException,
-      UnsupportedEncodingException, InvalidExecutionContextException {
+  public void test_invalidEncodingType() throws Exception {
     String exceptionText = "unsupported type!";
     UnsupportedEncodingTypeException exception =
         new UnsupportedEncodingTypeException(exceptionText);
@@ -112,9 +104,7 @@ public class PutRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void test_RegionNotFound()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void test_RegionNotFound() throws Exception {
     when(cacheStub.getRegion(TEST_REGION)).thenReturn(null);
     PutRequestOperationHandler operationHandler = new PutRequestOperationHandler();
     Result<RegionAPI.PutResponse> result = operationHandler.process(serializationServiceStub,
@@ -127,9 +117,7 @@ public class PutRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
   }
 
   @Test
-  public void test_RegionThrowsClasscastException()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void test_RegionThrowsClasscastException() throws Exception {
     when(regionMock.put(any(), any())).thenThrow(ClassCastException.class);
 
     PutRequestOperationHandler operationHandler = new PutRequestOperationHandler();

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/RemoveRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/RemoveRequestOperationHandlerJUnitTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.UnsupportedEncodingException;
-
 import com.google.protobuf.ByteString;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,21 +28,19 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
-import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Failure;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.Success;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
-import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
+import org.apache.geode.security.server.NoOpAuthorizer;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -71,9 +67,7 @@ public class RemoveRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processValidKeyRemovesTheEntryAndReturnSuccess()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processValidKeyRemovesTheEntryAndReturnSuccess() throws Exception {
     RegionAPI.RemoveRequest removeRequest = generateTestRequest(false, false).getRemoveRequest();
     Result<RegionAPI.RemoveResponse> result = operationHandler.process(serializationServiceStub,
         removeRequest,
@@ -84,9 +78,7 @@ public class RemoveRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processReturnsUnsucessfulResponseForInvalidRegion()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsUnsucessfulResponseForInvalidRegion() throws Exception {
     RegionAPI.RemoveRequest removeRequest = generateTestRequest(true, false).getRemoveRequest();
     Result<RegionAPI.RemoveResponse> result = operationHandler.process(serializationServiceStub,
         removeRequest,
@@ -98,9 +90,7 @@ public class RemoveRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processReturnsSuccessWhenKeyIsNotFound()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, InvalidExecutionContextException {
+  public void processReturnsSuccessWhenKeyIsNotFound() throws Exception {
     RegionAPI.RemoveRequest removeRequest = generateTestRequest(false, true).getRemoveRequest();
     Result<RegionAPI.RemoveResponse> result = operationHandler.process(serializationServiceStub,
         removeRequest,
@@ -110,10 +100,7 @@ public class RemoveRequestOperationHandlerJUnitTest extends OperationHandlerJUni
   }
 
   @Test
-  public void processReturnsErrorWhenUnableToDecodeRequest()
-      throws CodecAlreadyRegisteredForTypeException, UnsupportedEncodingTypeException,
-      CodecNotRegisteredForTypeException, UnsupportedEncodingException,
-      InvalidExecutionContextException {
+  public void processReturnsErrorWhenUnableToDecodeRequest() throws Exception {
     CodecNotRegisteredForTypeException exception =
         new CodecNotRegisteredForTypeException("error finding codec for type");
     when(serializationServiceStub.decode(any(), any())).thenThrow(exception);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/serialization/registry/CodecRegistryJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/serialization/registry/CodecRegistryJUnitTest.java
@@ -39,7 +39,7 @@ public class CodecRegistryJUnitTest {
   private SerializationCodecRegistry codecRegistry;
 
   @Before
-  public void startup() throws CodecAlreadyRegisteredForTypeException {
+  public void startup() {
     codecRegistry = new SerializationCodecRegistry();
   }
 
@@ -49,32 +49,23 @@ public class CodecRegistryJUnitTest {
   }
 
   @Test
-  public void testRegisterCodec() throws CodecAlreadyRegisteredForTypeException {
+  public void testRegisterCodec() {
     Assert.assertEquals(1, codecRegistry.getRegisteredCodecCount());
     SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
     codecRegistry.register(mockSerializationType, new DummyTypeCodec());
     Assert.assertEquals(2, codecRegistry.getRegisteredCodecCount());
   }
 
-  @Test
-  public void testRegisteringCodecForRegisteredType_throwsException()
-      throws CodecAlreadyRegisteredForTypeException {
+  @Test(expected = CodecAlreadyRegisteredForTypeException.class)
+  public void testRegisteringCodecForRegisteredType_throwsException() {
     SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
     codecRegistry.register(mockSerializationType, new DummyTypeCodec());
 
-    boolean caughtException = false;
-    try {
-      codecRegistry.register(mockSerializationType, new DummyTypeCodec());
-    } catch (CodecAlreadyRegisteredForTypeException e) {
-      caughtException = true;
-    }
-    Assert.assertTrue("This was supposed to have thrown a CodecAlreadyRegisteredException",
-        caughtException);
+    codecRegistry.register(mockSerializationType, new DummyTypeCodec());
   }
 
   @Test
-  public void testGetRegisteredCodec()
-      throws CodecAlreadyRegisteredForTypeException, CodecNotRegisteredForTypeException {
+  public void testGetRegisteredCodec() throws Exception {
     TypeCodec expectedCodec = new DummyTypeCodec();
     SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
     codecRegistry.register(mockSerializationType, expectedCodec);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/serialization/registry/CodecRegistryJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/serialization/registry/CodecRegistryJUnitTest.java
@@ -14,27 +14,19 @@
  */
 package org.apache.geode.internal.serialization.registry;
 
+import static junit.framework.TestCase.assertNotNull;
+
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.apache.geode.internal.serialization.SerializationType;
-import org.apache.geode.internal.serialization.TypeCodec;
-import org.apache.geode.internal.serialization.registry.exception.CodecAlreadyRegisteredForTypeException;
 import org.apache.geode.internal.serialization.registry.exception.CodecNotRegisteredForTypeException;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("*.UnitTest")
-@PrepareForTest({SerializationType.class})
 public class CodecRegistryJUnitTest {
   private SerializationCodecRegistry codecRegistry;
 
@@ -49,51 +41,9 @@ public class CodecRegistryJUnitTest {
   }
 
   @Test
-  public void testRegisterCodec() {
-    Assert.assertEquals(1, codecRegistry.getRegisteredCodecCount());
-    SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
-    codecRegistry.register(mockSerializationType, new DummyTypeCodec());
-    Assert.assertEquals(2, codecRegistry.getRegisteredCodecCount());
-  }
-
-  @Test(expected = CodecAlreadyRegisteredForTypeException.class)
-  public void testRegisteringCodecForRegisteredType_throwsException() {
-    SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
-    codecRegistry.register(mockSerializationType, new DummyTypeCodec());
-
-    codecRegistry.register(mockSerializationType, new DummyTypeCodec());
-  }
-
-  @Test
-  public void testGetRegisteredCodec() throws Exception {
-    TypeCodec expectedCodec = new DummyTypeCodec();
-    SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
-    codecRegistry.register(mockSerializationType, expectedCodec);
-    TypeCodec codec = codecRegistry.getCodecForType(mockSerializationType);
-    Assert.assertSame(expectedCodec, codec);
-  }
-
-  @Test(expected = CodecNotRegisteredForTypeException.class)
-  public void testGetCodecForUnregisteredType_throwsException()
-      throws CodecNotRegisteredForTypeException {
-    SerializationType mockSerializationType = PowerMockito.mock(SerializationType.class);
-    codecRegistry.getCodecForType(mockSerializationType);
-  }
-
-  class DummyTypeCodec implements TypeCodec {
-    @Override
-    public Object decode(byte[] incoming) {
-      return null;
-    }
-
-    @Override
-    public byte[] encode(Object incoming) {
-      return new byte[0];
-    }
-
-    @Override
-    public SerializationType getSerializationType() {
-      return PowerMockito.mock(SerializationType.class);
-    }
+  public void loadingWorks() throws CodecNotRegisteredForTypeException {
+    // This test relies on the serializer being present and registered in META-INF, which it is in
+    // this package.
+    assertNotNull(codecRegistry.getCodecForType(SerializationType.JSON));
   }
 }


### PR DESCRIPTION
GEODE-3710 Make CodecAlreadyRegisteredForTypeException a RuntimeException.

If we throw this exception, the `SerializationCodecRegistry` will
already be in an invalid state, so it doesn't make sense for anyone to
catch it.

Signed-off-by: Sarge <mdodge@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
