### PR TITLE
GEODE-3684: fix a warning during javadoc generation.

### DIFF
--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/utilities/ProtobufUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/utilities/ProtobufUtilities.java
@@ -84,7 +84,7 @@ public abstract class ProtobufUtilities {
 
   /**
    * Creates a protobuf (key, value) pair from unencoded data. if the value is null, it will be
-   * unset in the {@link BasicTypes.Entry}.
+   * unset in the BasicTypes.Entry.
    *
    * The key MUST NOT be null.
    *


### PR DESCRIPTION
We used to have

```
warning - Tag @link: reference not found: BasicTypes.Entry
```

Planning to merge this as soon as PR build goes green.