### PR TITLE
GEODE-3713: add VM.getId() and fix VM.getPid()

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache30/ClientServerCCEDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/ClientServerCCEDUnitTest.java
@@ -999,7 +999,7 @@ public class ClientServerCCEDUnitTest extends JUnit4CacheTestCase {
         cf.setPoolSubscriptionEnabled(true);
         cf.setPoolSubscriptionRedundancy(1);
         // bug #50683 - secondary durable queue retains all GC messages
-        cf.set(DURABLE_CLIENT_ID, "" + vm.getPid());
+        cf.set(DURABLE_CLIENT_ID, "" + vm.getId());
         cf.set(DURABLE_CLIENT_TIMEOUT, "" + 200);
         cf.set(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
         ClientCache cache = getClientCache(cf);

--- a/geode-core/src/test/java/org/apache/geode/cache30/RegionExpirationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/RegionExpirationDUnitTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 import org.apache.geode.cache.AttributesFactory;
@@ -157,7 +156,7 @@ public class RegionExpirationDUnitTest extends JUnit4CacheTestCase {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
-    LogWriterUtils.getLogWriter().info("vm0 is " + vm0.getPid() + ", vm1 is " + vm1);
+    LogWriterUtils.getLogWriter().info("vm0 is " + vm0.getId() + ", vm1 is " + vm1);
 
     LogWriterUtils.getLogWriter().info("2: " + regionName + " action is " + action);
 

--- a/geode-core/src/test/java/org/apache/geode/disttx/DistributedTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/disttx/DistributedTransactionDUnitTest.java
@@ -1348,10 +1348,10 @@ public class DistributedTransactionDUnitTest extends JUnit4CacheTestCase {
     final VM primary = isPrimary.booleanValue() ? server1 : server2;
     final VM secondary = !isPrimary.booleanValue() ? server1 : server2;
 
-    System.out.println("TEST:SERVER-1:VM-" + server1.getPid());
-    System.out.println("TEST:SERVER-2:VM-" + server2.getPid());
-    System.out.println("TEST:PRIMARY=VM-" + primary.getPid());
-    System.out.println("TEST:SECONDARY=VM-" + secondary.getPid());
+    System.out.println("TEST:SERVER-1:VM-" + server1.getId());
+    System.out.println("TEST:SERVER-2:VM-" + server2.getId());
+    System.out.println("TEST:PRIMARY=VM-" + primary.getId());
+    System.out.println("TEST:SECONDARY=VM-" + secondary.getId());
 
     class WaitRelease implements Runnable {
       CountDownLatch cdl;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BackupDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BackupDUnitTest.java
@@ -544,7 +544,7 @@ public class BackupDUnitTest extends PersistentPartitionedRegionTestBase {
     SerializableRunnable validateUserFileBackup = new SerializableRunnable("set user backups") {
       public void run() {
         try {
-          FileUtils.deleteDirectory(new File("userbackup_" + vm.getPid()));
+          FileUtils.deleteDirectory(new File("userbackup_" + vm.getId()));
         } catch (IOException e) {
           fail(e.getMessage());
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
@@ -23,13 +23,11 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.cache.*;
-import org.apache.geode.cache30.CacheTestCase;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
@@ -49,7 +47,6 @@ import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.test.dunit.*;
 import org.apache.geode.test.junit.categories.FlakyTest;
-import org.junit.experimental.categories.Category;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -2262,8 +2259,8 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
       P = vm1;
       R = vm0;
     }
-    LogWriterUtils.getLogWriter().info("After assignVMsToPandR, P is " + P.getPid() + "; R is "
-        + R.getPid() + " for region " + REGION_NAME);
+    LogWriterUtils.getLogWriter().info("After assignVMsToPandR, P is " + P.getId() + "; R is "
+        + R.getId() + " for region " + REGION_NAME);
   }
 
   private DiskStoreID getMemberID(VM vm) {
@@ -2573,7 +2570,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
   }
 
   private String generateValue(final VM vm) {
-    return "VALUE from vm" + vm.getPid();
+    return "VALUE from vm" + vm.getId();
   }
 
   private SerializableRunnable oneDestroyOp(final String key, final String value,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryDUnitTest.java
@@ -40,10 +40,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import org.apache.geode.cache.Cache;
@@ -268,7 +266,7 @@ public class PartitionedRegionQueryDUnitTest extends JUnit4CacheTestCase {
       Cache cache = getCache();
       Region region = cache.getRegion("region");
       IntStream.range(1, 10)
-          .forEach(i -> region.put(i, new NotDeserializableAsset(vmToFailCreationOn.getPid())));
+          .forEach(i -> region.put(i, new NotDeserializableAsset(vmToFailCreationOn.getId())));
     });
 
     vm0.invoke(() -> {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
@@ -209,7 +209,7 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
   }
 
   protected File getDiskDirForVM(final VM vm) {
-    File dir = new File(diskDir, String.valueOf(vm.getPid()));
+    File dir = new File(diskDir, String.valueOf(vm.getId()));
     return dir;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
@@ -568,7 +568,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
     String regionName = "aRegion";
     RegionShortcut shortcut = RegionShortcut.REPLICATE_PERSISTENT;
     for (int i = 0; i < testingDirs.length; i++) {
-      testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getPid()))
+      testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getId()))
           .getAbsoluteFile();
       if (!testingDirs[i].exists()) {
         System.out.println(" Creating diskdir for server: " + i);
@@ -1265,7 +1265,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getPid());
+    VM rollServer = Host.getHost(0).getVM(oldServer.getId());
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -1275,7 +1275,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   private VM rollClientToCurrent(VM oldClient, String[] hostNames, int[] locatorPorts,
       boolean subscriptionEnabled) throws Exception {
     oldClient.invoke(invokeCloseCache());
-    VM rollClient = Host.getHost(0).getVM(oldClient.getPid());
+    VM rollClient = Host.getHost(0).getVM(oldClient.getId());
     rollClient.invoke(invokeCreateClientCache(getClientSystemProperties(), hostNames, locatorPorts,
         subscriptionEnabled));
     rollClient.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -1341,7 +1341,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     rollLocator.invoke(invokeStopLocator());
-    VM newLocator = Host.getHost(0).getVM(rollLocator.getPid());
+    VM newLocator = Host.getHost(0).getVM(rollLocator.getId());
     newLocator.invoke(invokeStartLocator(serverHostName, port, testName,
         getLocatorProperties91AndAfter(locatorString)));
     return newLocator;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
@@ -160,7 +160,7 @@ public class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase {
     } else if ((regionType.equals("persistentReplicate"))) {
       shortcutName = RegionShortcut.PARTITION_PERSISTENT.name();
       for (int i = 0; i < testingDirs.length; i++) {
-        testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getPid()))
+        testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getId()))
             .getAbsoluteFile();
         if (!testingDirs[i].exists()) {
           System.out.println(" Creating diskdir for server: " + i);
@@ -355,7 +355,7 @@ public class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase {
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getPid()); // gets a vm with the current version
+    VM rollServer = Host.getHost(0).getVM(oldServer.getId()); // gets a vm with the current version
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -400,7 +400,7 @@ public class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase {
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     oldLocator.invoke(invokeStopLocator());
-    VM rollLocator = Host.getHost(0).getVM(oldLocator.getPid()); // gets a VM with current version
+    VM rollLocator = Host.getHost(0).getVM(oldLocator.getId()); // gets a VM with current version
     final Properties props = new Properties();
     props.setProperty(DistributionConfig.ENABLE_CLUSTER_CONFIGURATION_NAME, "false");
     rollLocator.invoke(invokeStartLocator(serverHostName, port, testName, locatorString, props));

--- a/geode-core/src/test/java/org/apache/geode/management/ManagementTestRule.java
+++ b/geode-core/src/test/java/org/apache/geode/management/ManagementTestRule.java
@@ -173,7 +173,7 @@ public class ManagementTestRule implements MethodRule, Serializable {
 
   public void createMember(final VM memberVM) {
     Properties properties = new Properties();
-    properties.setProperty(NAME, "memberVM-" + memberVM.getPid());
+    properties.setProperty(NAME, "memberVM-" + memberVM.getId());
     memberVM.invoke("createMember", () -> createMember(properties));
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
@@ -83,7 +83,7 @@ public class AlterRegionCommandDUnitTest extends CliCommandTestBase {
     });
 
     this.alterVm1 = Host.getHost(0).getVM(1);
-    this.alterVm1Name = "VM" + this.alterVm1.getPid();
+    this.alterVm1Name = "VM" + this.alterVm1.getId();
     this.alterVm1.invoke(() -> {
       Properties localProps = new Properties();
       localProps.setProperty(NAME, alterVm1Name);
@@ -117,7 +117,7 @@ public class AlterRegionCommandDUnitTest extends CliCommandTestBase {
     });
 
     this.alterVm2 = Host.getHost(0).getVM(2);
-    this.alterVm2Name = "VM" + this.alterVm2.getPid();
+    this.alterVm2Name = "VM" + this.alterVm2.getId();
     this.alterVm2.invoke(() -> {
       Properties localProps = new Properties();
       localProps.setProperty(NAME, alterVm2Name);
@@ -154,7 +154,7 @@ public class AlterRegionCommandDUnitTest extends CliCommandTestBase {
     });
 
     this.alterVm1 = Host.getHost(0).getVM(1);
-    this.alterVm1Name = "VM" + this.alterVm1.getPid();
+    this.alterVm1Name = "VM" + this.alterVm1.getId();
     this.alterVm1.invoke(() -> {
       Properties localProps = new Properties();
       localProps.setProperty(NAME, alterVm1Name);
@@ -168,7 +168,7 @@ public class AlterRegionCommandDUnitTest extends CliCommandTestBase {
     });
 
     this.alterVm2 = Host.getHost(0).getVM(2);
-    this.alterVm2Name = "VM" + this.alterVm2.getPid();
+    this.alterVm2Name = "VM" + this.alterVm2.getId();
     this.alterVm2.invoke(() -> {
       Properties localProps = new Properties();
       localProps.setProperty(NAME, alterVm2Name);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -130,7 +130,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
 
     final VM vm0 = Host.getHost(0).getVM(0);
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     final String diskStoreName = "DiskStoreCommandsDUnitTest";
 
     // Default setup creates a cache in the Manager, now create a cache in VM1
@@ -145,12 +145,12 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
 
     // Create a disk store and region in the Manager (VM0) and VM1 VMs
     for (final VM vm : (new VM[] {vm0, vm1})) {
-      final String vmName = "VM" + vm.getPid();
+      final String vmName = "VM" + vm.getId();
       vm.invoke(new SerializableRunnable() {
         public void run() {
           Cache cache = getCache();
 
-          File diskStoreDirFile = new File(diskStoreName + vm.getPid());
+          File diskStoreDirFile = new File(diskStoreName + vm.getId());
           diskStoreDirFile.mkdirs();
 
           DiskStoreFactory diskStoreFactory = cache.createDiskStoreFactory();
@@ -248,7 +248,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     System.out.println("command result=" + stringResult);
     assertEquals(5, countLinesInString(stringResult, false));
     assertTrue(stringContainsLine(stringResult, "Disk Store ID.*Host.*Directory"));
-    assertTrue(stringContainsLine(stringResult, ".*" + diskStoreName + vm1.getPid()));
+    assertTrue(stringContainsLine(stringResult, ".*" + diskStoreName + vm1.getId()));
 
     // Extract the id from the returned missing disk store
     String line = getLineFromString(stringResult, 4);
@@ -266,11 +266,11 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     // Do our own cleanup so that the disk store directories can be removed
     super.destroyDefaultSetup();
     for (final VM vm : (new VM[] {vm0, vm1})) {
-      final String vmName = "VM" + vm.getPid();
+      final String vmName = "VM" + vm.getId();
       vm.invoke(new SerializableRunnable() {
         public void run() {
           try {
-            FileUtils.deleteDirectory((new File(diskStoreName + vm.getPid())));
+            FileUtils.deleteDirectory((new File(diskStoreName + vm.getId())));
           } catch (IOException iex) {
             // There's nothing else we can do
           }
@@ -288,7 +288,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
 
     final VM vm0 = Host.getHost(0).getVM(0);
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     final String diskStoreName = "DiskStoreCommandsDUnitTest";
 
     // Default setup creates a cache in the Manager, now create a cache in VM1
@@ -303,12 +303,12 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
 
     // Create a disk store and region in the Manager (VM0) and VM1 VMs
     for (final VM vm : (new VM[] {vm0, vm1})) {
-      final String vmName = "VM" + vm.getPid();
+      final String vmName = "VM" + vm.getId();
       vm.invoke(new SerializableRunnable() {
         public void run() {
           Cache cache = getCache();
 
-          File diskStoreDirFile = new File(diskStoreName + vm.getPid());
+          File diskStoreDirFile = new File(diskStoreName + vm.getId());
           diskStoreDirFile.mkdirs();
 
           DiskStoreFactory diskStoreFactory = cache.createDiskStoreFactory();
@@ -507,11 +507,11 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     // Do our own cleanup so that the disk store directories can be removed
     super.destroyDefaultSetup();
     for (final VM vm : (new VM[] {vm0, vm1})) {
-      final String vmName = "VM" + vm.getPid();
+      final String vmName = "VM" + vm.getId();
       vm.invoke(new SerializableRunnable() {
         public void run() {
           try {
-            FileUtils.deleteDirectory((new File(diskStoreName + vm.getPid())));
+            FileUtils.deleteDirectory((new File(diskStoreName + vm.getId())));
           } catch (IOException iex) {
             // There's nothing else we can do
           }
@@ -1155,7 +1155,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     assertTrue(commandResultToString(cmdResult).contains("No Disk Stores Found"));
 
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     final File diskStore1Dir1 = new File(new File(".").getAbsolutePath(), diskStore1Name + ".1");
     this.filesToBeDeleted.add(diskStore1Dir1.getAbsolutePath());
     final File diskStore1Dir2 = new File(new File(".").getAbsolutePath(), diskStore1Name + ".2");
@@ -1174,7 +1174,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     });
 
     final VM vm2 = Host.getHost(0).getVM(2);
-    final String vm2Name = "VM" + vm2.getPid();
+    final String vm2Name = "VM" + vm2.getId();
     final File diskStore2Dir = new File(new File(".").getAbsolutePath(), diskStore2Name);
     this.filesToBeDeleted.add(diskStore2Dir.getAbsolutePath());
     vm2.invoke(new SerializableRunnable() {
@@ -1276,7 +1276,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     assertTrue(commandResultToString(cmdResult).contains("No Disk Stores Found"));
 
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     final File diskStore1Dir1 = new File(new File(".").getAbsolutePath(), diskStore1Name + ".1");
     this.filesToBeDeleted.add(diskStore1Dir1.getAbsolutePath());
     final File diskStore2Dir1 = new File(new File(".").getAbsolutePath(), diskStore2Name + ".1");
@@ -1302,7 +1302,7 @@ public class DiskStoreCommandsDUnitTest extends CliCommandTestBase {
     });
 
     final VM vm2 = Host.getHost(0).getVM(2);
-    final String vm2Name = "VM" + vm2.getPid();
+    final String vm2Name = "VM" + vm2.getId();
     final File diskStore1Dir2 = new File(new File(".").getAbsolutePath(), diskStore1Name + ".2");
     this.filesToBeDeleted.add(diskStore1Dir2.getAbsolutePath());
     final File diskStore2Dir2 = new File(new File(".").getAbsolutePath(), diskStore2Name + ".2");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTest.java
@@ -595,7 +595,7 @@ public class FunctionCommandsDUnitTest extends CliCommandTestBase {
     final Function function2 = new TestFunction(true, TestFunction.TEST_FUNCTION2);
     final Function function3 = new TestFunction(true, TestFunction.TEST_FUNCTION3);
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     vm1.invoke(new SerializableRunnable() {
       public void run() {
         Properties localProps = new Properties();
@@ -614,7 +614,7 @@ public class FunctionCommandsDUnitTest extends CliCommandTestBase {
     final Function function5 = new TestFunction(true, TestFunction.TEST_FUNCTION5);
     final Function function6 = new TestFunction(true, TestFunction.TEST_FUNCTION6);
     final VM vm2 = Host.getHost(0).getVM(2);
-    final String vm2Name = "VM" + vm2.getPid();
+    final String vm2Name = "VM" + vm2.getId();
     vm2.invoke(new SerializableRunnable() {
       public void run() {
         Properties localProps = new Properties();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GetCommandOnRegionWithCacheLoaderDuringCacheMissDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GetCommandOnRegionWithCacheLoaderDuringCacheMissDUnitTest.java
@@ -313,7 +313,7 @@ public class GetCommandOnRegionWithCacheLoaderDuringCacheMissDUnitTest extends C
 
       buffer.append(" {configuration = ").append(getConfiguration());
       buffer.append(", name = ").append(getName());
-      buffer.append(", pid = ").append(getVm().getPid());
+      buffer.append(", pid = ").append(getVm().getId());
       buffer.append("}");
 
       return buffer.toString();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/QueueCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/QueueCommandsDUnitTest.java
@@ -99,7 +99,7 @@ public class QueueCommandsDUnitTest extends CliCommandTestBase {
     assertTrue(commandResultToString(cmdResult).contains("No Async Event Queues Found"));
 
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
     final File diskStoreDir = new File(new File(".").getAbsolutePath(), diskStoreName);
     this.filesToBeDeleted.add(diskStoreDir.getAbsolutePath());
     vm1.invoke(new SerializableRunnable() {
@@ -115,7 +115,7 @@ public class QueueCommandsDUnitTest extends CliCommandTestBase {
     });
 
     final VM vm2 = Host.getHost(0).getVM(2);
-    final String vm2Name = "VM" + vm2.getPid();
+    final String vm2Name = "VM" + vm2.getId();
     vm2.invoke(new SerializableRunnable() {
       public void run() {
         Properties localProps = new Properties();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
@@ -78,7 +78,7 @@ public class ShowMetricsDUnitTest extends CliCommandTestBase {
     setUpJmxManagerOnVm0ThenConnect(null);
     createLocalSetUp();
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
 
     vm1.invoke(new SerializableRunnable() {
       public void run() {
@@ -122,7 +122,7 @@ public class ShowMetricsDUnitTest extends CliCommandTestBase {
     setUpJmxManagerOnVm0ThenConnect(null);
     createLocalSetUp();
     final VM vm1 = Host.getHost(0).getVM(1);
-    final String vm1Name = "VM" + vm1.getPid();
+    final String vm1Name = "VM" + vm1.getId();
 
     vm1.invoke(new SerializableRunnable() {
       public void run() {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/Host.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/Host.java
@@ -17,9 +17,7 @@ package org.apache.geode.test.dunit;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.geode.test.dunit.standalone.RemoteDUnitVMIF;
 import org.apache.geode.test.dunit.standalone.VersionManager;
@@ -48,7 +46,7 @@ public abstract class Host implements Serializable {
   private String hostName;
 
   /** The VMs that run on this host */
-  private List vms;
+  private List<VM> vms;
 
   /** The GemFire systems that are available on this host */
   private List systems;
@@ -164,8 +162,8 @@ public abstract class Host implements Serializable {
   /**
    * return a collection of all VMs
    */
-  public Set<VM> getAllVMs() {
-    return new HashSet<>(vms);
+  public List<VM> getAllVMs() {
+    return new ArrayList<>(vms);
   }
 
   /**
@@ -179,8 +177,8 @@ public abstract class Host implements Serializable {
   /**
    * Adds a VM to this {@code Host} with the given process id and client record.
    */
-  protected void addVM(int pid, RemoteDUnitVMIF client) {
-    VM vm = new VM(this, pid, client);
+  protected void addVM(int vmid, RemoteDUnitVMIF client) {
+    VM vm = new VM(this, vmid, client);
     this.vms.add(vm);
   }
 
@@ -192,8 +190,8 @@ public abstract class Host implements Serializable {
     locator = l;
   }
 
-  protected void addLocator(int pid, RemoteDUnitVMIF client) {
-    setLocator(new VM(this, pid, client));
+  protected void addLocator(int vmid, RemoteDUnitVMIF client) {
+    setLocator(new VM(this, vmid, client));
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/VM.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.rmi.RemoteException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.awaitility.Awaitility;
 import hydra.MethExecutorResult;
@@ -39,8 +40,8 @@ public class VM implements Serializable {
   /** The host on which this VM runs */
   private Host host;
 
-  /** The process id of this VM */
-  private int pid;
+  /** The sequential id of this VM */
+  private int id;
 
   /** The version of Geode used in this VM */
   private String version;
@@ -98,16 +99,14 @@ public class VM implements Serializable {
 
   /**
    * Creates a new {@code VM} that runs on a given host with a given process id.
-   *
-   * TODO: change pid to reflect value from {@link ProcessUtils#identifyPid()}
    */
-  public VM(final Host host, final int pid, final RemoteDUnitVMIF client) {
-    this(host, VersionManager.CURRENT_VERSION, pid, client);
+  public VM(final Host host, int id, final RemoteDUnitVMIF client) {
+    this(host, VersionManager.CURRENT_VERSION, id, client);
   }
 
-  public VM(final Host host, final String version, final int pid, final RemoteDUnitVMIF client) {
+  public VM(final Host host, final String version, final int id, final RemoteDUnitVMIF client) {
     this.host = host;
-    this.pid = pid;
+    this.id = id;
     this.version = version;
     this.client = client;
     this.available = true;
@@ -131,10 +130,17 @@ public class VM implements Serializable {
   }
 
   /**
+   * Returns the VM id of this {@code VM}.
+   */
+  public int getId() {
+    return this.id;
+  }
+
+  /**
    * Returns the process id of this {@code VM}.
    */
   public int getPid() {
-    return this.pid;
+    return invoke(() -> ProcessUtils.identifyPid());
   }
 
   /**
@@ -414,8 +420,8 @@ public class VM implements Serializable {
     this.available = false;
 
     try {
-      BounceResult result = DUnitEnv.get().bounce(targetVersion, this.pid);
-      this.pid = result.getNewPid();
+      BounceResult result = DUnitEnv.get().bounce(targetVersion, this.id);
+      this.id = result.getNewId();
       this.client = result.getNewClient();
       this.version = targetVersion;
       this.available = true;
@@ -434,12 +440,12 @@ public class VM implements Serializable {
   }
 
   public String toString() {
-    return "VM " + getPid() + " running on " + getHost()
+    return "VM " + getId() + " running on " + getHost()
         + (VersionManager.isCurrentVersion(version) ? "" : (" with version " + version));
   }
 
   public File getWorkingDirectory() {
-    return DUnitEnv.get().getWorkingDirectory(getVersion(), getPid());
+    return DUnitEnv.get().getWorkingDirectory(getVersion(), getId());
   }
 
   private MethExecutorResult execute(final Class targetClass, final String methodName,

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/BounceResult.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/BounceResult.java
@@ -15,16 +15,16 @@
 package org.apache.geode.test.dunit.standalone;
 
 public class BounceResult {
-  private final int newPid;
+  private final int newId;
   private final RemoteDUnitVMIF newClient;
 
-  public BounceResult(int newPid, RemoteDUnitVMIF newClient) {
-    this.newPid = newPid;
+  public BounceResult(int newId, RemoteDUnitVMIF newClient) {
+    this.newId = newId;
     this.newClient = newClient;
   }
 
-  public int getNewPid() {
-    return newPid;
+  public int getNewId() {
+    return newId;
   }
 
   public RemoteDUnitVMIF getNewClient() {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/tests/GetPidAndIdAfterBounceDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/tests/GetPidAndIdAfterBounceDistributedTest.java
@@ -12,42 +12,51 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit.examples;
+package org.apache.geode.test.dunit.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedTestRule;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 @Category(DistributedTest.class)
-public class InvokeCallableExampleTest {
+public class GetPidAndIdAfterBounceDistributedTest {
+
+  private int[] idsBefore;
+  private int[] pidsBefore;
 
   @ClassRule
   public static DistributedTestRule distributedTestRule = new DistributedTestRule();
 
-  private static final String[] names = {"Batman", "Superman", "Wonder Woman", "Aquaman"};
+  @Before
+  public void setUp() throws Exception {
+    idsBefore = new int[Host.getHost(0).getVMCount()];
+    pidsBefore = new int[Host.getHost(0).getVMCount()];
 
-  @Test
-  public void invokeIdentityInEachVM() throws Exception {
     for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
-      final int whichVM = i;
-      VM vm = Host.getHost(0).getVM(whichVM);
-      String name = vm.invoke(() -> names[whichVM]);
-      assertThat(name).isEqualTo(names[i]);
+      idsBefore[i] = Host.getHost(0).getVM(i).getId();
+      pidsBefore[i] = Host.getHost(0).getVM(i).getPid();
+      Host.getHost(0).getVM(i).bounce();
     }
   }
 
   @Test
-  public void getPidOfEachVM() throws Exception {
-    for (VM vm : Host.getHost(0).getAllVMs()) {
-      System.out.println("vm.getPid() is " + vm.getPid());
+  public void getIdShouldReturnSameValueAfterBounce() throws Exception {
+    for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
+      assertThat(Host.getHost(0).getVM(i).getId()).isEqualTo(idsBefore[i]);
+    }
+  }
+
+  @Test
+  public void getPidShouldReturnDifferentValueAfterBounce() throws Exception {
+    for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
+      assertThat(Host.getHost(0).getVM(i).getPid()).isNotEqualTo(pidsBefore[i]);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/tests/GetPidAndIdDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/tests/GetPidAndIdDistributedTest.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit.examples;
+package org.apache.geode.test.dunit.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,27 +27,25 @@ import org.apache.geode.test.dunit.rules.DistributedTestRule;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 @Category(DistributedTest.class)
-public class InvokeCallableExampleTest {
+public class GetPidAndIdDistributedTest {
 
   @ClassRule
   public static DistributedTestRule distributedTestRule = new DistributedTestRule();
 
-  private static final String[] names = {"Batman", "Superman", "Wonder Woman", "Aquaman"};
-
   @Test
-  public void invokeIdentityInEachVM() throws Exception {
+  public void getId_returnsVMSequentialId() throws Exception {
     for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
-      final int whichVM = i;
-      VM vm = Host.getHost(0).getVM(whichVM);
-      String name = vm.invoke(() -> names[whichVM]);
-      assertThat(name).isEqualTo(names[i]);
+      VM vm = Host.getHost(0).getVM(i);
+      assertThat(vm.getId()).isEqualTo(i);
     }
   }
 
   @Test
-  public void getPidOfEachVM() throws Exception {
-    for (VM vm : Host.getHost(0).getAllVMs()) {
-      System.out.println("vm.getPid() is " + vm.getPid());
+  public void getPid_returnsVMProcessId() throws Exception {
+    for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
+      VM vm = Host.getHost(0).getVM(i);
+      int remotePid = vm.invoke(() -> ProcessUtils.identifyPid());
+      assertThat(vm.getPid()).isEqualTo(remotePid);
     }
   }
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
@@ -304,7 +304,7 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
   private VM rollClientToCurrent(VM oldClient, String[] hostNames, int[] locatorPorts,
       boolean subscriptionEnabled) throws Exception {
     oldClient.invoke(invokeCloseCache());
-    VM rollClient = Host.getHost(0).getVM(oldClient.getPid());
+    VM rollClient = Host.getHost(0).getVM(oldClient.getId());
     rollClient.invoke(invokeCreateClientCache(getClientSystemProperties(), hostNames, locatorPorts,
         subscriptionEnabled));
     rollClient.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -406,7 +406,7 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
     } else if ((regionType.equals("persistentPartitioned"))) {
       shortcutName = RegionShortcut.PARTITION_PERSISTENT.name();
       for (int i = 0; i < testingDirs.length; i++) {
-        testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getPid()))
+        testingDirs[i] = new File(diskDir, "diskStoreVM_" + String.valueOf(host.getVM(i).getId()))
             .getAbsoluteFile();
         if (!testingDirs[i].exists()) {
           System.out.println(" Creating diskdir for server: " + i);
@@ -578,7 +578,7 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getPid()); // gets a vm with the current version
+    VM rollServer = Host.getHost(0).getVM(oldServer.getId()); // gets a vm with the current version
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -605,7 +605,7 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     oldLocator.invoke(invokeStopLocator());
-    VM rollLocator = Host.getHost(0).getVM(oldLocator.getPid()); // gets a VM with current version
+    VM rollLocator = Host.getHost(0).getVM(oldLocator.getId()); // gets a VM with current version
     final Properties props = new Properties();
     props.setProperty(DistributionConfig.ENABLE_CLUSTER_CONFIGURATION_NAME, "false");
     rollLocator.invoke(invokeStartLocator(serverHostName, port, testName, locatorString, props));

--- a/geode-wan/src/test/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
@@ -31,7 +31,6 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.parallel.BatchRemovalThreadHelper;
 import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySenderQueue;
@@ -513,7 +512,7 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
   private VM rollLocatorToCurrent(VM rollLocator, int port, int distributedSystemId,
       String locators, String remoteLocators) throws Exception {
     rollLocator.invoke(() -> stopLocator());
-    VM newLocator = Host.getHost(0).getVM(rollLocator.getPid());
+    VM newLocator = Host.getHost(0).getVM(rollLocator.getId());
     newLocator.invoke(() -> startLocator(port, distributedSystemId, locators, remoteLocators));
     return newLocator;
   }
@@ -522,7 +521,7 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
       int distributedSystem, String regionName, String senderId, int messageSyncInterval)
       throws Exception {
     oldServer.invoke(() -> closeCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getPid());
+    VM rollServer = Host.getHost(0).getVM(oldServer.getId());
     startAndConfigureServers(rollServer, null, locators, distributedSystem, regionName, senderId,
         messageSyncInterval);
     return rollServer;


### PR DESCRIPTION
Introduce getId() to VM and change all callers of VM.getPid() to VM.getId().

Fix VM.getPid() to return the OS process id for the VM.
