### PR TITLE
GEODE-3613: Dumping container logs files in session replication tests

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/session/tests/CargoTestBase.java
+++ b/geode-assembly/src/test/java/org/apache/geode/session/tests/CargoTestBase.java
@@ -68,6 +68,7 @@ public abstract class CargoTestBase extends JUnit4CacheTestCase {
    */
   @After
   public void stop() throws IOException {
+    manager.dumpLogs();
     manager.stopAllActiveContainers();
     manager.cleanUp();
   }

--- a/geode-assembly/src/test/java/org/apache/geode/session/tests/ContainerManager.java
+++ b/geode-assembly/src/test/java/org/apache/geode/session/tests/ContainerManager.java
@@ -122,6 +122,12 @@ public class ContainerManager {
     stopContainers(getActiveContainerIndexes());
   }
 
+  public void dumpLogs() throws IOException {
+    for (ServerContainer container : getActiveContainers()) {
+      container.dumpLogs();
+    }
+  }
+
   /**
    * Set the name of the current test
    *


### PR DESCRIPTION
The session replication tests were generating logs files that were
getting deleted. In order to debug issues with the session state tests
we need to information in the log files to show up in the test output.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
