### PR TITLE
GEODE-3722: Fixing typo in lucene query command

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/search.html.md.erb
@@ -30,7 +30,7 @@ See also [create lucene index](create.html#create_lucene_index), [describe lucen
 **Syntax:**
 
 ``` pre
-search lucene --name=value --region=value --queryStrings=value --defaultField=value
+search lucene --name=value --region=value --queryString=value --defaultField=value
     [--limit=value] [--keys-only=value]
 ```
 
@@ -61,7 +61,7 @@ search lucene --name=value --region=value --queryStrings=value --defaultField=va
 <td> </td>
 </tr>
 <tr>
-<td><span class="keyword parmname" style="whitespace:nowrap;">&#8209;&#8208;queryStrings</span></td>
+<td><span class="keyword parmname" style="whitespace:nowrap;">&#8209;&#8208;queryString</span></td>
 <td><em>Required</em>. Query string to search the Lucene index. Use <code>__REGION_VALUE_FIELD</code> as the field name within the query string when the field is a primitive value. Surround a string with double quote marks to do an exact match of the string.</td>
 <td> </td>
 </tr>
@@ -84,19 +84,19 @@ search lucene --name=value --region=value --queryStrings=value --defaultField=va
 **Example Commands:**
 
 ``` pre
-gfsh> search lucene --name=testIndex --region=/testRegion --queryStrings=value1
+gfsh> search lucene --name=testIndex --region=/testRegion --queryString=value1
    --defaultField=__REGION_VALUE_FIELD
  
 
 gfsh> search lucene --name=indexOfStrings --region=/stringTestRegion 
-      --queryStrings='__REGION_VALUE_FIELD:"my exact string"'
+      --queryString='__REGION_VALUE_FIELD:"my exact string"'
       --defaultField=__REGION_VALUE_FIELD
 ```
 
 **Sample Output:**
 
 ``` pre
-gfsh>search lucene --name=testIndex --region=/testRegion --queryStrings=value* 
+gfsh>search lucene --name=testIndex --region=/testRegion --queryString=value* 
    --defaultField=__REGION_VALUE_FIELD
 key | value  | score
 --- | ------ | -----
@@ -107,7 +107,7 @@ key | value  | score
 
 ``` pre
 gfsh>search lucene --region=/Person --name=analyzerIndex 
-   --defaultField=addr --queryStrings="97763"
+   --defaultField=addr --queryString="97763"
  key   |                         value                                      | score
 ------ | ------------------------------------------------------------------ | --------
 key763 | Person{name='Kris Cat', addr='7 Ash St, Portland_OR_97763', emai.. | 1.669657

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -75,7 +75,8 @@ public class LuceneCliStrings {
       "Name of the lucene index to search.";
   public static final String LUCENE_SEARCH_INDEX__REGION_HELP =
       "Name/Path of the region defining the lucene index to be searched.";
-  public static final String LUCENE_SEARCH_INDEX__QUERY_STRING = "queryStrings";
+  public static final String LUCENE_SEARCH_INDEX__QUERY_STRING = "queryString";
+  public static final String LUCENE_SEARCH_INDEX__QUERY_STRINGS = "queryStrings";
   public static final String LUCENE_SEARCH_INDEX__LIMIT = "limit";
   public static final String LUCENE_SEARCH_INDEX__LIMIT__HELP = "Number of search results needed";
   public static final String LUCENE_SEARCH_INDEX__QUERY_STRING__HELP =

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -285,7 +285,10 @@ public class LuceneIndexCommands implements GfshCommand {
           optionContext = ConverterHint.REGION_PATH,
           help = LuceneCliStrings.LUCENE_SEARCH_INDEX__REGION_HELP) final String regionPath,
 
-      @CliOption(key = LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING, mandatory = true,
+      @CliOption(
+          key = {LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING,
+              LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRINGS},
+          mandatory = true,
           help = LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING__HELP) final String queryString,
 
       @CliOption(key = LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD, mandatory = true,


### PR DESCRIPTION
Supporting --queryString and --queryStrings in the search lucene command.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.