### PR TITLE
GEODE-3705: add handshake to the Protobuf protocol.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -18,42 +18,6 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_ACCESSOR_PP;
 import static org.apache.geode.internal.cache.tier.CommunicationMode.ClientToServerForQueue;
 
-import org.apache.geode.CancelException;
-import org.apache.geode.SystemFailure;
-import org.apache.geode.ToDataException;
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.RegionDestroyedException;
-import org.apache.geode.cache.client.internal.PoolImpl;
-import org.apache.geode.cache.server.CacheServer;
-import org.apache.geode.cache.wan.GatewayTransportFilter;
-import org.apache.geode.distributed.internal.DM;
-import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.LonerDistributionManager;
-import org.apache.geode.distributed.internal.PooledExecutorWithDMStats;
-import org.apache.geode.distributed.internal.ReplyProcessor21;
-import org.apache.geode.internal.SystemTimer;
-import org.apache.geode.internal.cache.BucketAdvisor;
-import org.apache.geode.internal.cache.BucketAdvisor.BucketProfile;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.internal.cache.partitioned.AllBucketProfilesUpdateMessage;
-import org.apache.geode.internal.cache.tier.Acceptor;
-import org.apache.geode.internal.cache.tier.CachedRegionHelper;
-import org.apache.geode.internal.cache.tier.CommunicationMode;
-import org.apache.geode.internal.cache.wan.GatewayReceiverStats;
-import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.internal.logging.LogService;
-import org.apache.geode.internal.logging.LoggingThreadGroup;
-import org.apache.geode.internal.logging.log4j.LocalizedMessage;
-import org.apache.geode.internal.net.SocketCreator;
-import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.security.SecurableCommunicationChannel;
-import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.internal.tcp.ConnectionTable;
-import org.apache.geode.internal.util.ArrayUtils;
-import org.apache.logging.log4j.Logger;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -91,6 +55,43 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.CancelException;
+import org.apache.geode.SystemFailure;
+import org.apache.geode.ToDataException;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.cache.wan.GatewayTransportFilter;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.LonerDistributionManager;
+import org.apache.geode.distributed.internal.PooledExecutorWithDMStats;
+import org.apache.geode.distributed.internal.ReplyProcessor21;
+import org.apache.geode.internal.SystemTimer;
+import org.apache.geode.internal.cache.BucketAdvisor;
+import org.apache.geode.internal.cache.BucketAdvisor.BucketProfile;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.partitioned.AllBucketProfilesUpdateMessage;
+import org.apache.geode.internal.cache.tier.Acceptor;
+import org.apache.geode.internal.cache.tier.CachedRegionHelper;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
+import org.apache.geode.internal.cache.wan.GatewayReceiverStats;
+import org.apache.geode.internal.i18n.LocalizedStrings;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.logging.LoggingThreadGroup;
+import org.apache.geode.internal.logging.log4j.LocalizedMessage;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.tcp.ConnectionTable;
+import org.apache.geode.internal.util.ArrayUtils;
 
 /**
  * Implements the acceptor thread on the bridge server. Accepts connections from the edge and starts
@@ -336,72 +337,24 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
     this.isGatewayReceiver = isGatewayReceiver;
     this.gatewayTransportFilters = transportFilter;
     this.serverConnectionFactory = serverConnectionFactory;
-    {
-      int tmp_maxConnections = maxConnections;
-      if (tmp_maxConnections < MINIMUM_MAX_CONNECTIONS) {
-        tmp_maxConnections = MINIMUM_MAX_CONNECTIONS;
-      }
-      this.maxConnections = tmp_maxConnections;
+
+    this.maxConnections = Math.min(maxConnections, MINIMUM_MAX_CONNECTIONS);
+    this.maxThreads = calculateMaxThreads(maxThreads);
+
+    if (isSelector()) {
+      this.selector = Selector.open();
+      this.selectorQueue = new LinkedBlockingQueue();
+      this.commBufferQueue = new LinkedBlockingQueue();
+      this.selectorRegistrations = new HashSet(512);
+      this.hsTimer = new SystemTimer(internalCache.getDistributedSystem(), true);
+    } else {
+      this.selector = null;
+      this.selectorQueue = null;
+      this.commBufferQueue = null;
+      this.selectorRegistrations = null;
+      this.hsTimer = null;
     }
-    {
-      int tmp_maxThreads = maxThreads;
-      if (maxThreads == CacheServer.DEFAULT_MAX_THREADS) {
-        // consult system properties for 5.0.2 backwards compatibility
-        if (DEPRECATED_SELECTOR) {
-          tmp_maxThreads = DEPRECATED_SELECTOR_POOL_SIZE;
-        }
-      }
-      if (tmp_maxThreads < 0) {
-        tmp_maxThreads = 0;
-      } else if (tmp_maxThreads > this.maxConnections) {
-        tmp_maxThreads = this.maxConnections;
-      }
-      boolean isWindows = false;
-      String os = System.getProperty("os.name");
-      if (os != null) {
-        if (os.indexOf("Windows") != -1) {
-          isWindows = true;
-        }
-      }
-      if (tmp_maxThreads > 0 && isWindows) {
-        // bug #40472 and JDK bug 6230761 - NIO can't be used with IPv6 on Windows
-        if (getBindAddress() instanceof Inet6Address) {
-          logger.warn(LocalizedMessage
-              .create(LocalizedStrings.AcceptorImpl_IGNORING_MAX_THREADS_DUE_TO_JROCKIT_NIO_BUG));
-          tmp_maxThreads = 0;
-        }
-        // bug #40198 - Selector.wakeup() hangs if VM starts to exit
-        if (isJRockit) {
-          logger.warn(LocalizedMessage
-              .create(LocalizedStrings.AcceptorImpl_IGNORING_MAX_THREADS_DUE_TO_WINDOWS_IPV6_BUG));
-          tmp_maxThreads = 0;
-        }
-      }
-      this.maxThreads = tmp_maxThreads;
-    }
-    {
-      Selector tmp_s = null;
-      // Selector tmp2_s = null;
-      LinkedBlockingQueue tmp_q = null;
-      LinkedBlockingQueue tmp_commQ = null;
-      HashSet tmp_hs = null;
-      SystemTimer tmp_timer = null;
-      if (isSelector()) {
-        tmp_s = Selector.open(); // no longer catch ex to fix bug 36907
-        // tmp2_s = Selector.open(); // workaround for bug 39624
-        tmp_q = new LinkedBlockingQueue();
-        tmp_commQ = new LinkedBlockingQueue();
-        tmp_hs = new HashSet(512);
-        tmp_timer = new SystemTimer(internalCache.getDistributedSystem(), true);
-      }
-      this.selector = tmp_s;
-      // this.tmpSel = tmp2_s;
-      this.selectorQueue = tmp_q;
-      this.commBufferQueue = tmp_commQ;
-      this.selectorRegistrations = tmp_hs;
-      this.hsTimer = tmp_timer;
-      this.tcpNoDelay = tcpNoDelay;
-    }
+    this.tcpNoDelay = tcpNoDelay;
 
     {
       if (!isGatewayReceiver) {
@@ -631,6 +584,43 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
 
     isPostAuthzCallbackPresent =
         (postAuthzFactoryName != null && postAuthzFactoryName.length() > 0) ? true : false;
+  }
+
+  private int calculateMaxThreads(int maxThreads) throws IOException {
+    int tmp_maxThreads = maxThreads;
+    if (maxThreads == CacheServer.DEFAULT_MAX_THREADS) {
+      // consult system properties for 5.0.2 backwards compatibility
+      if (DEPRECATED_SELECTOR) {
+        tmp_maxThreads = DEPRECATED_SELECTOR_POOL_SIZE;
+      }
+    }
+    if (tmp_maxThreads < 0) {
+      tmp_maxThreads = 0;
+    } else if (tmp_maxThreads > this.maxConnections) {
+      tmp_maxThreads = this.maxConnections;
+    }
+    boolean isWindows = false;
+    String os = System.getProperty("os.name");
+    if (os != null) {
+      if (os.indexOf("Windows") != -1) {
+        isWindows = true;
+      }
+    }
+    if (tmp_maxThreads > 0 && isWindows) {
+      // bug #40472 and JDK bug 6230761 - NIO can't be used with IPv6 on Windows
+      if (getBindAddress() instanceof Inet6Address) {
+        logger.warn(LocalizedMessage
+            .create(LocalizedStrings.AcceptorImpl_IGNORING_MAX_THREADS_DUE_TO_JROCKIT_NIO_BUG));
+        tmp_maxThreads = 0;
+      }
+      // bug #40198 - Selector.wakeup() hangs if VM starts to exit
+      if (isJRockit) {
+        logger.warn(LocalizedMessage
+            .create(LocalizedStrings.AcceptorImpl_IGNORING_MAX_THREADS_DUE_TO_WINDOWS_IPV6_BUG));
+        tmp_maxThreads = 0;
+      }
+    }
+    return tmp_maxThreads;
   }
 
   public long getAcceptorId() {
@@ -1463,7 +1453,7 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
     ServerConnection serverConn =
         serverConnectionFactory.makeServerConnection(socket, this.cache, this.crHelper, this.stats,
             AcceptorImpl.handShakeTimeout, this.socketBufferSize, communicationMode.toString(),
-            communicationMode.getModeNumber(), this, this.securityService, this.getBindAddress());
+            communicationMode.getModeNumber(), this, this.securityService);
 
     synchronized (this.allSCsLock) {
       this.allSCs.add(serverConn);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -338,7 +338,7 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
     this.gatewayTransportFilters = transportFilter;
     this.serverConnectionFactory = serverConnectionFactory;
 
-    this.maxConnections = Math.min(maxConnections, MINIMUM_MAX_CONNECTIONS);
+    this.maxConnections = Math.max(maxConnections, MINIMUM_MAX_CONNECTIONS);
     this.maxThreads = calculateMaxThreads(maxThreads);
 
     if (isSelector()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolHandshaker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolHandshaker.java
@@ -12,31 +12,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.protocol.protobuf;
 
-public enum ProtocolErrorCode {
-  GENERIC_FAILURE(1000),
-  VALUE_ENCODING_ERROR(1100),
-  UNSUPPORTED_VERSION(1101),
-  UNSUPPORTED_OPERATION(1102),
-  UNSUPPORTED_AUTHENTICATION_MODE(1103),
-  AUTHENTICATION_FAILED(1200),
-  AUTHORIZATION_FAILED(1201),
-  UNAUTHORIZED_REQUEST(1202),
-  LOW_MEMORY(1300),
-  DATA_UNREACHABLE(1301),
-  OPERATION_TIMEOUT(1302),
-  CONSTRAINT_VIOLATION(2000),
-  BAD_QUERY(2001),
-  REGION_NOT_FOUND(2100),
-  QUERY_PARAMETER_MISMATCH(2200),
-  QUERY_BIND_FAILURE(2201),
-  QUERY_NOT_PERMITTED(2202),
-  QUERY_TIMEOUT(2203);
+package org.apache.geode.internal.cache.tier.sockets;
 
-  ProtocolErrorCode(int value) {
-    codeValue = value;
-  }
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-  public int codeValue;
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.security.server.Authenticator;
+
+public interface ClientProtocolHandshaker {
+  public Authenticator handshake(InputStream inputStream, OutputStream outputStream)
+      throws IOException, IncompatibleVersionException;
+
+  public boolean shaken();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolHandshaker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolHandshaker.java
@@ -22,9 +22,23 @@ import java.io.OutputStream;
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.security.server.Authenticator;
 
+/**
+ * ClientProtocolHandshaker provides the handshake for the protocol implemented by
+ * {@link ClientProtocolMessageHandler}. It is responsible for checking version compatibility
+ * information as well as authentication mode.
+ */
 public interface ClientProtocolHandshaker {
-  public Authenticator handshake(InputStream inputStream, OutputStream outputStream)
+  /**
+   * Read a handshake message from the input stream and write a response to output.
+   *
+   * @return an authenticator from those available. These are currently only set in one place, see
+   *         {@link ServerConnectionFactory}.
+   */
+  Authenticator handshake(InputStream inputStream, OutputStream outputStream)
       throws IOException, IncompatibleVersionException;
 
-  public boolean shaken();
+  /**
+   * @return false until handshake is complete, then true afterwards.
+   */
+  boolean handshakeComplete();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolMessageHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolMessageHandler.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
 
 
@@ -30,6 +29,9 @@ import org.apache.geode.StatisticsFactory;
  * Currently, only one {@link ClientProtocolMessageHandler} at a time can be used in a Geode
  * instance. It gets wired into {@link ServerConnectionFactory} to create all instances of
  * {@link GenericProtocolServerConnection}.
+ *
+ * Implementors of this interface are expected to be able to be used for any number of connections
+ * at a time (stateless except for the statistics).
  */
 public interface ClientProtocolMessageHandler {
   void initializeStatistics(String statisticsName, StatisticsFactory factory);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
@@ -12,31 +12,25 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.protocol.protobuf;
 
-public enum ProtocolErrorCode {
-  GENERIC_FAILURE(1000),
-  VALUE_ENCODING_ERROR(1100),
-  UNSUPPORTED_VERSION(1101),
-  UNSUPPORTED_OPERATION(1102),
-  UNSUPPORTED_AUTHENTICATION_MODE(1103),
-  AUTHENTICATION_FAILED(1200),
-  AUTHORIZATION_FAILED(1201),
-  UNAUTHORIZED_REQUEST(1202),
-  LOW_MEMORY(1300),
-  DATA_UNREACHABLE(1301),
-  OPERATION_TIMEOUT(1302),
-  CONSTRAINT_VIOLATION(2000),
-  BAD_QUERY(2001),
-  REGION_NOT_FOUND(2100),
-  QUERY_PARAMETER_MISMATCH(2200),
-  QUERY_BIND_FAILURE(2201),
-  QUERY_NOT_PERMITTED(2202),
-  QUERY_TIMEOUT(2203);
+package org.apache.geode.internal.cache.tier.sockets;
 
-  ProtocolErrorCode(int value) {
-    codeValue = value;
-  }
+import java.util.Map;
 
-  public int codeValue;
+import org.apache.geode.security.server.Authenticator;
+
+/**
+ * Provides a convenient location for a client protocol service to be loaded into the system.
+ */
+public interface ClientProtocolService {
+  /**
+   * The handshaker chooses an authenticator from those available based on the protocol.
+   *
+   * @param availableAuthenticators A list of valid authenticators for the current system.
+   */
+  ClientProtocolHandshaker getHandshaker(
+      Map<String, Class<? extends Authenticator>> availableAuthenticators);
+
+  ClientProtocolMessageHandler getMessageHandler();
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
@@ -18,11 +18,10 @@ package org.apache.geode.internal.cache.tier.sockets;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
-public class MessageHandlerFactory {
-  public ClientProtocolMessageHandler makeMessageHandler() {
-    ServiceLoader<ClientProtocolMessageHandler> loader =
-        ServiceLoader.load(ClientProtocolMessageHandler.class);
-    Iterator<ClientProtocolMessageHandler> iterator = loader.iterator();
+public class ClientProtocolServiceLoader {
+  public ClientProtocolService loadService() {
+    ServiceLoader<ClientProtocolService> loader = ServiceLoader.load(ClientProtocolService.class);
+    Iterator<ClientProtocolService> iterator = loader.iterator();
 
     if (!iterator.hasNext()) {
       throw new ServiceLoadingFailureException(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/LegacyServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/LegacyServerConnection.java
@@ -15,15 +15,15 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import java.io.IOException;
+import java.net.Socket;
+
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.Acceptor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.log4j.LocalizedMessage;
 import org.apache.geode.internal.security.SecurityService;
-
-import java.io.IOException;
-import java.net.Socket;
 
 /**
  * Handles everything but the new client protocol.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
-import static org.apache.geode.distributed.ConfigurationProperties.*;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTHENTICATOR;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -46,13 +46,15 @@ public class ServerConnectionFactory {
       return clientProtocolService;
     }
 
-    clientProtocolService = new ClientProtocolServiceLoader().loadService();
-    protocolHandler = clientProtocolService.getMessageHandler();
-    protocolHandler.initializeStatistics(statisticsName, statisticsFactory);
+    ClientProtocolService service = new ClientProtocolServiceLoader().loadService();
+    ClientProtocolMessageHandler messageHandler = service.getMessageHandler();
+    messageHandler.initializeStatistics(statisticsName, statisticsFactory);
 
     ensureAuthenticatorsAreInitialized();
 
-    return clientProtocolService;
+    this.protocolHandler = messageHandler;
+    this.clientProtocolService = service;
+    return this.clientProtocolService;
   }
 
   private void ensureAuthenticatorsAreInitialized() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -18,9 +18,8 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.apache.geode.internal.cache.tier.CommunicationMode.ProtobufClientServerProtocol;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.Socket;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -37,79 +36,84 @@ import org.apache.geode.security.server.Authenticator;
 public class ServerConnectionFactory {
   private ClientProtocolMessageHandler protocolHandler;
   private Map<String, Class<? extends Authenticator>> authenticators = null;
+  private ClientProtocolService clientProtocolService;
 
   public ServerConnectionFactory() {}
+
+  private synchronized ClientProtocolService initializeClientProtocolService(
+      StatisticsFactory statisticsFactory, String statisticsName) {
+    if (clientProtocolService != null) {
+      return clientProtocolService;
+    }
+
+    clientProtocolService = new ClientProtocolServiceLoader().loadService();
+    protocolHandler = clientProtocolService.getMessageHandler();
+    protocolHandler.initializeStatistics(statisticsName, statisticsFactory);
+
+    ensureAuthenticatorsAreInitialized();
+
+    return clientProtocolService;
+  }
+
+  private void ensureAuthenticatorsAreInitialized() {
+    if (authenticators == null) {
+      initializeAuthenticatorsMap();
+    }
+  }
 
   private synchronized void initializeAuthenticatorsMap() {
     if (authenticators != null) {
       return;
     }
-    HashMap tmp = new HashMap<>();
+
+    String authenticationMode = System.getProperty("geode.protocol-authentication-mode", "NOOP");
 
     ServiceLoader<Authenticator> loader = ServiceLoader.load(Authenticator.class);
+
+    Authenticator found = null;
+
     for (Authenticator streamAuthenticator : loader) {
-      tmp.put(streamAuthenticator.implementationID(), streamAuthenticator.getClass());
-    }
-
-    authenticators = tmp;
-  }
-
-  private synchronized ClientProtocolMessageHandler initializeMessageHandler(
-      StatisticsFactory statisticsFactory, String statisticsName) {
-    if (protocolHandler != null) {
-      return protocolHandler;
-    }
-
-    ClientProtocolMessageHandler tempHandler = new MessageHandlerFactory().makeMessageHandler();
-    tempHandler.initializeStatistics(statisticsName, statisticsFactory);
-
-    protocolHandler = tempHandler;
-    return protocolHandler;
-  }
-
-  private Authenticator findStreamAuthenticator(String implementationID) {
-    if (authenticators == null) {
-      initializeAuthenticatorsMap();
-    }
-    Class<? extends Authenticator> streamAuthenticatorClass = authenticators.get(implementationID);
-    if (streamAuthenticatorClass == null) {
-      throw new ServiceLoadingFailureException(
-          "Could not find implementation for Authenticator with implementation ID "
-              + implementationID);
-    } else {
-      try {
-        return streamAuthenticatorClass.newInstance();
-      } catch (InstantiationException | IllegalAccessException e) {
-        throw new ServiceLoadingFailureException(
-            "Unable to instantiate authenticator for ID " + implementationID, e);
+      if (authenticationMode.equals(streamAuthenticator.implementationID())) {
+        if (found != null) {
+          throw new ServiceLoadingFailureException(
+              "Multiple Authenticators present for mode " + authenticationMode);
+        }
+        found = streamAuthenticator;
       }
     }
+
+    if (found == null) {
+      throw new ServiceLoadingFailureException(
+          "Could not find implementation for Authenticator with implementation ID "
+              + authenticationMode);
+    }
+
+    authenticators = Collections.singletonMap(authenticationMode, found.getClass());
   }
 
-  private ClientProtocolMessageHandler getOrCreateClientProtocolMessageHandler(
+  private ClientProtocolService getOrCreateClientProtocolService(
       StatisticsFactory statisticsFactory, String serverName) {
-    if (protocolHandler == null) {
-      return initializeMessageHandler(statisticsFactory, serverName);
+    if (clientProtocolService == null) {
+      return initializeClientProtocolService(statisticsFactory, serverName);
     }
-    return protocolHandler;
+    return clientProtocolService;
   }
 
   public ServerConnection makeServerConnection(Socket socket, InternalCache cache,
       CachedRegionHelper helper, CacheServerStats stats, int hsTimeout, int socketBufferSize,
       String communicationModeStr, byte communicationMode, Acceptor acceptor,
-      SecurityService securityService, InetAddress bindAddress) throws IOException {
+      SecurityService securityService) throws IOException {
     if (communicationMode == ProtobufClientServerProtocol.getModeNumber()) {
       if (!Boolean.getBoolean("geode.feature-protobuf-protocol")) {
         throw new IOException("Server received unknown communication mode: " + communicationMode);
       } else {
-        String authenticationMode =
-            System.getProperty("geode.protocol-authentication-mode", "NOOP");
+
+
+        getOrCreateClientProtocolService(cache.getDistributedSystem(), acceptor.getServerName());
 
         return new GenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,
-            socketBufferSize, communicationModeStr, communicationMode, acceptor,
-            getOrCreateClientProtocolMessageHandler(cache.getDistributedSystem(),
-                acceptor.getServerName()),
-            securityService, findStreamAuthenticator(authenticationMode));
+            socketBufferSize, communicationModeStr, communicationMode, acceptor, protocolHandler,
+            securityService, clientProtocolService.getHandshaker(authenticators));
       }
     } else {
       return new LegacyServerConnection(socket, cache, helper, stats, hsTimeout, socketBufferSize,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -33,7 +33,7 @@ public class TcpServerFactory {
 
   public TcpServerFactory() {
     try {
-      protocolHandler = new MessageHandlerFactory().makeMessageHandler();
+      protocolHandler = new ClientProtocolServiceLoader().loadService().getMessageHandler();
     } catch (ServiceLoadingFailureException ex) {
       logger.warn(ex.getMessage());
     }

--- a/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
@@ -14,16 +14,13 @@
  */
 package org.apache.geode.cache.partition;
 
-import org.junit.experimental.categories.Category;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import static org.junit.Assert.*;
-
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-import org.apache.geode.test.junit.categories.DistributedTest;
-
-import java.net.UnknownHostException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -32,6 +29,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
@@ -43,7 +43,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.Region.Entry;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache30.CacheSerializableRunnable;
-import org.apache.geode.cache30.CacheTestCase;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.BucketRegion;
@@ -51,6 +50,7 @@ import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionHelper;
 import org.apache.geode.internal.cache.partitioned.fixed.FixedPartitioningTestBase.Months_Accessor;
+import org.apache.geode.internal.cache.partitioned.fixed.QuarterPartitionResolver;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Host;
@@ -58,7 +58,8 @@ import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.internal.cache.partitioned.fixed.QuarterPartitionResolver;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+import org.apache.geode.test.junit.categories.DistributedTest;
 
 @Category(DistributedTest.class)
 public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
@@ -97,8 +98,6 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
         PartitionRegionHelper.assignBucketsToPartitions(region);
       }
     };
-
-
 
     AsyncInvocation future1 = vm0.invokeAsync(assignBuckets);
     AsyncInvocation future2 = vm1.invokeAsync(assignBuckets);

--- a/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
@@ -98,6 +98,8 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
+
+
     AsyncInvocation future1 = vm0.invokeAsync(assignBuckets);
     AsyncInvocation future2 = vm1.invokeAsync(assignBuckets);
     AsyncInvocation future3 = vm2.invokeAsync(assignBuckets);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
@@ -28,6 +28,7 @@ import org.junit.experimental.categories.Category;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.ServiceLoader;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -55,7 +56,6 @@ public class ServerConnectionFactoryTest {
   public void newClientProtocolFailsWithoutSystemPropertySet() throws IOException {
     ServerConnection serverConnection = serverConnectionMockedExceptForCommunicationMode(
         CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
-
   }
 
   /**
@@ -70,7 +70,7 @@ public class ServerConnectionFactoryTest {
   }
 
   @Test
-  public void makeServerConnection() throws Exception {
+  public void makeLegacyServerConnection() throws Exception {
     CommunicationMode[] communicationModes = new CommunicationMode[] {
         CommunicationMode.ClientToServer, CommunicationMode.PrimaryServerToClient,
         CommunicationMode.SecondaryServerToClient, CommunicationMode.GatewayToGateway,
@@ -109,5 +109,4 @@ public class ServerConnectionFactoryTest {
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "", communicationMode,
         mock(AcceptorImpl.class), mock(SecurityService.class), InetAddress.getLocalHost());
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
@@ -107,6 +107,6 @@ public class ServerConnectionFactoryTest {
 
     return new ServerConnectionFactory().makeServerConnection(socketMock, mock(InternalCache.class),
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "", communicationMode,
-        mock(AcceptorImpl.class), mock(SecurityService.class), InetAddress.getLocalHost());
+        mock(AcceptorImpl.class), mock(SecurityService.class));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -84,7 +84,7 @@ public class ServerConnectionTest {
 
     serverConnection = new ServerConnectionFactory().makeServerConnection(socket, cache, null, null,
         0, 0, null, CommunicationMode.PrimaryServerToClient.getModeNumber(), acceptor,
-        securityService, InetAddress.getLocalHost());
+        securityService);
     MockitoAnnotations.initMocks(this);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -82,9 +82,9 @@ public class ServerConnectionTest {
     InternalCache cache = mock(InternalCache.class);
     SecurityService securityService = mock(SecurityService.class);
 
-    serverConnection = new ServerConnectionFactory().makeServerConnection(socket, cache, null, null,
-        0, 0, null, CommunicationMode.PrimaryServerToClient.getModeNumber(), acceptor,
-        securityService);
+    serverConnection =
+        new ServerConnectionFactory().makeServerConnection(socket, cache, null, null, 0, 0, null,
+            CommunicationMode.PrimaryServerToClient.getModeNumber(), acceptor, securityService);
     MockitoAnnotations.initMocks(this);
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol;
+
+import java.util.Map;
+
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolHandshaker;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolService;
+import org.apache.geode.internal.protocol.protobuf.Handshaker;
+import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
+import org.apache.geode.security.server.Authenticator;
+
+public class ProtobufProtocolService implements ClientProtocolService {
+  @Override
+  public ClientProtocolHandshaker getHandshaker(
+      Map<String, Class<? extends Authenticator>> availableAuthenticators) {
+    return new Handshaker(availableAuthenticators);
+  }
+
+  @Override
+  public ClientProtocolMessageHandler getMessageHandler() {
+    return new ProtobufStreamProcessor();
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/Handshaker.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/Handshaker.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.protocol.protobuf;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -45,6 +46,10 @@ public class Handshaker implements ClientProtocolHandshaker {
       throws IOException, IncompatibleVersionException {
     HandshakeAPI.HandshakeRequest handshakeRequest =
         HandshakeAPI.HandshakeRequest.parseDelimitedFrom(inputStream);
+
+    if (handshakeRequest == null) {
+      throw new EOFException("No handshake received from client");
+    }
 
     HandshakeAPI.Semver version = handshakeRequest.getVersion();
     if (version.getMajor() != MAJOR_VERSION) {

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/Handshaker.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/Handshaker.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.protocol.protobuf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolHandshaker;
+import org.apache.geode.internal.cache.tier.sockets.ServiceLoadingFailureException;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.security.server.Authenticator;
+
+public class Handshaker implements ClientProtocolHandshaker {
+  private static final int MAJOR_VERSION = 1;
+  private static final int MINOR_VERSION = 0;
+  private static final Logger logger = LogService.getLogger();
+
+  private final Map<String, Class<? extends Authenticator>> authenticators;
+  private boolean shaken = false;
+
+  public Handshaker(Map<String, Class<? extends Authenticator>> availableAuthenticators) {
+    this.authenticators = availableAuthenticators;
+  }
+
+  @Override
+  public Authenticator handshake(InputStream inputStream, OutputStream outputStream)
+      throws IOException, IncompatibleVersionException {
+    HandshakeAPI.HandshakeRequest handshakeRequest =
+        HandshakeAPI.HandshakeRequest.parseDelimitedFrom(inputStream);
+
+    HandshakeAPI.Semver version = handshakeRequest.getVersion();
+    if (version.getMajor() != MAJOR_VERSION) {
+      writeFailureTo(outputStream, ProtocolErrorCode.UNSUPPORTED_VERSION.codeValue,
+          "Version mismatch: incompatible major version");
+      throw new IncompatibleVersionException(
+          "Client major version does not match server major version");
+    }
+    if (version.getMinor() > MINOR_VERSION) {
+      writeFailureTo(outputStream, ProtocolErrorCode.UNSUPPORTED_VERSION.codeValue,
+          "Version mismatch: client newer than server");
+      throw new IncompatibleVersionException(
+          "Client minor version is greater than server minor version");
+    }
+
+    try {
+      Class<? extends Authenticator> authenticatorClass =
+          selectAuthenticator(authenticators, handshakeRequest.getAuthenticationMode());
+
+      if (authenticatorClass == null) {
+        writeFailureTo(outputStream, ProtocolErrorCode.UNSUPPORTED_AUTHENTICATION_MODE.codeValue,
+            "Invalid authentication mode");
+        throw new IncompatibleVersionException("Invalid authentication mode");
+      }
+
+      HandshakeAPI.HandshakeResponse.newBuilder().setOk(true).build()
+          .writeDelimitedTo(outputStream);
+      shaken = true;
+      return authenticatorClass.newInstance();
+
+    } catch (IllegalAccessException | InstantiationException e) {
+      logger.error("Could not instantiate authenticator from handshake: ", e);
+      throw new ServiceLoadingFailureException(e);
+    }
+  }
+
+  private Class<? extends Authenticator> selectAuthenticator(
+      Map<String, Class<? extends Authenticator>> authenticators,
+      HandshakeAPI.AuthenticationMode authenticationMode)
+      throws IllegalAccessException, InstantiationException {
+    switch (authenticationMode) {
+      case SIMPLE:
+        return authenticators.get("SIMPLE");
+      case NONE:
+        return authenticators.get("NOOP");
+      case UNRECOGNIZED:
+        // fallthrough!
+      default:
+        return null;
+    }
+  }
+
+  private void writeFailureTo(OutputStream outputStream, int errorCode, String errorMessage)
+      throws IOException {
+    HandshakeAPI.HandshakeResponse.newBuilder().setOk(false)
+        .setError(BasicTypes.Error.newBuilder().setErrorCode(errorCode).setMessage(errorMessage))
+        .build().writeDelimitedTo(outputStream);
+  }
+
+  @Override
+  public boolean shaken() {
+    return shaken;
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/utilities/ProtobufUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/utilities/ProtobufUtilities.java
@@ -14,7 +14,12 @@
  */
 package org.apache.geode.internal.protocol.protobuf.utilities;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 import com.google.protobuf.ByteString;
+import com.google.protobuf.GeneratedMessageV3;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Region;
@@ -22,6 +27,7 @@ import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.EncodingTypeTranslator;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.utilities.exception.UnknownProtobufPrimitiveType;
@@ -219,12 +225,6 @@ public abstract class ProtobufUtilities {
     protoRegionBuilder.setScope(regionAttributes.getScope().toString());
     protoRegionBuilder.setDataPolicy(regionAttributes.getDataPolicy().toString());
     return protoRegionBuilder.build();
-  }
-
-  public static ClientProtocol.Request createProtobufRequestWithGetRegionNamesRequest(
-      RegionAPI.GetRegionNamesRequest getRegionNamesRequest) {
-    return ClientProtocol.Request.newBuilder().setGetRegionNamesRequest(getRegionNamesRequest)
-        .build();
   }
 
   public static ClientProtocol.Request.Builder createProtobufRequestBuilder() {

--- a/geode-protobuf/src/main/proto/handshake_API.proto
+++ b/geode-protobuf/src/main/proto/handshake_API.proto
@@ -1,7 +1,7 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
  *
@@ -12,31 +12,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
+syntax = "proto3";
 package org.apache.geode.internal.protocol.protobuf;
 
-public enum ProtocolErrorCode {
-  GENERIC_FAILURE(1000),
-  VALUE_ENCODING_ERROR(1100),
-  UNSUPPORTED_VERSION(1101),
-  UNSUPPORTED_OPERATION(1102),
-  UNSUPPORTED_AUTHENTICATION_MODE(1103),
-  AUTHENTICATION_FAILED(1200),
-  AUTHORIZATION_FAILED(1201),
-  UNAUTHORIZED_REQUEST(1202),
-  LOW_MEMORY(1300),
-  DATA_UNREACHABLE(1301),
-  OPERATION_TIMEOUT(1302),
-  CONSTRAINT_VIOLATION(2000),
-  BAD_QUERY(2001),
-  REGION_NOT_FOUND(2100),
-  QUERY_PARAMETER_MISMATCH(2200),
-  QUERY_BIND_FAILURE(2201),
-  QUERY_NOT_PERMITTED(2202),
-  QUERY_TIMEOUT(2203);
+import "basicTypes.proto";
 
-  ProtocolErrorCode(int value) {
-    codeValue = value;
-  }
 
-  public int codeValue;
+message Semver {
+    int32 major = 1;
+    int32 minor = 2;
+}
+
+enum AuthenticationMode {
+    NONE = 0;
+    SIMPLE = 1;
+}
+
+message HandshakeRequest {
+    Semver version = 1;
+    AuthenticationMode authenticationMode = 2;
+}
+
+message HandshakeResponse {
+    bool ok = 1;
+    Error error = 2; // only set if not OK.
 }

--- a/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler
+++ b/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler
@@ -1,1 +1,0 @@
-org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor

--- a/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolService
+++ b/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolService
@@ -1,0 +1,1 @@
+org.apache.geode.internal.protocol.ProtobufProtocolService

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
@@ -33,14 +33,12 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
@@ -48,12 +46,9 @@ import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
 import org.apache.geode.internal.protocol.protobuf.Handshaker;
 import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
-import org.apache.geode.internal.protocol.protobuf.RegionAPI;
-import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
 import org.apache.geode.security.server.Authenticator;
-import org.apache.geode.security.server.NoOpAuthenticator;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -112,7 +107,7 @@ public class GenericProtocolServerConnectionTest {
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
     ClientProtocolMessageHandler clientProtocolMock = mock(ClientProtocolMessageHandler.class);
     ClientProtocolHandshaker handshakerMock = mock(ClientProtocolHandshaker.class);
-    when(handshakerMock.shaken()).thenReturn(false).thenReturn(true);
+    when(handshakerMock.handshakeComplete()).thenReturn(false).thenReturn(true);
     when(handshakerMock.handshake(any(), any())).thenReturn(mock(Authenticator.class));
 
     ServerConnection serverConnection =
@@ -129,7 +124,7 @@ public class GenericProtocolServerConnectionTest {
   @Test
   public void handshakeIsRequiredToMoveAlong() throws Exception {
     ClientProtocolHandshaker handshaker = mock(ClientProtocolHandshaker.class);
-    when(handshaker.shaken()).thenReturn(false);
+    when(handshaker.handshakeComplete()).thenReturn(false);
     Authenticator authenticator = mock(Authenticator.class);
     when(handshaker.handshake(any(), any())).thenReturn(authenticator);
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.internal.protocol;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -25,15 +27,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import junitparams.JUnitParamsRunner;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -42,6 +47,8 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.management.internal.security.ResourceConstants;
@@ -49,20 +56,22 @@ import org.apache.geode.security.SecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
 @Category(IntegrationTest.class)
+@RunWith(JUnitParamsRunner.class)
 public class AuthenticationIntegrationTest {
 
-  private static final String TEST_USERNAME = "bob";
-  private static final String TEST_PASSWORD = "bobspassword";
-  private Cache cache;
+  protected static final String TEST_USERNAME = "bob";
+  protected static final String TEST_PASSWORD = "bobspassword";
+  protected Cache cache;
 
   @Rule
-  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+  protected final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  private OutputStream outputStream;
-  private InputStream inputStream;
-  private ProtobufProtocolSerializer protobufProtocolSerializer;
+  protected OutputStream outputStream;
+  protected InputStream inputStream;
+  protected ProtobufProtocolSerializer protobufProtocolSerializer;
 
-  public void setUp(String authenticationMode) throws IOException {
+  // not @Before, the tests set system properties.
+  private void setUp() throws IOException {
     Properties expectedAuthProperties = new Properties();
     expectedAuthProperties.setProperty(ResourceConstants.USER_NAME, TEST_USERNAME);
     expectedAuthProperties.setProperty(ResourceConstants.PASSWORD, TEST_PASSWORD);
@@ -75,7 +84,7 @@ public class AuthenticationIntegrationTest {
     Properties properties = new Properties();
     CacheFactory cacheFactory = new CacheFactory(properties);
     cacheFactory.set(ConfigurationProperties.MCAST_PORT, "0"); // sometimes it isn't due to other
-                                                               // tests.
+    // tests.
     cacheFactory.set(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "false");
     cacheFactory.set(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "false");
 
@@ -87,9 +96,7 @@ public class AuthenticationIntegrationTest {
     cacheServer.setPort(cacheServerPort);
     cacheServer.start();
 
-
     System.setProperty("geode.feature-protobuf-protocol", "true");
-    System.setProperty("geode.protocol-authentication-mode", authenticationMode);
     Socket socket = new Socket("localhost", cacheServerPort);
 
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
@@ -110,7 +117,12 @@ public class AuthenticationIntegrationTest {
 
   @Test
   public void noopAuthenticationSucceeds() throws Exception {
-    setUp("NOOP");
+    System.setProperty("geode.protocol-authentication-mode", "NOOP");
+    setUp();
+
+    ProtobufTestUtilities.verifyHandshake(inputStream, outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
+
     ClientProtocol.Message getRegionsMessage =
         ClientProtocol.Message.newBuilder().setRequest(ClientProtocol.Request.newBuilder()
             .setGetRegionNamesRequest(RegionAPI.GetRegionNamesRequest.newBuilder())).build();
@@ -123,7 +135,12 @@ public class AuthenticationIntegrationTest {
 
   @Test
   public void simpleAuthenticationSucceeds() throws Exception {
-    setUp("SIMPLE");
+    System.setProperty("geode.protocol-authentication-mode", "SIMPLE");
+    setUp();
+
+    ProtobufTestUtilities.verifyHandshake(inputStream, outputStream,
+        HandshakeAPI.AuthenticationMode.SIMPLE);
+
     AuthenticationAPI.SimpleAuthenticationRequest authenticationRequest =
         AuthenticationAPI.SimpleAuthenticationRequest.newBuilder().setUsername(TEST_USERNAME)
             .setPassword(TEST_PASSWORD).build();
@@ -142,5 +159,55 @@ public class AuthenticationIntegrationTest {
     assertEquals(ClientProtocol.Response.ResponseAPICase.GETREGIONNAMESRESPONSE,
         regionsResponse.getResponse().getResponseAPICase());
 
+  }
+
+  @Test
+  public void ensureAuthenticationModes() {
+    // This assertion is for the following tests, to make sure they test all authentication modes.
+    HandshakeAPI.AuthenticationMode[] modes =
+        {HandshakeAPI.AuthenticationMode.NONE, HandshakeAPI.AuthenticationMode.SIMPLE};
+    assertTrue(Arrays.equals(modes, HandshakeAPI.AuthenticationMode.class.getEnumConstants()));
+  }
+
+  @Test(expected = IOException.class)
+  public void simpleAuthenticationFailsWithNoopModeSet() throws Exception {
+    System.setProperty("geode.protocol-authentication-mode", "NOOP");
+    setUp();
+
+    ProtobufTestUtilities.buildHandshakeRequest(HandshakeAPI.AuthenticationMode.SIMPLE)
+        .writeDelimitedTo(outputStream);
+
+    HandshakeAPI.HandshakeResponse handshakeResponse =
+        HandshakeAPI.HandshakeResponse.parseDelimitedFrom(inputStream);
+
+    assertFalse(handshakeResponse.getOk());
+    assertNotNull(handshakeResponse.getError());
+
+    // socket is closed, writing should throw an IOException.
+    AuthenticationAPI.SimpleAuthenticationRequest authenticationRequest =
+        AuthenticationAPI.SimpleAuthenticationRequest.newBuilder().setUsername(TEST_USERNAME)
+            .setPassword(TEST_PASSWORD).build();
+    authenticationRequest.writeDelimitedTo(outputStream);
+  }
+
+  @Test(expected = IOException.class)
+  public void noopAuthenticationFailsWithSimpleAuthenticationEnabled() throws Exception {
+    System.setProperty("geode.protocol-authentication-mode", "SIMPLE");
+    setUp();
+
+    ProtobufTestUtilities.buildHandshakeRequest(HandshakeAPI.AuthenticationMode.NONE)
+        .writeDelimitedTo(outputStream);
+
+    HandshakeAPI.HandshakeResponse handshakeResponse =
+        HandshakeAPI.HandshakeResponse.parseDelimitedFrom(inputStream);
+
+    assertFalse(handshakeResponse.getOk());
+    assertNotNull(handshakeResponse.getError());
+
+    // this should throw.
+    ClientProtocol.Message getRegionsMessage =
+        ClientProtocol.Message.newBuilder().setRequest(ClientProtocol.Request.newBuilder()
+            .setGetRegionNamesRequest(RegionAPI.GetRegionNamesRequest.newBuilder())).build();
+    protobufProtocolSerializer.serialize(getRegionsMessage, outputStream);
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthenticationIntegrationTest.java
@@ -64,7 +64,7 @@ public class AuthenticationIntegrationTest {
   protected Cache cache;
 
   @Rule
-  protected final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   protected OutputStream outputStream;
   protected InputStream inputStream;

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthorizationIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/AuthorizationIntegrationTest.java
@@ -42,7 +42,9 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.protocol.protobuf.AuthenticationAPI;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
@@ -72,7 +74,7 @@ public class AuthorizationIntegrationTest {
   private ProtobufProtocolSerializer protobufProtocolSerializer;
   private Object securityPrincipal;
   private SecurityManager mockSecurityManager;
-  private String testRegion;
+
   public static final ResourcePermission READ_PERMISSION =
       new ResourcePermission(ResourcePermission.Resource.DATA, ResourcePermission.Operation.READ);
   public static final ResourcePermission WRITE_PERMISSION =
@@ -110,6 +112,9 @@ public class AuthorizationIntegrationTest {
     outputStream = socket.getOutputStream();
     inputStream = socket.getInputStream();
     outputStream.write(110);
+
+    ProtobufTestUtilities.verifyHandshake(inputStream, outputStream,
+        HandshakeAPI.AuthenticationMode.SIMPLE);
 
     serializationService = new ProtobufSerializationService();
     protobufProtocolSerializer = new ProtobufProtocolSerializer();

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
@@ -56,6 +56,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -63,7 +64,9 @@ import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
@@ -144,7 +147,10 @@ public class CacheConnectionJUnitTest {
     }
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     serializationService = new ProtobufSerializationService();
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionTimeoutJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionTimeoutJUnitTest.java
@@ -41,11 +41,14 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.MessageUtil;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.serialization.SerializationService;
@@ -74,7 +77,6 @@ public class CacheConnectionTimeoutJUnitTest {
   public TestName testName = new TestName();
   private long monitorInterval;
   private int maximumTimeBetweenPings;
-  private static final int pollInterval = 20;
 
   @Before
   public void setup() throws Exception {
@@ -104,7 +106,10 @@ public class CacheConnectionTimeoutJUnitTest {
 
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     serializationService = new ProtobufSerializationService();
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
@@ -54,7 +54,9 @@ import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.test.junit.categories.IntegrationTest;
@@ -106,7 +108,10 @@ public class CacheMaxConnectionJUnitTest {
     socket = new Socket("localhost", cacheServerPort);
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     outputStream = socket.getOutputStream();
-    outputStream.write(110);
+    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     serializationService = new ProtobufSerializationService();
     protobufProtocolSerializer = new ProtobufProtocolSerializer();
@@ -192,6 +197,8 @@ public class CacheMaxConnectionJUnitTest {
           Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
           OutputStream outputStream = socket.getOutputStream();
           outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+          ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+              HandshakeAPI.AuthenticationMode.NONE);
 
           ClientProtocol.Message putMessage =
               MessageUtil.makePutRequestMessage(serializationService, TEST_KEY, TEST_VALUE,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
@@ -69,8 +69,6 @@ public class CacheMaxConnectionJUnitTest {
   private final String TEST_REGION = "testRegion";
 
   private Cache cache;
-  private int cacheServerPort;
-  private OutputStream outputStream;
 
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
@@ -91,8 +89,7 @@ public class CacheMaxConnectionJUnitTest {
     cache = cacheFactory.create();
 
     CacheServer cacheServer = cache.addCacheServer();
-    cacheServerPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    cacheServer.setPort(cacheServerPort);
+    cacheServer.setPort(0);
     cacheServer.start();
 
     RegionFactory<Object, Object> regionFactory = cache.createRegionFactory();
@@ -125,7 +122,7 @@ public class CacheMaxConnectionJUnitTest {
   // can't create another, and repeat once to be sure we're cleaning up.
   private void testNewProtocolRespectsMaxConnectionLimit(int threads, boolean isSelector)
       throws Exception {
-    final int connections = 16;
+    final int connections = 17;
 
     List<CacheServer> cacheServers = cache.getCacheServers();
     assertEquals(1, cacheServers.size());

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheMaxConnectionJUnitTest.java
@@ -61,9 +61,6 @@ import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSe
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
-/**
- * Test that using the magic byte to indicate intend ot use ProtoBuf messages works
- */
 @Category(IntegrationTest.class)
 public class CacheMaxConnectionJUnitTest {
   private static final String TEST_KEY = "testKey";
@@ -71,10 +68,8 @@ public class CacheMaxConnectionJUnitTest {
   private static final int TEST_PUT_CORRELATION_ID = 12355;
   private final String TEST_REGION = "testRegion";
 
-
   private Cache cache;
   private int cacheServerPort;
-  private Socket socket;
   private OutputStream outputStream;
 
   @Rule
@@ -105,14 +100,6 @@ public class CacheMaxConnectionJUnitTest {
 
     System.setProperty("geode.feature-protobuf-protocol", "true");
 
-    socket = new Socket("localhost", cacheServerPort);
-    Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
-    outputStream = socket.getOutputStream();
-    outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
-
-    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
-        HandshakeAPI.AuthenticationMode.NONE);
-
     serializationService = new ProtobufSerializationService();
     protobufProtocolSerializer = new ProtobufProtocolSerializer();
   }
@@ -120,7 +107,6 @@ public class CacheMaxConnectionJUnitTest {
   @After
   public void cleanup() throws IOException {
     cache.close();
-    socket.close();
     SocketCreatorFactory.close();
   }
 
@@ -185,8 +171,8 @@ public class CacheMaxConnectionJUnitTest {
     ExecutorService executor = Executors.newFixedThreadPool(connections);
 
     // Used to assert the exception is non-null.
-    ArrayList<Callable<Exception>> callables = new ArrayList<>();
-
+    // The boolean is just because invokeAll doesn't take runnable and we need *some* return type.
+    ArrayList<Callable<Boolean>> callables = new ArrayList<>();
     for (int i = 0; i < connections; i++) {
       final int j = i;
       callables.add(() -> {
@@ -206,15 +192,15 @@ public class CacheMaxConnectionJUnitTest {
           protobufProtocolSerializer.serialize(putMessage, outputStream);
           validatePutResponse(socket, protobufProtocolSerializer);
         } catch (Exception e) {
-          return e;
+          throw new RuntimeException(e);
         }
-        return null;
+        return true;
       });
     }
-    List<Future<Exception>> futures = executor.invokeAll(callables);
 
-    for (Future<Exception> f : futures) {
-      assertNull(f.get());
+    List<Future<Boolean>> futures = executor.invokeAll(callables);
+    for (Future<?> f : futures) {
+      f.get(1, TimeUnit.MINUTES); // throws if failure.
     }
 
     // try to start a new socket, expecting it to be disconnected.

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheOperationsJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheOperationsJUnitTest.java
@@ -62,7 +62,9 @@ import org.apache.geode.internal.protocol.MessageUtil;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
 import org.apache.geode.internal.protocol.protobuf.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.HandshakeAPI;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
@@ -142,6 +144,10 @@ public class CacheOperationsJUnitTest {
     outputStream = socket.getOutputStream();
     outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
 
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
+
+
     serializationService = new ProtobufSerializationService();
   }
 
@@ -160,6 +166,8 @@ public class CacheOperationsJUnitTest {
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
     outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     Set<BasicTypes.Entry> putEntries = new HashSet<>();
@@ -202,6 +210,8 @@ public class CacheOperationsJUnitTest {
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
     outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     Set<BasicTypes.Entry> putEntries = new HashSet<>();
@@ -263,8 +273,8 @@ public class CacheOperationsJUnitTest {
         ProtobufRequestUtilities.createGetRegionNamesRequest();
 
     ClientProtocol.Message getRegionsMessage = ProtobufUtilities.createProtobufMessage(
-        ProtobufUtilities.createMessageHeader(correlationId),
-        ProtobufUtilities.createProtobufRequestWithGetRegionNamesRequest(getRegionNamesRequest));
+        ProtobufUtilities.createMessageHeader(correlationId), ProtobufTestUtilities
+            .createProtobufRequestWithGetRegionNamesRequest(getRegionNamesRequest));
     protobufProtocolSerializer.serialize(getRegionsMessage, outputStream);
     validateGetRegionNamesResponse(socket, correlationId, protobufProtocolSerializer);
   }
@@ -277,6 +287,8 @@ public class CacheOperationsJUnitTest {
     Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
     OutputStream outputStream = socket.getOutputStream();
     outputStream.write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+    ProtobufTestUtilities.verifyHandshake(socket.getInputStream(), outputStream,
+        HandshakeAPI.AuthenticationMode.NONE);
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
     ClientProtocol.Message getRegionMessage = MessageUtil.makeGetRegionRequestMessage(TEST_REGION,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.protocol.protobuf;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.security.SecurityManager;
+import org.apache.geode.security.server.Authenticator;
+import org.apache.geode.security.server.Authorizer;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class HandshakerTest {
+
+  private Map<String, Class<? extends Authenticator>> authenticatorMap;
+  private Handshaker handshaker;
+
+  public static class AuthenticatorMock implements Authenticator {
+
+    @Override
+    public void authenticate(InputStream inputStream, OutputStream outputStream,
+        SecurityManager securityManager) throws IOException {
+
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+      return false;
+    }
+
+    @Override
+    public Authorizer getAuthorizer() throws AuthenticationRequiredException {
+      return null;
+    }
+
+    @Override
+    public String implementationID() {
+      return null;
+    }
+  }
+
+  public static class SimpleMock extends AuthenticatorMock {
+  }
+
+  public static class NoopMock extends AuthenticatorMock {
+  }
+
+  @Before
+  public void setUp() {
+    authenticatorMap = new HashMap<>();
+
+    authenticatorMap.put("NOOP", NoopMock.class);
+    authenticatorMap.put("SIMPLE", SimpleMock.class);
+
+    handshaker = new Handshaker(authenticatorMap);
+    assertFalse(handshaker.shaken());
+  }
+
+  @Test
+  public void version1_0IsSupported() throws Exception {
+    HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
+        .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
+        .setAuthenticationMode(HandshakeAPI.AuthenticationMode.NONE).build();
+
+    ByteArrayInputStream byteArrayInputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(handshakeRequest);
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    Authenticator actualAuthenticator =
+        handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
+    assertTrue(actualAuthenticator instanceof NoopMock);
+
+    assertTrue(handshaker.shaken());
+  }
+
+  @Test(expected = IncompatibleVersionException.class)
+  public void version2NotSupported() throws Exception {
+    HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
+        .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(2).setMinor(0))
+        .setAuthenticationMode(HandshakeAPI.AuthenticationMode.NONE).build();
+
+    ByteArrayInputStream byteArrayInputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(handshakeRequest);
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
+  }
+
+  @Test(expected = IncompatibleVersionException.class)
+  public void bogusAuthenticationMode() throws Exception {
+    HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
+        .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
+        .setAuthenticationModeValue(-1).build();
+
+    ByteArrayInputStream byteArrayInputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(handshakeRequest);
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
+  }
+
+  @Test
+  public void simpleIsSupported() throws Exception {
+    HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
+        .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
+        .setAuthenticationMode(HandshakeAPI.AuthenticationMode.SIMPLE).build();
+
+    ByteArrayInputStream byteArrayInputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(handshakeRequest);
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    Authenticator actualAuthenticator =
+        handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
+    assertTrue(actualAuthenticator instanceof SimpleMock);
+
+    assertTrue(handshaker.shaken());
+  }
+}

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -147,5 +148,10 @@ public class HandshakerTest {
     assertTrue(actualAuthenticator instanceof SimpleMock);
 
     assertTrue(handshaker.shaken());
+  }
+
+  @Test(expected = EOFException.class)
+  public void eofAtHandshake() throws Exception {
+    handshaker.handshake(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream());
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/HandshakerTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.IncompatibleVersionException;
-import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.security.AuthenticationRequiredException;
 import org.apache.geode.security.SecurityManager;
 import org.apache.geode.security.server.Authenticator;
@@ -83,7 +82,7 @@ public class HandshakerTest {
     authenticatorMap.put("SIMPLE", SimpleMock.class);
 
     handshaker = new Handshaker(authenticatorMap);
-    assertFalse(handshaker.shaken());
+    assertFalse(handshaker.handshakeComplete());
   }
 
   @Test
@@ -101,7 +100,7 @@ public class HandshakerTest {
         handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
     assertTrue(actualAuthenticator instanceof NoopMock);
 
-    assertTrue(handshaker.shaken());
+    assertTrue(handshaker.handshakeComplete());
   }
 
   @Test(expected = IncompatibleVersionException.class)
@@ -119,7 +118,7 @@ public class HandshakerTest {
   }
 
   @Test(expected = IncompatibleVersionException.class)
-  public void bogusAuthenticationMode() throws Exception {
+  public void invalidAuthenticationMode() throws Exception {
     HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
         .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
         .setAuthenticationModeValue(-1).build();
@@ -133,7 +132,7 @@ public class HandshakerTest {
   }
 
   @Test
-  public void simpleIsSupported() throws Exception {
+  public void validAuthenticationMode() throws Exception {
     HandshakeAPI.HandshakeRequest handshakeRequest = HandshakeAPI.HandshakeRequest.newBuilder()
         .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
         .setAuthenticationMode(HandshakeAPI.AuthenticationMode.SIMPLE).build();
@@ -147,7 +146,7 @@ public class HandshakerTest {
         handshaker.handshake(byteArrayInputStream, byteArrayOutputStream);
     assertTrue(actualAuthenticator instanceof SimpleMock);
 
-    assertTrue(handshaker.shaken());
+    assertTrue(handshaker.handshakeComplete());
   }
 
   @Test(expected = EOFException.class)

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufSimpleAuthenticatorJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufSimpleAuthenticatorJUnitTest.java
@@ -15,26 +15,28 @@
 
 package org.apache.geode.internal.protocol.protobuf;
 
-import org.apache.geode.examples.security.ExampleSecurityManager;
-import org.apache.geode.management.internal.security.ResourceConstants;
-import org.apache.geode.security.AuthenticationFailedException;
-import org.apache.geode.security.SecurityManager;
-import org.apache.geode.test.junit.categories.UnitTest;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Properties;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.examples.security.ExampleSecurityManager;
+import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
+import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.geode.security.AuthenticationFailedException;
+import org.apache.geode.security.SecurityManager;
+import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
 public class ProtobufSimpleAuthenticatorJUnitTest {
@@ -58,9 +60,8 @@ public class ProtobufSimpleAuthenticatorJUnitTest {
     expectedAuthProperties.setProperty(ResourceConstants.USER_NAME, TEST_USERNAME);
     expectedAuthProperties.setProperty(ResourceConstants.PASSWORD, TEST_PASSWORD);
 
-    ByteArrayOutputStream messageStream = new ByteArrayOutputStream();
-    basicAuthenticationRequest.writeDelimitedTo(messageStream);
-    byteArrayInputStream = new ByteArrayInputStream(messageStream.toByteArray());
+    byteArrayInputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(basicAuthenticationRequest);
     byteArrayOutputStream = new ByteArrayOutputStream();
 
     securityPrincipal = new Object();

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufTestUtilities.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufTestUtilities.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.protobuf.GeneratedMessageV3;
+
+public class ProtobufTestUtilities {
+  public static ByteArrayInputStream messageToByteArrayInputStream(GeneratedMessageV3 message)
+      throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    message.writeDelimitedTo(byteArrayOutputStream);
+    return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+  }
+
+
+  public static ClientProtocol.Request createProtobufRequestWithGetRegionNamesRequest(
+      RegionAPI.GetRegionNamesRequest getRegionNamesRequest) {
+    return ClientProtocol.Request.newBuilder().setGetRegionNamesRequest(getRegionNamesRequest)
+        .build();
+  }
+
+  public static void verifyHandshake(InputStream inputStream, OutputStream outputStream,
+      HandshakeAPI.AuthenticationMode authenticationMode) throws IOException {
+    buildHandshakeRequest(authenticationMode).writeDelimitedTo(outputStream);
+
+    HandshakeAPI.HandshakeResponse handshakeResponse =
+        HandshakeAPI.HandshakeResponse.parseDelimitedFrom(inputStream);
+
+    assertTrue(handshakeResponse.getOk());
+    assertFalse(handshakeResponse.hasError());
+  }
+
+  public static HandshakeAPI.HandshakeRequest buildHandshakeRequest(
+      HandshakeAPI.AuthenticationMode authenticationMode) {
+    return HandshakeAPI.HandshakeRequest.newBuilder()
+        .setVersion(HandshakeAPI.Semver.newBuilder().setMajor(1).setMinor(0))
+        .setAuthenticationMode(authenticationMode).build();
+  }
+}

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufTestUtilities.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufTestUtilities.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -47,6 +48,7 @@ public class ProtobufTestUtilities {
     HandshakeAPI.HandshakeResponse handshakeResponse =
         HandshakeAPI.HandshakeResponse.parseDelimitedFrom(inputStream);
 
+    assertNotNull(handshakeResponse);
     assertTrue(handshakeResponse.getOk());
     assertFalse(handshakeResponse.hasError());
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/serializer/ProtobufProtocolSerializerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/serializer/ProtobufProtocolSerializerJUnitTest.java
@@ -14,20 +14,23 @@
  */
 package org.apache.geode.internal.protocol.serializer;
 
-import org.apache.geode.internal.protocol.MessageUtil;
-import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
-import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
-import org.apache.geode.test.junit.categories.UnitTest;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import org.apache.geode.internal.protocol.MessageUtil;
+import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.ProtobufTestUtilities;
+import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
+import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
+import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
 public class ProtobufProtocolSerializerJUnitTest {
@@ -43,10 +46,8 @@ public class ProtobufProtocolSerializerJUnitTest {
       throws IOException, InvalidProtocolMessageException {
     ClientProtocol.Message expectedRequestMessage = MessageUtil.createGetRequestMessage();
 
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-    expectedRequestMessage.writeDelimitedTo(byteArrayOutputStream);
-    InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+    InputStream inputStream =
+        ProtobufTestUtilities.messageToByteArrayInputStream(expectedRequestMessage);
 
     ClientProtocol.Message actualMessage = protocolSerializer.deserialize(inputStream);
     Assert.assertEquals(expectedRequestMessage, actualMessage);


### PR DESCRIPTION
* Add handshake to the Protobuf messages.
* Create a new `ClientProtocolHandshaker` class.
* Add a new `ClientProtocolService` that encapsulates handshaker and
  message processor. This is now the single load point for the new
  client protocol.
* Add tests for handshake and authentication mode, rework old tests.
* Fix old tests to use the `Handshaker` in setup.

misc:
* Simplify (same behavior) `AcceptorImpl`'s constructor.
* optimize a bunch of imports
* remove dead parameter from `makeServerConnection`
* refactor methods to `ProtobufTestUtilities`.

Signed-off-by: Galen O'Sullivan <gosullivan@pivotal.io>

Signed-off-by: Sarge <mdodge@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
