### PR TITLE
GEODE-3628: Lucene query only needs DATA:READ

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction.java
@@ -18,6 +18,8 @@ package org.apache.geode.cache.lucene.internal.distributed;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.Function;
@@ -45,6 +47,7 @@ import org.apache.geode.cache.lucene.internal.repository.RepositoryManager;
 import org.apache.geode.internal.InternalEntity;
 import org.apache.geode.internal.cache.BucketNotFoundException;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.security.ResourcePermission;
 
 /**
  * {@link LuceneQueryFunction} coordinates text search on a member. It receives text search query
@@ -52,14 +55,14 @@ import org.apache.geode.internal.logging.LogService;
  * and provides a result collector. The locally collected results are sent to the search
  * coordinator.
  */
-public class LuceneQueryFunction implements Function, InternalEntity {
+public class LuceneQueryFunction implements Function<LuceneFunctionContext>, InternalEntity {
   private static final long serialVersionUID = 1L;
   public static final String ID = LuceneQueryFunction.class.getName();
 
   private static final Logger logger = LogService.getLogger();
 
   @Override
-  public void execute(FunctionContext context) {
+  public void execute(FunctionContext<LuceneFunctionContext> context) {
     RegionFunctionContext ctx = (RegionFunctionContext) context;
     ResultSender<TopEntriesCollector> resultSender = ctx.getResultSender();
 
@@ -173,6 +176,13 @@ public class LuceneQueryFunction implements Function, InternalEntity {
   @Override
   public boolean optimizeForWrite() {
     return true;
+  }
+
+  @Override
+  public Collection<ResourcePermission> getRequiredPermissions(Optional<String> regionName) {
+    ResourcePermission read = new ResourcePermission(ResourcePermission.Resource.DATA,
+        ResourcePermission.Operation.READ, regionName.get());
+    return Collections.singleton(read);
   }
 }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/WaitUntilFlushedFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/WaitUntilFlushedFunction.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.cache.lucene.internal.distributed;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.cache.Cache;
@@ -26,13 +29,14 @@ import org.apache.geode.cache.execute.RegionFunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.internal.InternalEntity;
+import org.apache.geode.security.ResourcePermission;
 
 /**
  * {@link WaitUntilFlushedFunction} will check all the members with index to wait until the events
  * in current AEQs are flushed into index. This function enables an accessor and client to call to
  * make sure the current events are processed.
  */
-public class WaitUntilFlushedFunction implements Function, InternalEntity {
+public class WaitUntilFlushedFunction implements Function<Object>, InternalEntity {
   private static final long serialVersionUID = 1L;
   public static final String ID = WaitUntilFlushedFunction.class.getName();
 
@@ -75,5 +79,12 @@ public class WaitUntilFlushedFunction implements Function, InternalEntity {
   @Override
   public boolean optimizeForWrite() {
     return true;
+  }
+
+  @Override
+  public Collection<ResourcePermission> getRequiredPermissions(Optional<String> regionName) {
+    ResourcePermission read = new ResourcePermission(ResourcePermission.Resource.DATA,
+        ResourcePermission.Operation.READ, regionName.get());
+    return Collections.singleton(read);
   }
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/results/LuceneGetPageFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/results/LuceneGetPageFunction.java
@@ -27,16 +27,21 @@ import org.apache.geode.internal.cache.PrimaryBucketException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.security.ResourcePermission;
+
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
  * {@link LuceneGetPageFunction} Returns the values of entries back to the user This behaves
  * basically like a getAll, but it does not invoke a cache loader
  */
-public class LuceneGetPageFunction implements Function, InternalEntity {
+public class LuceneGetPageFunction implements Function<Object>, InternalEntity {
   private static final long serialVersionUID = 1L;
   public static final String ID = LuceneGetPageFunction.class.getName();
 
@@ -85,5 +90,12 @@ public class LuceneGetPageFunction implements Function, InternalEntity {
   @Override
   public boolean optimizeForWrite() {
     return false;
+  }
+
+  @Override
+  public Collection<ResourcePermission> getRequiredPermissions(Optional<String> regionName) {
+    ResourcePermission read = new ResourcePermission(ResourcePermission.Resource.DATA,
+        ResourcePermission.Operation.READ, regionName.get());
+    return Collections.singleton(read);
   }
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
@@ -18,24 +18,32 @@ import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.ServerOperationException;
+import org.apache.geode.cache.lucene.test.TestObject;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.SimpleTestSecurityManager;
@@ -70,8 +78,11 @@ public class LuceneClientSecurityDUnitTest extends LuceneQueriesAccessorBase {
     server.setPort(0);
     server.start();
     LuceneService luceneService = LuceneServiceProvider.get(cache);
-    luceneService.createIndexFactory().addField("text").create(INDEX_NAME, REGION_NAME);
-    cache.createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
+    luceneService.createIndexFactory().addField("field1").create(INDEX_NAME, REGION_NAME);
+    Region region = cache.createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
+
+    region.put("key", new org.apache.geode.cache.lucene.test.TestObject("hello", "world"));
+
     return server.getPort();
   }
 
@@ -87,24 +98,41 @@ public class LuceneClientSecurityDUnitTest extends LuceneQueriesAccessorBase {
   }
 
   private void executeTextSearch(boolean expectAuthorizationError, String expectedResponse)
-      throws LuceneQueryException {
+      throws LuceneQueryException, InterruptedException {
     LuceneService service = LuceneServiceProvider.get(getCache());
     LuceneQuery<Integer, TestObject> query =
-        service.createLuceneQueryFactory().create(INDEX_NAME, REGION_NAME, "test", "text");
+        service.createLuceneQueryFactory().create(INDEX_NAME, REGION_NAME, "hello", "field1");
     try {
-      query.findKeys();
+      service.waitUntilFlushed(INDEX_NAME, REGION_NAME, 5, TimeUnit.MINUTES);
       assertFalse(expectAuthorizationError);
-    } catch (ServerOperationException e) {
-      assertTrue(e.getCause() != null && e.getCause() instanceof NotAuthorizedException);
-      assertTrue(expectAuthorizationError);
-      assertTrue(e.getLocalizedMessage().contains(expectedResponse));
+    } catch (Exception e) {
+      if (!expectAuthorizationError) {
+        throw e;
+      }
+      assertThat(e).hasCauseInstanceOf(ServerOperationException.class);
+      assertThat(e.getCause()).hasCauseInstanceOf(NotAuthorizedException.class);
+    }
+
+
+    try {
+      List<LuceneResultStruct<Integer, TestObject>> results = query.findResults();
+      assertEquals(1, results.size());
+      assertEquals("key", results.get(0).getKey());
+      assertFalse(expectAuthorizationError);
+    } catch (Exception e) {
+      if (!expectAuthorizationError) {
+        throw e;
+      }
+      assertThat(e).hasCauseInstanceOf(NotAuthorizedException.class);
+      assertThat(e.getLocalizedMessage()).contains(expectedResponse);
     }
   }
 
   protected LuceneCommandsSecurityDUnitTest.UserNameAndExpectedResponse[] getSearchIndexUserNameAndExpectedResponses() {
     return new LuceneCommandsSecurityDUnitTest.UserNameAndExpectedResponse[] {
         new LuceneCommandsSecurityDUnitTest.UserNameAndExpectedResponse("nopermissions", true,
-            "nopermissions not authorized for DATA:WRITE"),
-        new LuceneCommandsSecurityDUnitTest.UserNameAndExpectedResponse("datawrite", false, null)};
+            "nopermissions not authorized for DATA:READ"),
+        new LuceneCommandsSecurityDUnitTest.UserNameAndExpectedResponse("dataread" + REGION_NAME,
+            false, null)};
   }
 }


### PR DESCRIPTION
Changing the permissions on the LuceneQueryFunction to only require
DATA:READ

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
