### PR TITLE
GEODE-3730: Moved retry logic to receiver when gemfire.GatewaySender.…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -56,6 +56,9 @@ public class GatewayReceiverStats extends CacheServerStats {
   /** Name of the unprocessed events added by primary statistic */
   private static final String EXCEPTIONS_OCCURRED = "exceptionsOccurred";
 
+  /** Name of the events retried */
+  private static final String EVENTS_RETRIED = "eventsRetried";
+
   // /** Id of the events queued statistic */
   // private int failoverBatchesReceivedId;
 
@@ -86,6 +89,9 @@ public class GatewayReceiverStats extends CacheServerStats {
   /** Id of the unprocessed events added by primary statistic */
   private int exceptionsOccurredId;
 
+  /** Id of the events retried statistic */
+  private int eventsRetriedId;
+
   // ///////////////////// Constructors ///////////////////////
 
   public static GatewayReceiverStats createGatewayReceiverStats(String ownerName) {
@@ -110,7 +116,9 @@ public class GatewayReceiverStats extends CacheServerStats {
         f.createIntCounter(UNKNOWN_OPERATIONS_RECEIVED,
             "total number of unknown operations received by this GatewayReceiver", "operations"),
         f.createIntCounter(EXCEPTIONS_OCCURRED,
-            "number of exceptions occurred while porcessing the batches", "operations")};
+            "number of exceptions occurred while porcessing the batches", "operations"),
+        f.createIntCounter(EVENTS_RETRIED,
+            "total number events retried by this GatewayReceiver due to exceptions", "operations")};
     return new GatewayReceiverStats(f, ownerName, typeName, descriptors);
 
   }
@@ -129,6 +137,7 @@ public class GatewayReceiverStats extends CacheServerStats {
     destroyRequestId = statType.nameToId(DESTROY_REQUESTS);
     unknowsOperationsReceivedId = statType.nameToId(UNKNOWN_OPERATIONS_RECEIVED);
     exceptionsOccurredId = statType.nameToId(EXCEPTIONS_OCCURRED);
+    eventsRetriedId = statType.nameToId(EVENTS_RETRIED);
   }
 
   // /////////////////// Instance Methods /////////////////////
@@ -241,6 +250,17 @@ public class GatewayReceiverStats extends CacheServerStats {
 
   public int getExceptionsOccurred() {
     return this.stats.getInt(exceptionsOccurredId);
+  }
+
+  /**
+   * Increments the number of events received by 1.
+   */
+  public void incEventsRetried() {
+    this.stats.incInt(eventsRetriedId, 1);
+  }
+
+  public int getEventsRetried() {
+    return this.stats.getInt(eventsRetriedId);
   }
 
   /**

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcher.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcher.java
@@ -622,36 +622,18 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
               // to resend all the pdx events as well in the next batch.
               final GatewaySenderStats statistics = sender.getStatistics();
               statistics.incBatchesRedistributed();
-              // log batch exceptions and remove all the events if remove from
-              // exception is true
-              // do not remove if it is false
               if (sender.isRemoveFromQueueOnException()) {
                 // log the batchExceptions
                 logBatchExceptions(ack.getBatchException());
                 processor.handleSuccessBatchAck(batchId);
               } else {
-                // we assume that batch exception will not occur for PDX related
-                // events
-                List<GatewaySenderEventImpl> pdxEvents =
-                    processor.getBatchIdToPDXEventsMap().get(ack.getBatchException().getBatchId());
-                if (pdxEvents != null) {
-                  for (GatewaySenderEventImpl senderEvent : pdxEvents) {
-                    senderEvent.isAcked = true;
-                  }
-                }
-                // log the batchExceptions
+                // log the batchExceptions. These are exceptions that were not retried on the remote
+                // site (e.g. NotAuthorizedException)
+                // @TODO Shoud anything else be done here to warn that events are lost even though
+                // the boolean is false
                 logBatchExceptions(ack.getBatchException());
-                // remove the events that have been processed.
-                BatchException70 be = ack.getBatchException();
-                List<BatchException70> exceptions = be.getExceptions();
-
-                for (int i = 0; i < exceptions.get(0).getIndex(); i++) {
-                  processor.eventQueueRemove(1);
-                }
-                // reset the sender
-                processor.handleException();
+                processor.handleSuccessBatchAck(batchId);
               }
-
             } // unsuccessful batch
             else { // The batch was successful.
               if (logger.isDebugEnabled()) {

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/KeepEventsOnGatewaySenderQueueDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/KeepEventsOnGatewaySenderQueueDUnitTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan.misc;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
+import org.apache.geode.internal.cache.wan.WANTestBase;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.junit.categories.DistributedTest;
+
+@Category(DistributedTest.class)
+public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
+
+  public KeepEventsOnGatewaySenderQueueDUnitTest() {
+    super();
+  }
+
+  @Test
+  public void testBasicKeepEventsOnGatewaySenderQueue() throws Exception {
+    // Start locators
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm2.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    String regionName = getTestMethodName() + "_PR";
+    String senderId = "ny";
+
+    // Configure receiving site members
+    createCacheInVMs(nyPort, vm3, vm4);
+    createReceiverInVMs(vm3, vm4);
+    vm3.invoke(() -> createPartitionedRegionWithPersistence(regionName, null, 0, 100));
+    vm4.invoke(() -> createPartitionedRegionWithPersistence(regionName, null, 0, 100));
+    vm4.invoke(() -> assignBuckets(regionName));
+
+    // Configure sending site members
+    createCacheInVMs(lnPort, vm1);
+    vm1.invoke(() -> createSender(senderId, 2, true, 100, 10, false, true, null, false));
+    vm1.invoke(() -> disableRemoveFromQueueOnException(senderId));
+    vm1.invoke(() -> createPartitionedRegionWithPersistence(regionName, senderId, 0, 100));
+
+    // Asynchronously do puts in sending site member
+    AsyncInvocation<Integer> putInvocation = vm1.invokeAsync(() -> doPuts(regionName, 60000l));
+
+    // Repeatedly bounce a receiving site member which will cause PartitionOfflineExceptions
+    AsyncInvocation<Integer> closeOpenInvocation =
+        vm3.invokeAsync(() -> closeRecreateCache(nyPort, regionName, 3));
+
+    // Once puts are complete, wait for queue to be empty
+    int numPuts = putInvocation.get(120, TimeUnit.SECONDS);
+    vm1.invoke(() -> validateQueueSizeStat(senderId, 0));
+
+    // Once the receiving site member bounce has completed, verify region sizes in both sites
+    closeOpenInvocation.join(120000);
+    vm1.invoke(() -> validateRegionSize(regionName, numPuts));
+    vm3.invoke(() -> validateRegionSize(regionName, numPuts));
+    vm4.invoke(() -> validateRegionSize(regionName, numPuts));
+  }
+
+  private void disableRemoveFromQueueOnException(String senderId) {
+    AbstractGatewaySender ags = (AbstractGatewaySender) cache.getGatewaySender(senderId);
+    ags.setRemoveFromQueueOnException(false);
+  }
+
+  private void assignBuckets(String regionName) {
+    Region region = cache.getRegion(regionName);
+    PartitionRegionHelper.assignBucketsToPartitions(region);
+  }
+
+  private int doPuts(String regionName, long timeToRun) throws Exception {
+    int numPuts = 0;
+    Region region = cache.getRegion(regionName);
+    long end = System.currentTimeMillis() + timeToRun;
+    while (System.currentTimeMillis() < end) {
+      region.put(UUID.randomUUID(), 0);
+      numPuts++;
+      Thread.sleep(10);
+    }
+    return numPuts;
+  }
+
+  private void closeRecreateCache(int locatorPort, String regionName, int iterations)
+      throws Exception {
+    for (int i = 0; i < iterations; i++) {
+      closeCache();
+      Thread.sleep(5000);
+      createCache(locatorPort);
+      createReceiver();
+      createPartitionedRegionWithPersistence(regionName, null, 0, 100);
+    }
+  }
+}

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/KeepEventsOnGatewaySenderQueueDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/KeepEventsOnGatewaySenderQueueDUnitTest.java
@@ -14,15 +14,23 @@
  */
 package org.apache.geode.internal.cache.wan.misc;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.cache.wan.GatewayReceiver;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
+import org.apache.geode.internal.cache.wan.GatewayReceiverStats;
 import org.apache.geode.internal.cache.wan.WANTestBase;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -35,10 +43,10 @@ public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
   }
 
   @Test
-  public void testBasicKeepEventsOnGatewaySenderQueue() throws Exception {
+  public void testKeepEventsOnGatewaySenderQueueWithPartitionOfflineException() throws Exception {
     // Start locators
-    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = vm2.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm2.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
     String regionName = getTestMethodName() + "_PR";
     String senderId = "ny";
@@ -51,7 +59,7 @@ public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
     vm4.invoke(() -> assignBuckets(regionName));
 
     // Configure sending site members
-    createCacheInVMs(lnPort, vm1);
+    vm1.invoke(() -> createCache(lnPort));
     vm1.invoke(() -> createSender(senderId, 2, true, 100, 10, false, true, null, false));
     vm1.invoke(() -> disableRemoveFromQueueOnException(senderId));
     vm1.invoke(() -> createPartitionedRegionWithPersistence(regionName, senderId, 0, 100));
@@ -63,7 +71,7 @@ public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
     AsyncInvocation<Integer> closeOpenInvocation =
         vm3.invokeAsync(() -> closeRecreateCache(nyPort, regionName, 3));
 
-    // Once puts are complete, wait for queue to be empty
+    // Once puts are complete, wait for sending site member queue to be empty
     int numPuts = putInvocation.get(120, TimeUnit.SECONDS);
     vm1.invoke(() -> validateQueueSizeStat(senderId, 0));
 
@@ -72,6 +80,43 @@ public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
     vm1.invoke(() -> validateRegionSize(regionName, numPuts));
     vm3.invoke(() -> validateRegionSize(regionName, numPuts));
     vm4.invoke(() -> validateRegionSize(regionName, numPuts));
+  }
+
+  @Test
+  public void testKeepEventsOnGatewaySenderQueueWithRegionDestroyedException() throws Exception {
+    // Start locators
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm2.invoke(() -> createFirstRemoteLocator(2, lnPort));
+
+    String regionName = getTestMethodName() + "_PR";
+    String senderId = "ny";
+
+    // Configure receiving site member
+    vm3.invoke(() -> createCache(nyPort));
+    vm3.invoke(() -> createReceiver());
+
+    // Configure sending site member
+    vm1.invoke(() -> createCache(lnPort));
+    vm1.invoke(() -> createSender(senderId, 2, true, 100, 10, false, true, null, false));
+    vm1.invoke(() -> disableRemoveFromQueueOnException(senderId));
+    vm1.invoke(() -> createPartitionedRegionWithPersistence(regionName, senderId, 0, 100));
+
+    // Do puts in sending site member
+    int numPuts = 10;
+    vm1.invoke(() -> doPuts(regionName, numPuts));
+
+    // Wait for some retries to occur
+    vm3.invoke(() -> waitForEventRetries(10));
+
+    // Create region in receiving site member
+    vm3.invoke(() -> createPartitionedRegionWithPersistence(regionName, null, 0, 100));
+
+    // Wait for sending site member queue to be empty
+    vm1.invoke(() -> validateQueueSizeStat(senderId, 0));
+
+    // Verify region sizes in both sites
+    vm1.invoke(() -> validateRegionSize(regionName, numPuts));
+    vm3.invoke(() -> validateRegionSize(regionName, numPuts));
   }
 
   private void disableRemoveFromQueueOnException(String senderId) {
@@ -105,5 +150,19 @@ public class KeepEventsOnGatewaySenderQueueDUnitTest extends WANTestBase {
       createReceiver();
       createPartitionedRegionWithPersistence(regionName, null, 0, 100);
     }
+  }
+
+  private void waitForEventRetries(int numRetries) {
+    GatewayReceiverStats stats = getGatewayReceiverStats();
+    Awaitility.await().atMost(60, TimeUnit.SECONDS)
+        .until(() -> stats.getEventsRetried() > numRetries);
+  }
+
+  private GatewayReceiverStats getGatewayReceiverStats() {
+    Set<GatewayReceiver> gatewayReceivers = cache.getGatewayReceivers();
+    GatewayReceiver receiver = gatewayReceivers.iterator().next();
+    CacheServerStats stats = ((CacheServerImpl) receiver.getServer()).getAcceptor().getStats();
+    assertThat(stats).isInstanceOf(GatewayReceiverStats.class);
+    return (GatewayReceiverStats) stats;
   }
 }


### PR DESCRIPTION
…REMOVE_FROM_QUEUE_ON_EXCEPTION=false

There are a few places this code change doesn't handle. All look to me like they would be bugs in the product not something that can really happen.

An example is:
```
try {
  possibleDuplicatePartBytes = (byte[]) possibleDuplicatePart.getObject();
} catch (Exception e) {
  logger.warn(..., e);
  throw e;
}
```
This code change doesn't handle this exception. It'll be returned to the caller. There are a few others just like this including:

- reading the eventId part
- reading the key part
- reading the callbackArg part
- reading the regionName part

These all currently log and throw which will cause the event to be returned to the caller and dropped. Maybe I need to put the retry logic around the entire switch statement instead of within each case? I'm not sure.

The code change does handle any exceptions that occur while actually doing the operation.

Also, I removed the earlyAck code since it was all dead-code and a bit in the way.

