### PR TITLE
GEODE-3441: Use random port in Tomcat8SessionsClientServerDUnitTest

### DIFF
--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
@@ -23,6 +23,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.PoolFactory;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.server.CacheServer;
@@ -41,7 +42,7 @@ public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Bas
   // Set up the session manager we need
   @Override
   public void postSetUp() throws Exception {
-    setupServer(new Tomcat8DeltaSessionManager());
+    setupServer();
   }
 
   @Override
@@ -53,7 +54,7 @@ public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Bas
   }
 
   // Set up the servers we need
-  public void setupServer(DeltaSessionManager manager) throws Exception {
+  public void setupServer() throws Exception {
     Host host = Host.getHost(0);
     vm0 = host.getVM(1);
     String hostName = vm0.getHost().getHostName();
@@ -62,12 +63,18 @@ public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Bas
       CacheFactory cf = new CacheFactory(props);
       Cache cache = cf.create();
       CacheServer server = cache.addCacheServer();
+      server.setPort(0);
       server.start();
       return server.getPort();
     });
 
     port = AvailablePortHelper.getRandomAvailableTCPPort();
     server = new EmbeddedTomcat8("/test", port, "JVM-1");
+
+    ClientCacheFactory cacheFactory = new ClientCacheFactory();
+    cacheFactory.addPoolServer(hostName, cacheServerPort);
+    cacheFactory.create();
+    DeltaSessionManager manager = new Tomcat8DeltaSessionManager();
 
     ClientServerCacheLifecycleListener listener = new ClientServerCacheLifecycleListener();
     listener.setProperty(MCAST_PORT, "0");
@@ -80,9 +87,6 @@ public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Bas
     servlet = server.addServlet("/test/*", "default", CommandServlet.class.getName());
     server.startContainer();
 
-    PoolFactory pf = PoolManager.createFactory();
-    pf.addServer(hostName, cacheServerPort);
-    pf.create("Pool Connecting to Cache Server");
 
     /*
      * Can only retrieve the region once the container has started up (and the cache has started


### PR DESCRIPTION
Changing this test to use a random port for the geode server.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
