### PR TITLE
GEODE-3242, GEODE-3243: Add gfsh support for LuceneSerializer

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -44,16 +44,9 @@ public class LuceneCliStrings {
   public static final String LUCENE_CREATE_INDEX__ANALYZER = "analyzer";
   public static final String LUCENE_CREATE_INDEX__ANALYZER_HELP =
       "Type of the analyzer for each field.\nUse the case sensitive keyword DEFAULT or leave an analyzer blank to use the default standard analyzer.";
-  public static final String CREATE_INDEX__SUCCESS__MSG =
-      "Index successfully created with following details";
-  public static final String CREATE_INDEX__FAILURE__MSG =
-      "Failed to create index \"{0}\" due to following reasons";
-  public static final String CREATE_INDEX__NAME__MSG = "Name       : {0}";
-  public static final String CREATE_INDEX__REGIONPATH__MSG = "RegionPath : {0}";
-  public static final String CREATE_INDEX__MEMBER__MSG = "Members which contain the index";
-  public static final String CREATE_INDEX__NUMBER__AND__MEMBER = "{0}. {1}";
-  public static final String CREATE_INDEX__EXCEPTION__OCCURRED__ON =
-      "Occurred on following members";
+  public static final String LUCENE_CREATE_INDEX__SERIALIZER = "serializer";
+  public static final String LUCENE_CREATE_INDEX__SERIALIZER_HELP =
+      "Fully qualified class name of the LuceneSerializer to use with this index.\n";
 
   // Describe lucene index commands
   public static final String LUCENE_DESCRIBE_INDEX = "describe lucene index";
@@ -84,9 +77,6 @@ public class LuceneCliStrings {
   public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP =
       "Default field to search in";
   public static final String LUCENE_SEARCH_INDEX__NO_RESULTS_MESSAGE = "No results";
-  public static final String LUCENE_SEARCH_INDEX__PAGE_SIZE = "pageSize";
-  public static final String LUCENE_SEARCH_INDEX__PAGE_SIZE__HELP =
-      "Number of results to be returned in a page";
   public static final String LUCENE_SEARCH_INDEX__KEYSONLY = "keys-only";
   public static final String LUCENE_SEARCH_INDEX__KEYSONLY__HELP =
       "Return only keys of search results.";

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -139,6 +139,7 @@ public class LuceneIndexCommands implements GfshCommand {
         indexData.accumulate("Server Name", indexDetails.getServerName());
         indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
         indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
+        indexData.accumulate("Serializer", indexDetails.getSerializerString());
         indexData.accumulate("Status", indexDetails.getInitialized() ? "Initialized" : "Defined");
 
         if (stats) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -181,7 +181,9 @@ public class LuceneIndexCommands implements GfshCommand {
           help = LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD_HELP) final String[] fields,
 
       @CliOption(key = LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,
-          help = LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER_HELP) final String[] analyzers) {
+          help = LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER_HELP) final String[] analyzers,
+      @CliOption(key = LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER,
+          help = LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER_HELP) final String serializer) {
 
     Result result;
     XmlEntity xmlEntity = null;
@@ -195,7 +197,7 @@ public class LuceneIndexCommands implements GfshCommand {
       // trim fields for any leading trailing spaces.
       String[] trimmedFields = Arrays.stream(fields).map(String::trim).toArray(String[]::new);
       LuceneIndexInfo indexInfo =
-          new LuceneIndexInfo(indexName, regionPath, trimmedFields, analyzers);
+          new LuceneIndexInfo(indexName, regionPath, trimmedFields, analyzers, serializer);
 
       final ResultCollector<?, ?> rc =
           this.executeFunctionOnAllMembers(createIndexFunction, indexInfo);

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -20,9 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.cache.lucene.internal.LuceneIndexCreationProfile;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneIndexStats;
+import org.apache.geode.cache.lucene.internal.repository.serializer.HeterogeneousLuceneSerializer;
 
 import org.apache.lucene.analysis.Analyzer;
 
@@ -34,27 +36,32 @@ public class LuceneIndexDetails extends LuceneFunctionSerializable
   private Map<String, String> fieldAnalyzers = null;
   private final Map<String, Integer> indexStats;
   private boolean initialized;
+  private String serializer;
 
   public LuceneIndexDetails(final String indexName, final String regionPath,
       final String[] searchableFieldNames, final Map<String, Analyzer> fieldAnalyzers,
-      LuceneIndexStats indexStats, boolean initialized, final String serverName) {
+      LuceneIndexStats indexStats, boolean initialized, final String serverName,
+      LuceneSerializer serializer) {
     super(indexName, regionPath);
     this.serverName = serverName;
     this.searchableFieldNames = searchableFieldNames;
     this.fieldAnalyzers = getFieldAnalyzerStrings(fieldAnalyzers);
     this.indexStats = getIndexStatsMap(indexStats);
     this.initialized = initialized;
+    this.serializer = serializer != null ? serializer.getClass().getSimpleName()
+        : HeterogeneousLuceneSerializer.class.getSimpleName();
   }
 
   public LuceneIndexDetails(LuceneIndexImpl index, final String serverName) {
     this(index.getName(), index.getRegionPath(), index.getFieldNames(), index.getFieldAnalyzers(),
-        index.getIndexStats(), true, serverName);
+        index.getIndexStats(), true, serverName, index.getLuceneSerializer());
   }
 
   public LuceneIndexDetails(LuceneIndexCreationProfile indexProfile, final String serverName) {
     this(indexProfile.getIndexName(), indexProfile.getRegionPath(), indexProfile.getFieldNames(),
-        null, null, false, serverName);
+        null, null, false, serverName, null);
     this.fieldAnalyzers = getFieldAnalyzerStringsFromProfile(indexProfile.getFieldAnalyzers());
+    this.serializer = indexProfile.getSerializerClass();
   }
 
   public Map<String, Integer> getIndexStats() {
@@ -114,9 +121,12 @@ public class LuceneIndexDetails extends LuceneFunctionSerializable
     return Arrays.asList(searchableFieldNames).toString();
   }
 
-
   public String getFieldAnalyzersString() {
     return fieldAnalyzers.toString();
+  }
+
+  public String getSerializerString() {
+    return this.serializer;
   }
 
   @Override
@@ -126,6 +136,7 @@ public class LuceneIndexDetails extends LuceneFunctionSerializable
     buffer.append(",\tRegion Path = " + regionPath);
     buffer.append(",\tIndexed Fields = " + getSearchableFieldNamesString());
     buffer.append(",\tField Analyzer = " + getFieldAnalyzersString());
+    buffer.append(",\tSerializer = " + getSerializerString());
     buffer.append(",\tStatus =\n\t" + getInitialized());
     buffer.append(",\tIndex Statistics =\n\t" + getIndexStatsString());
     buffer.append("\n}\n");

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexInfo.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexInfo.java
@@ -19,16 +19,18 @@ public class LuceneIndexInfo extends LuceneFunctionSerializable {
 
   private final String[] searchableFieldNames;
   private final String[] fieldAnalyzers;
+  private final String serializer;
 
   public LuceneIndexInfo(final String indexName, final String regionPath,
-      final String[] searchableFieldNames, String[] fieldAnalyzers) {
+      final String[] searchableFieldNames, String[] fieldAnalyzers, String serializer) {
     super(indexName, regionPath);
     this.searchableFieldNames = searchableFieldNames;
     this.fieldAnalyzers = fieldAnalyzers;
+    this.serializer = serializer;
   }
 
   public LuceneIndexInfo(final String indexName, final String regionPath) {
-    this(indexName, regionPath, null, null);
+    this(indexName, regionPath, null, null, null);
   }
 
   public String[] getSearchableFieldNames() {
@@ -37,5 +39,9 @@ public class LuceneIndexInfo extends LuceneFunctionSerializable {
 
   public String[] getFieldAnalyzers() {
     return fieldAnalyzers;
+  }
+
+  public String getSerializer() {
+    return serializer;
   }
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
@@ -27,6 +27,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.execute.FunctionAdapter;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.lucene.LuceneIndexFactory;
+import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.cache.lucene.LuceneService;
 import org.apache.geode.cache.lucene.LuceneServiceProvider;
 import org.apache.geode.cache.lucene.internal.cli.LuceneCliStrings;
@@ -73,6 +74,7 @@ public class LuceneCreateIndexFunction extends FunctionAdapter implements Intern
 
       String[] fields = indexInfo.getSearchableFieldNames();
       String[] analyzerName = indexInfo.getFieldAnalyzers();
+      String serializerName = indexInfo.getSerializer();
 
       final LuceneIndexFactory indexFactory = service.createIndexFactory();
       if (analyzerName == null || analyzerName.length == 0) {
@@ -88,6 +90,10 @@ public class LuceneCreateIndexFunction extends FunctionAdapter implements Intern
         }
       }
 
+      if (serializerName != null && !serializerName.equals("")) {
+        indexFactory.setLuceneSerializer(toSerializer(serializerName));
+      }
+
       REGION_PATH.validateName(indexInfo.getRegionPath());
 
       indexFactory.create(indexInfo.getIndexName(), indexInfo.getRegionPath());
@@ -100,6 +106,17 @@ public class LuceneCreateIndexFunction extends FunctionAdapter implements Intern
           e.getClass().getName(), e.getMessage());
       context.getResultSender().lastResult(new CliFunctionResult(memberId, e, e.getMessage()));
     }
+  }
+
+  private LuceneSerializer toSerializer(String serializerName)
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    String trimmedName = StringUtils.trim(serializerName);
+    if (trimmedName == "") {
+      return null;
+    }
+    Class<? extends LuceneSerializer> clazz =
+        CliUtil.forName(serializerName, LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER);
+    return CliUtil.newInstance(clazz, LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER);
   }
 
   private Analyzer toAnalyzer(String className) {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -417,6 +417,30 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
   }
 
   @Test
+  public void describeIndexShouldShowSerializer() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    vm1.invoke(() -> {
+      getCache();
+    });
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER,
+        PrimitiveSerializer.class.getCanonicalName());
+
+    String resultAsString = executeCommandAndLogResult(csb);
+    vm1.invoke(() -> createRegion());
+
+    csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    resultAsString = executeCommandAndLogResult(csb);
+    assertThat(resultAsString).contains(PrimitiveSerializer.class.getSimpleName());
+  }
+
+  @Test
   public void describeIndexShouldNotReturnResultWhenIndexNotFound() throws Exception {
     final VM vm1 = Host.getHost(0).getVM(1);
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -56,6 +56,7 @@ import org.apache.geode.cache.lucene.internal.cli.functions.LuceneCreateIndexFun
 import org.apache.geode.cache.lucene.internal.cli.functions.LuceneDescribeIndexFunction;
 import org.apache.geode.cache.lucene.internal.cli.functions.LuceneDestroyIndexFunction;
 import org.apache.geode.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
+import org.apache.geode.cache.lucene.internal.repository.serializer.PrimitiveSerializer;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
@@ -212,8 +213,10 @@ public class LuceneIndexCommandsJUnitTest {
     String[] fieldAnalyzers = {StandardAnalyzer.class.getCanonicalName(),
         KeywordAnalyzer.class.getCanonicalName(), StandardAnalyzer.class.getCanonicalName()};
 
+    String serializer = PrimitiveSerializer.class.getCanonicalName();
+
     CommandResult result = (CommandResult) commands.createIndex(indexName, regionPath,
-        searchableFields, fieldAnalyzers);
+        searchableFields, fieldAnalyzers, serializer);
     assertEquals(Status.OK, result.getStatus());
     TabularResultData data = (TabularResultData) result.getResultData();
     assertEquals(Arrays.asList("member1", "member2", "member3"), data.retrieveAllValues("Member"));


### PR DESCRIPTION
gfsh create index now supports a LuceneSerializer and the serializer is
persisted in cluster configuration.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
