### PR TITLE
GEODE-3687: GatewayReceiverImpl constructor and create method updates

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewayReceiver.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewayReceiver.java
@@ -134,7 +134,7 @@ public interface GatewayReceiver {
    * 
    * @return the ip address or host name to give to clients so they can connect to this receiver
    */
-  public String getHost();
+  public String getHostnameForSenders();
 
   /**
    * Returns the configured buffer size of the socket connection for this

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewayReceiver.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewayReceiver.java
@@ -134,6 +134,11 @@ public interface GatewayReceiver {
    * 
    * @return the ip address or host name to give to clients so they can connect to this receiver
    */
+  public String getHost();
+
+  /**
+   * Returns the hostname configured by {@link GatewayReceiverFactory#setHostnameForSenders(String)}
+   */
   public String getHostnameForSenders();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -536,7 +536,7 @@ public class CacheCreation implements InternalCache {
       for (GatewayTransportFilter filter : receiverCreation.getGatewayTransportFilters()) {
         factory.addGatewayTransportFilter(filter);
       }
-      factory.setHostnameForSenders(receiverCreation.getHost());
+      factory.setHostnameForSenders(receiverCreation.getHostnameForSenders());
       GatewayReceiver receiver = factory.create();
       if (receiver.isManualStart()) {
         cache.getLoggerI18n().info(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
@@ -114,7 +114,7 @@ public class GatewayReceiverCreation implements GatewayReceiver {
   }
 
   public String getHost() {
-    throw new IllegalStateException("getHost should not be invoked on GatewayReiverCreation");
+    throw new IllegalStateException("getHost should not be invoked on GatewayReceiverCreation");
   }
 
   public String getBindAddress() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
@@ -51,6 +51,8 @@ public class GatewayReceiverCreation implements GatewayReceiver {
 
   private String bindAddress;
 
+  private String hostnameForSenders;
+
   private boolean manualStart;
 
   private CacheServer receiver;
@@ -61,34 +63,12 @@ public class GatewayReceiverCreation implements GatewayReceiver {
       boolean manualStart) {
     this.cache = cache;
 
-    /*
-     * If user has set hostNameForSenders then it should take precedence over bindAddress. If user
-     * hasn't set either hostNameForSenders or bindAddress then getLocalHost().getHostName() should
-     * be used.
-     */
-    if (hostnameForSenders == null || hostnameForSenders.isEmpty()) {
-      if (bindAdd == null || bindAdd.isEmpty()) {
-        try {
-          logger
-              .warn(LocalizedMessage.create(LocalizedStrings.GatewayReceiverImpl_USING_LOCAL_HOST));
-          this.host = SocketCreator.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-          throw new IllegalStateException(
-              LocalizedStrings.GatewayReceiverImpl_COULD_NOT_GET_HOST_NAME.toLocalizedString(), e);
-        }
-      } else {
-        this.host = bindAdd;
-      }
-    } else {
-      this.host = hostnameForSenders;
-    }
-
-
     this.startPort = startPort;
     this.endPort = endPort;
     this.maxTimeBetweenPings = timeBetPings;
     this.socketBufferSize = buffSize;
     this.bindAddress = bindAdd;
+    this.hostnameForSenders = hostnameForSenders;
     this.transFilter = filters;
     this.manualStart = manualStart;
   }
@@ -129,8 +109,8 @@ public class GatewayReceiverCreation implements GatewayReceiver {
     this.socketBufferSize = socketBufferSize;
   }
 
-  public String getHost() {
-    return this.host;
+  public String getHostnameForSenders() {
+    return this.hostnameForSenders;
   }
 
   public String getBindAddress() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/GatewayReceiverCreation.java
@@ -113,6 +113,10 @@ public class GatewayReceiverCreation implements GatewayReceiver {
     return this.hostnameForSenders;
   }
 
+  public String getHost() {
+    throw new IllegalStateException("getHost should not be invoked on GatewayReiverCreation");
+  }
+
   public String getBindAddress() {
     return this.bindAddress;
   }

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
@@ -46,6 +46,8 @@ public class GatewayReceiverImpl implements GatewayReceiver {
 
   private String host;
 
+  private String hostnameForSenders;
+
   private int startPort;
 
   private int endPort;
@@ -71,28 +73,7 @@ public class GatewayReceiverImpl implements GatewayReceiver {
       boolean manualStart) {
     this.cache = cache;
 
-    /*
-     * If user has set hostNameForSenders then it should take precedence over bindAddress. If user
-     * hasn't set either hostNameForSenders or bindAddress then getLocalHost().getHostName() should
-     * be used.
-     */
-    if (hostnameForSenders == null || hostnameForSenders.isEmpty()) {
-      if (bindAdd == null || bindAdd.isEmpty()) {
-        try {
-          logger
-              .warn(LocalizedMessage.create(LocalizedStrings.GatewayReceiverImpl_USING_LOCAL_HOST));
-          this.host = SocketCreator.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-          throw new IllegalStateException(
-              LocalizedStrings.GatewayReceiverImpl_COULD_NOT_GET_HOST_NAME.toLocalizedString(), e);
-        }
-      } else {
-        this.host = bindAdd;
-      }
-    } else {
-      this.host = hostnameForSenders;
-    }
-
+    this.hostnameForSenders = hostnameForSenders;
     this.startPort = startPort;
     this.endPort = endPort;
     this.timeBetPings = timeBetPings;
@@ -100,6 +81,10 @@ public class GatewayReceiverImpl implements GatewayReceiver {
     this.bindAdd = bindAdd;
     this.filters = filters;
     this.manualStart = manualStart;
+  }
+
+  public String getHostnameForSenders() {
+    return hostnameForSenders;
   }
 
   public List<GatewayTransportFilter> getGatewayTransportFilters() {
@@ -148,7 +133,9 @@ public class GatewayReceiverImpl implements GatewayReceiver {
       receiver.setPort(this.port);
       receiver.setSocketBufferSize(socketBufferSize);
       receiver.setMaximumTimeBetweenPings(timeBetPings);
-      receiver.setHostnameForClients(host);
+      if (hostnameForSenders != null && !hostnameForSenders.isEmpty()) {
+        receiver.setHostnameForClients(hostnameForSenders);
+      }
       receiver.setBindAddress(bindAdd);
       receiver.setGroups(new String[] {GatewayReceiver.RECEIVER_GROUP});
       ((CacheServerImpl) receiver).setGatewayTransportFilter(this.filters);
@@ -209,10 +196,6 @@ public class GatewayReceiverImpl implements GatewayReceiver {
     receiver.stop();
   }
 
-  public String getHost() {
-    return this.host;
-  }
-
   public String getBindAddress() {
     return this.bindAdd;
   }
@@ -226,13 +209,13 @@ public class GatewayReceiverImpl implements GatewayReceiver {
 
   public String toString() {
     return new StringBuffer().append("Gateway Receiver").append("@")
-        .append(Integer.toHexString(hashCode())).append(" [").append("host='").append(getHost())
-        .append("'; port=").append(getPort()).append("; bindAddress=").append(getBindAddress())
-        .append("; maximumTimeBetweenPings=").append(getMaximumTimeBetweenPings())
-        .append("; socketBufferSize=").append(getSocketBufferSize()).append("; isManualStart=")
-        .append(isManualStart()).append("; group=")
-        .append(Arrays.toString(new String[] {GatewayReceiver.RECEIVER_GROUP})).append("]")
-        .toString();
+        .append(Integer.toHexString(hashCode())).append("'; port=").append(getPort())
+        .append("; bindAddress=").append(getBindAddress()).append("'; hostnameForSenders=")
+        .append(getHostnameForSenders()).append("; maximumTimeBetweenPings=")
+        .append(getMaximumTimeBetweenPings()).append("; socketBufferSize=")
+        .append(getSocketBufferSize()).append("; isManualStart=").append(isManualStart())
+        .append("; group=").append(Arrays.toString(new String[] {GatewayReceiver.RECEIVER_GROUP}))
+        .append("]").toString();
   }
 
 }

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
@@ -44,8 +44,6 @@ public class GatewayReceiverImpl implements GatewayReceiver {
 
   private static final Logger logger = LogService.getLogger();
 
-  private String host;
-
   private String hostnameForSenders;
 
   private int startPort;
@@ -85,6 +83,27 @@ public class GatewayReceiverImpl implements GatewayReceiver {
 
   public String getHostnameForSenders() {
     return hostnameForSenders;
+  }
+
+  public String getHost() {
+    if (receiver != null) {
+      return ((CacheServerImpl) receiver).getExternalAddress();
+    }
+
+    if (hostnameForSenders != null && !hostnameForSenders.isEmpty()) {
+      return hostnameForSenders;
+    }
+
+    if (bindAdd != null && !bindAdd.isEmpty()) {
+      return bindAdd;
+    }
+
+    try {
+      return SocketCreator.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException(
+          LocalizedStrings.GatewayReceiverImpl_COULD_NOT_GET_HOST_NAME.toLocalizedString(), e);
+    }
   }
 
   public List<GatewayTransportFilter> getGatewayTransportFilters() {

--- a/geode-wan/src/test/java/org/apache/geode/cache/CacheXml70GatewayDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/CacheXml70GatewayDUnitTest.java
@@ -219,7 +219,7 @@ public class CacheXml70GatewayDUnitTest extends CacheXmlTestCase {
   }
 
   static void validateGatewayReceiver(GatewayReceiver receiver1, GatewayReceiver gatewayReceiver) {
-    assertEquals(receiver1.getHost(), gatewayReceiver.getHost());
+    assertEquals(receiver1.getHostnameForSenders(), gatewayReceiver.getHostnameForSenders());
     assertEquals(receiver1.getStartPort(), gatewayReceiver.getStartPort());
     assertEquals(receiver1.getEndPort(), gatewayReceiver.getEndPort());
     assertEquals(receiver1.getMaximumTimeBetweenPings(),

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplJUnitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class GatewayReceiverImplJUnitTest {
+
+  @Test
+  public void getHostOnUnstartedGatewayShouldReturnLocalhost() throws UnknownHostException {
+    InternalCache cache = mock(InternalCache.class);
+    GatewayReceiverImpl gateway =
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+    assertEquals(SocketCreator.getLocalHost().getHostAddress(), gateway.getHost());
+  }
+
+  @Test
+  public void getHostOnRunningGatewayShouldReturnCacheServerAddress() throws IOException {
+    InternalCache cache = mock(InternalCache.class);
+    CacheServerImpl server = mock(CacheServerImpl.class);
+    InternalDistributedSystem system = mock(InternalDistributedSystem.class);
+    when(cache.getInternalDistributedSystem()).thenReturn(system);
+    when(server.getExternalAddress()).thenReturn("hello");
+    when(cache.addCacheServer(eq(true))).thenReturn(server);
+    GatewayReceiverImpl gateway =
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+    gateway.start();
+    assertEquals("hello", gateway.getHost());
+  }
+
+}

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplJUnitTest.java
@@ -39,7 +39,7 @@ public class GatewayReceiverImplJUnitTest {
     InternalCache cache = mock(InternalCache.class);
     GatewayReceiverImpl gateway =
         new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
-    assertEquals(SocketCreator.getLocalHost().getHostAddress(), gateway.getHost());
+    assertEquals(SocketCreator.getLocalHost().getHostName(), gateway.getHost());
   }
 
   @Test

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -223,7 +223,7 @@ public class WANConfigurationJUnitTest {
     Region region = cache.createRegionFactory().create("test_ValidateGatewayReceiverAttributes");
     Set<GatewayReceiver> receivers = cache.getGatewayReceivers();
     GatewayReceiver rec = receivers.iterator().next();
-    assertEquals(receiver1.getHost(), rec.getHost());
+    assertEquals(receiver1.getHostnameForSenders(), rec.getHostnameForSenders());
     assertEquals(receiver1.getStartPort(), rec.getStartPort());
     assertEquals(receiver1.getEndPort(), rec.getEndPort());
     assertEquals(receiver1.getBindAddress(), rec.getBindAddress());

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
@@ -20,12 +20,9 @@ import static org.apache.geode.test.dunit.Assert.fail;
 import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.internal.logging.log4j.LocalizedMessage;
 import org.apache.geode.internal.net.SocketCreator;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -64,6 +61,47 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     vm5.invoke(() -> createCache(dsIdPort));
 
     String command = CliStrings.CREATE_GATEWAYRECEIVER;
+    executeCommandAndVerifyStatus(command, 4);
+
+    // if neither bind-address or hostname-for-senders is set, profile
+    // uses AcceptorImpl.getExternalAddress() to derive canonical hostname
+    // when the Profile (and ServerLocation) are created
+    String hostname = getHostName();
+
+    vm3.invoke(() -> verifyGatewayReceiverProfile(hostname));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(hostname));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(hostname));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostname));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostname));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostname));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+  }
+
+  private String getHostName() throws Exception {
+    return SocketCreator.getLocalHost().getCanonicalHostName();
+  }
+
+  private String getBindAddress() throws Exception {
+    return InetAddress.getLocalHost().getHostAddress();
+  }
+
+  private void executeCommandAndVerifyStatus(String command, int numGatewayReceivers) {
     CommandResult cmdResult = executeCommand(command);
     if (cmdResult != null) {
       String strCmdResult = commandResultToString(cmdResult);
@@ -72,7 +110,9 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
 
       TabularResultData resultData = (TabularResultData) cmdResult.getResultData();
       List<String> status = resultData.retrieveAllValues("Status");
-      assertEquals(4, status.size());// expected size 4 includes the manager node
+      // expected size of 4 includes the manager node when we don't set the receiver groups to
+      // ignore it)
+      assertEquals(numGatewayReceivers, status.size());
       // verify there is no error in the status
       for (String stat : status) {
         assertTrue("GatewayReceiver creation failed with: " + stat, !stat.contains("ERROR:"));
@@ -80,22 +120,6 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     } else {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
-
-    String hostname;
-    hostname = SocketCreator.getLocalHost().getHostName();
-
-    vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
-        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
-        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null, hostname));
-    vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
-        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
-        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null, hostname));
-    vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
-        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
-        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null, hostname));
   }
 
   /**
@@ -119,35 +143,23 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
             + CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT + "=11000" + " --"
             + CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS + "=100000" + " --"
             + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000";
-    CommandResult cmdResult = executeCommand(command);
-    if (cmdResult != null) {
-      String strCmdResult = commandResultToString(cmdResult);
-      getLogWriter().info("testCreateGatewayReceiver stringResult : " + strCmdResult + ">>>>");
-      assertEquals(Result.Status.OK, cmdResult.getStatus());
+    executeCommandAndVerifyStatus(command, 4);
 
-      TabularResultData resultData = (TabularResultData) cmdResult.getResultData();
-      List<String> status = resultData.retrieveAllValues("Status");
-      assertEquals(4, status.size());// expected size 4 includes the manager node
-      // verify there is no error in the status
-      for (String stat : status) {
-        assertTrue("GatewayReceiver creation failed with: " + stat, !stat.contains("ERROR:"));
-      }
-    } else {
-      fail("testCreateGatewayReceiver failed as did not get CommandResult");
-    }
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm5.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
    * GatewayReceiver with hostnameForSenders
    */
   @Test
-  public void testCreateGatewayReceiverWithHostnameForSenders() throws UnknownHostException {
+  public void testCreateGatewayReceiverWithHostnameForSenders() throws Exception {
     VM puneLocator = Host.getLocator();
     int dsIdPort = puneLocator.invoke(this::getLocatorPort);
     propsSetUp(dsIdPort);
@@ -157,7 +169,7 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     vm4.invoke(() -> createCache(dsIdPort));
     vm5.invoke(() -> createCache(dsIdPort));
 
-    String hostnameForSenders = InetAddress.getLocalHost().getHostName();
+    String hostnameForSenders = getHostName();
     String command =
         CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART
             + "=false" + " --" + CliStrings.CREATE_GATEWAYRECEIVER__HOSTNAMEFORSENDERS + "="
@@ -165,23 +177,9 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
             + " --" + CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT + "=11000" + " --"
             + CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS + "=100000" + " --"
             + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000";
-    CommandResult cmdResult = executeCommand(command);
-    if (cmdResult != null) {
-      String strCmdResult = commandResultToString(cmdResult);
-      getLogWriter().info("testCreateGatewayReceiver stringResult : " + strCmdResult + ">>>>");
-      assertEquals(Result.Status.OK, cmdResult.getStatus());
+    executeCommandAndVerifyStatus(command, 4);
 
-      TabularResultData resultData = (TabularResultData) cmdResult.getResultData();
-      List<String> status = resultData.retrieveAllValues("Status");
-      assertEquals(4, status.size());// expected size 4 includes the manager node
-      // verify there is no error in the status
-      for (String stat : status) {
-        assertTrue("GatewayReceiver creation failed with: " + stat, !stat.contains("ERROR:"));
-      }
-    } else {
-      fail("testCreateGatewayReceiver failed as did not get CommandResult");
-    }
-
+    // verify hostname-for-senders is used when configured
     vm3.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
     vm4.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
     vm5.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
@@ -198,6 +196,246 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
         null, hostnameForSenders));
   }
 
+  /**
+   * GatewayReceiver with all default attributes and bind-address in gemfire-properties
+   */
+  @Test
+  public void testCreateGatewayReceiverWithDefaultAndBindProperty() throws Exception {
+    VM puneLocator = Host.getLocator();
+    int dsIdPort = puneLocator.invoke(this::getLocatorPort);
+    propsSetUp(dsIdPort);
+    vm2.invoke(() -> createFirstRemoteLocator(2, dsIdPort));
+
+    String expectedBindAddress = getBindAddress();
+
+    String receiverGroup = "receiverGroup";
+    vm3.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm4.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm5.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+
+    String command =
+        CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.GROUP + "=" + receiverGroup;
+    executeCommandAndVerifyStatus(command, 3);
+
+    // verify bind-address used when provided as a gemfire property
+    vm3.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+  }
+
+  /**
+   * GatewayReceiver with all default attributes and server-bind-address in the gemfire properties
+   */
+  @Test
+  public void testCreateGatewayReceiverWithDefaultsAndServerBindAddressProperty() throws Exception {
+    VM puneLocator = Host.getLocator();
+    int dsIdPort = puneLocator.invoke(this::getLocatorPort);
+    propsSetUp(dsIdPort);
+    vm2.invoke(() -> createFirstRemoteLocator(2, dsIdPort));
+
+    String expectedBindAddress = getBindAddress();
+
+    String receiverGroup = "receiverGroup";
+    vm3.invoke(
+        () -> createCacheWithServerBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm4.invoke(
+        () -> createCacheWithServerBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm5.invoke(
+        () -> createCacheWithServerBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+
+    String command =
+        CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.GROUP + "=" + receiverGroup;
+    executeCommandAndVerifyStatus(command, 3);
+
+    // verify server-bind-address used if provided as a gemfire property
+    vm3.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+  }
+
+  /**
+   * GatewayReceiver with all default attributes and server-bind-address in the gemfire properties
+   */
+  @Test
+  public void testCreateGatewayReceiverWithDefaultsAndMultipleBindAddressProperties()
+      throws Exception {
+    VM puneLocator = Host.getLocator();
+    int dsIdPort = puneLocator.invoke(this::getLocatorPort);
+    propsSetUp(dsIdPort);
+    vm2.invoke(() -> createFirstRemoteLocator(2, dsIdPort));
+
+    String extraBindAddress = "localhost";
+    String expectedBindAddress = getBindAddress();
+    String receiverGroup = "receiverGroup";
+
+    vm3.invoke(() -> createCacheWithMultipleBindAddressProperties(dsIdPort, extraBindAddress,
+        expectedBindAddress, receiverGroup));
+    vm4.invoke(() -> createCacheWithMultipleBindAddressProperties(dsIdPort, extraBindAddress,
+        expectedBindAddress, receiverGroup));
+    vm5.invoke(() -> createCacheWithMultipleBindAddressProperties(dsIdPort, extraBindAddress,
+        expectedBindAddress, receiverGroup));
+
+    String command =
+        CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.GROUP + "=" + receiverGroup;
+    executeCommandAndVerifyStatus(command, 3);
+
+    // verify server-bind-address used if provided as a gemfire property
+    vm3.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(expectedBindAddress));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, expectedBindAddress));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
+        GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
+        GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
+        GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
+  }
+
+
+  /**
+   * GatewayReceiver with hostnameForSenders
+   */
+  @Test
+  public void testCreateGatewayReceiverWithHostnameForSendersAndServerBindAddressProperty()
+      throws Exception {
+    VM puneLocator = Host.getLocator();
+    int dsIdPort = puneLocator.invoke(this::getLocatorPort);
+    propsSetUp(dsIdPort);
+    vm2.invoke(() -> createFirstRemoteLocator(2, dsIdPort));
+
+    String hostnameForSenders = getHostName();
+    String serverBindAddress = getBindAddress();
+
+    String receiverGroup = "receiverGroup";
+    vm3.invoke(() -> createCacheWithServerBindAddress(dsIdPort, serverBindAddress, receiverGroup));
+    vm4.invoke(() -> createCacheWithServerBindAddress(dsIdPort, serverBindAddress, receiverGroup));
+    vm5.invoke(() -> createCacheWithServerBindAddress(dsIdPort, serverBindAddress, receiverGroup));
+
+    String command =
+        CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART
+            + "=false" + " --" + CliStrings.CREATE_GATEWAYRECEIVER__HOSTNAMEFORSENDERS + "="
+            + hostnameForSenders + " --" + CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT + "=10000"
+            + " --" + CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT + "=11000" + " --"
+            + CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS + "=100000" + " --"
+            + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000" + " --"
+            + CliStrings.GROUP + "=" + receiverGroup;
+    executeCommandAndVerifyStatus(command, 3);
+
+    // verify server-bind-address takes precedence over hostname-for-senders
+    vm3.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+  }
+
+  /**
+   * GatewayReceiver with hostnameForSenders
+   */
+  @Test
+  public void testCreateGatewayReceiverWithHostnameForSendersAndBindAddressProperty()
+      throws Exception {
+    VM puneLocator = Host.getLocator();
+    int dsIdPort = puneLocator.invoke(this::getLocatorPort);
+    propsSetUp(dsIdPort);
+    vm2.invoke(() -> createFirstRemoteLocator(2, dsIdPort));
+
+    String hostnameForSenders = getHostName();
+    String expectedBindAddress = getBindAddress();
+
+    String receiverGroup = "receiverGroup";
+    vm3.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm4.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+    vm5.invoke(() -> createCacheWithBindAddress(dsIdPort, expectedBindAddress, receiverGroup));
+
+    String command =
+        CliStrings.CREATE_GATEWAYRECEIVER + " --" + CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART
+            + "=false" + " --" + CliStrings.CREATE_GATEWAYRECEIVER__HOSTNAMEFORSENDERS + "="
+            + hostnameForSenders + " --" + CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT + "=10000"
+            + " --" + CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT + "=11000" + " --"
+            + CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS + "=100000" + " --"
+            + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000" + " --"
+            + CliStrings.GROUP + "=" + receiverGroup;
+    executeCommandAndVerifyStatus(command, 3);
+
+    vm3.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+    vm4.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+    vm5.invoke(() -> verifyGatewayReceiverProfile(hostnameForSenders));
+
+    vm3.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+    vm4.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+    vm5.invoke(() -> verifyGatewayReceiverServerLocations(dsIdPort, hostnameForSenders));
+
+    vm3.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+    vm4.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+    vm5.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "", 100000, 512000,
+        null, hostnameForSenders));
+  }
 
   /**
    * GatewayReceiver with given attributes and a single GatewayTransportFilter.
@@ -222,31 +460,16 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
             + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000" + " --"
             + CliStrings.CREATE_GATEWAYRECEIVER__GATEWAYTRANSPORTFILTER
             + "=org.apache.geode.cache30.MyGatewayTransportFilter1";
-    CommandResult cmdResult = executeCommand(command);
-    if (cmdResult != null) {
-      String strCmdResult = commandResultToString(cmdResult);
-      getLogWriter().info("testCreateGatewayReceiver stringResult : " + strCmdResult + ">>>>");
-      assertEquals(Result.Status.OK, cmdResult.getStatus());
-
-      TabularResultData resultData = (TabularResultData) cmdResult.getResultData();
-      List<String> status = resultData.retrieveAllValues("Status");
-      assertEquals(4, status.size());// expected size 4 includes the manager node
-      // verify there is no error in the status
-      for (String stat : status) {
-        assertTrue("GatewayReceiver creation failed with: " + stat, !stat.contains("ERROR:"));
-      }
-    } else {
-      fail("testCreateGatewayReceiver failed as did not get CommandResult");
-    }
+    executeCommandAndVerifyStatus(command, 4);
     List<String> transportFilters = new ArrayList<String>();
     transportFilters.add("org.apache.geode.cache30.MyGatewayTransportFilter1");
 
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
-        512000, transportFilters, "localhost"));
+        512000, transportFilters, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
-        512000, transportFilters, "localhost"));
+        512000, transportFilters, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm5.invoke(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
-        512000, transportFilters, "localhost"));
+        512000, transportFilters, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -271,32 +494,20 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
         + CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE + "=512000" + " --"
         + CliStrings.CREATE_GATEWAYRECEIVER__GATEWAYTRANSPORTFILTER
         + "=org.apache.geode.cache30.MyGatewayTransportFilter1,org.apache.geode.cache30.MyGatewayTransportFilter2";
-    CommandResult cmdResult = executeCommand(command);
-    if (cmdResult != null) {
-      String strCmdResult = commandResultToString(cmdResult);
-      getLogWriter().info("testCreateGatewayReceiver stringResult : " + strCmdResult + ">>>>");
-      assertEquals(Result.Status.OK, cmdResult.getStatus());
-
-      TabularResultData resultData = (TabularResultData) cmdResult.getResultData();
-      List<String> status = resultData.retrieveAllValues("Status");
-      assertEquals(4, status.size());// expected size 4 includes the manager node
-      // verify there is no error in the status
-      for (String stat : status) {
-        assertTrue("GatewayReceiver creation failed with: " + stat, !stat.contains("ERROR:"));
-      }
-    } else {
-      fail("testCreateGatewayReceiver failed as did not get CommandResult");
-    }
+    executeCommandAndVerifyStatus(command, 4);
     List<String> transportFilters = new ArrayList<String>();
     transportFilters.add("org.apache.geode.cache30.MyGatewayTransportFilter1");
     transportFilters.add("org.apache.geode.cache30.MyGatewayTransportFilter2");
 
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        10000, 11000, "localhost", 100000, 512000, transportFilters, "localhost"));
+        10000, 11000, "localhost", 100000, 512000, transportFilters,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        10000, 11000, "localhost", 100000, 512000, transportFilters, "localhost"));
+        10000, 11000, "localhost", 100000, 512000, transportFilters,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm5.invoke(() -> verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-        10000, 11000, "localhost", 100000, 512000, transportFilters, "localhost"));
+        10000, 11000, "localhost", 100000, 512000, transportFilters,
+        GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -378,8 +589,11 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     } else {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
+
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -424,10 +638,13 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     } else {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
+
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -469,12 +686,14 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
 
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm5.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -516,10 +735,13 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     } else {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
+
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 
   /**
@@ -560,11 +782,14 @@ public class CreateGatewayReceiverCommandDUnitTest extends WANCommandTestBase {
     } else {
       fail("testCreateGatewayReceiver failed as did not get CommandResult");
     }
+
+    // cannot verify Profile/ServerLocation when manualStart is true
+
     vm3.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm4.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
     vm5.invoke(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
-        512000, null, "localhost"));
+        512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS));
   }
 }


### PR DESCRIPTION
- bind-address specified in gemfire.properties is now used to configure Profile and ServerLocations
- removed host field (previously calculated at config time based on hostname-for-sender and bind-address parameters)
  with result then passed to CacheServerImpl.start()
- replaced host field with hostnameForSenders, which is now used (when set) to set hostnameForClients in CacheServerImpl.
- replaced getHost with getHostnameForSenders
- associated tests, including those to set bind-address and server-bind-address through gemfire.properties

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
