### PR TITLE
Fix the path error in the Javadoc

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
+++ b/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
@@ -49,7 +49,7 @@ import org.apache.geode.security.SecurityManager;
  * A Geode member must be configured with the following:
  *
  * <p>
- * {@code security-manager = org.apache.geode.security.examples.ExampleSecurityManager}
+ * {@code security-manager = org.apache.geode.examples.security.ExampleSecurityManager}
  *
  * <p>
  * The class can be initialized with from a JSON resource called {@code security.json}. This file


### PR DESCRIPTION
It's security-manager = org.apache.geode.examples.security.ExampleSecurityManager not org.apache.geode.security.examplesExampleSecurityManager

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
https://stackoverflow.com/questions/46548293/geode-securitymanager-implementation

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?
Yeah

- [ ] Does `gradlew build` run cleanly?
I don't know

- [ ] Have you written or updated unit tests to verify your changes?
No!

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
