### PR TITLE
GEODE-3693: increase test coverage of CacheListener events

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheEventListenerDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheEventListenerDUnitTest.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.Serializable;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.test.dunit.cache.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.dunit.rules.SharedCountersRule;
+import org.apache.geode.test.dunit.rules.SharedErrorCollector;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+/**
+ * Converted from JUnit 3.
+ *
+ * @since 2.0
+ */
+@Category(DistributedTest.class)
+@SuppressWarnings("serial")
+public class CacheEventListenerDUnitTest implements Serializable {
+
+  private static final Logger logger = LogService.getLogger();
+
+  private static final String REGION_NAME = CacheEventListenerDUnitTest.class.getSimpleName();
+
+  private static final String CREATES = "CREATES";
+  private static final String UPDATES = "UPDATES";
+  private static final String INVALIDATES = "INVALIDATES";
+  private static final String DESTROYS = "DESTROYS";
+
+  private static volatile Object newValue;
+  private static volatile Object oldValue;
+
+  private String name;
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Rule
+  public CacheRule cacheRule = CacheRule.builder().createCacheInAll().build();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Rule
+  public SharedCountersRule sharedCountersRule = SharedCountersRule.builder().build();
+
+  @Rule
+  public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+  @Before
+  public void setUp() throws Exception {
+    name = testName.getMethodName();
+
+    sharedCountersRule.initialize(CREATES);
+    sharedCountersRule.initialize(DESTROYS);
+    sharedCountersRule.initialize(INVALIDATES);
+    sharedCountersRule.initialize(UPDATES);
+
+    cacheRule.getCache().createRegionFactory().setScope(Scope.DISTRIBUTED_ACK).create("root");
+    invokeInEveryVM(() -> {
+      cacheRule.getCache().createRegionFactory().setScope(Scope.DISTRIBUTED_ACK).create("root");
+    });
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    newValue = null;
+    oldValue = null;
+    invokeInEveryVM(() -> {
+      newValue = null;
+      oldValue = null;
+    });
+  }
+
+  @Test
+  public void testObjectAddedReplaced() throws Exception {
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        logger.info("Invoking afterCreate on listener; name={}", event.getKey());
+        sharedCountersRule.increment(CREATES);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.CREATE));
+        errorCollector.checkThat(event.getNewValue(), equalTo(0));
+        errorCollector.checkThat(event.getOldValue(), nullValue());
+
+        if (event.getSerializedOldValue() != null) {
+          errorCollector.checkThat(event.getSerializedOldValue().getDeserializedValue(),
+              equalTo(event.getOldValue()));
+        }
+        if (event.getSerializedNewValue() != null) {
+          errorCollector.checkThat(event.getSerializedNewValue().getDeserializedValue(),
+              equalTo(event.getNewValue()));
+        }
+
+        logger.info("create event new value is: {}", event.getNewValue());
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        logger.info("Invoking afterUpdate on listener; name=" + event.getKey());
+        sharedCountersRule.increment(UPDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+        logger.info("update event new value is: " + newValue);
+        logger.info("update event old value is: " + oldValue);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.UPDATE));
+        errorCollector.checkThat(event.getOldValue(), notNullValue());
+
+        if (event.getSerializedOldValue() != null) {
+          errorCollector.checkThat(event.getSerializedOldValue().getDeserializedValue(),
+              equalTo(event.getOldValue()));
+        }
+        if (event.getSerializedNewValue() != null) {
+          errorCollector.checkThat(event.getSerializedNewValue().getDeserializedValue(),
+              equalTo(event.getNewValue()));
+        }
+
+      }
+    };
+
+    int expectedCreates = 1;
+    int expectedUpdates = 0;
+
+    // Create in controller VM
+    createEntry(name, listener);
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    // Create in other DUnit VMs
+
+    // the expected number of update events is dependent on the number of VMs.
+    // Each "createEntry" does a put which fires a update event in each of
+    // the other VMs that have that entry already defined at that time.
+    // The first createEntry causes 0 update events.
+    // The second createEntry causes 1 update events (in the first VM)
+    // The third createEntry causes 2 update events, etc (in the first 2 VMs)
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      getHost(0).getVM(i).invoke(() -> createEntry(name, listener));
+
+      expectedCreates++;
+      expectedUpdates += (i + 1);
+    }
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(newValue).isEqualTo(0);
+    assertThat(oldValue).isEqualTo(0);
+
+    // test replace events
+    int replaceValue = 1;
+    replaceEntry(name, replaceValue);
+    expectedUpdates += getHost(0).getVMCount() + 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(oldValue).isEqualTo(replaceValue - 1);
+    assertThat(newValue).isEqualTo(replaceValue);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmOldValue = getHost(0).getVM(i).invoke(() -> oldValue);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmOldValue).as("oldValue is wrong in vm " + i).isEqualTo(replaceValue - 1);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isEqualTo(replaceValue);
+    }
+
+    replaceValue++;
+    int finalReplaceValue = replaceValue;
+    getHost(0).getVM(0).invoke(() -> replaceEntry(name, finalReplaceValue));
+    expectedUpdates += getHost(0).getVMCount() + 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(oldValue).isEqualTo(replaceValue - 1);
+    assertThat(newValue).isEqualTo(replaceValue);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmOldValue = getHost(0).getVM(i).invoke(() -> oldValue);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmOldValue).as("oldValue is wrong in vm " + i).isEqualTo(replaceValue - 1);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isEqualTo(replaceValue);
+    }
+  }
+
+  @Test
+  public void testObjectInvalidated() throws Exception {
+    int timeToLive = 5; // seconds
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterInvalidate(EntryEvent event) {
+        logger.info("Invoking tests invalidated listener");
+        sharedCountersRule.increment(INVALIDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.EXPIRE_LOCAL_INVALIDATE));
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+    };
+
+    // Create in controller VM
+    createEntry(name, timeToLive, ExpirationAction.LOCAL_INVALIDATE, listener);
+
+    // Create in other DUnit VMs
+    long start = System.currentTimeMillis();
+    invokeInEveryVM(
+        () -> createEntry(name, timeToLive, ExpirationAction.LOCAL_INVALIDATE, listener));
+
+    long time = System.currentTimeMillis() - start;
+    assertThat(sharedCountersRule.getTotal(INVALIDATES))
+        .as("Test timing intolerance: entry creation took " + time
+            + " ms. Increase expiration time in test.")
+        .isEqualTo(0);
+
+    // Wait for invalidation
+    await().atMost(1, MINUTES).until(() -> assertThat(sharedCountersRule.getTotal(INVALIDATES))
+        .isGreaterThanOrEqualTo(getHost(0).getVMCount() + 1));
+
+    assertThat(getRegion().getSubregion(name).get(name)).isNull();
+
+    assertThat(newValue).isNull();
+    assertThat(oldValue).isEqualTo(0);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmOldValue = getHost(0).getVM(i).invoke(() -> oldValue);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmOldValue).as("oldValue is wrong in vm " + i).isEqualTo(0);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+  }
+
+  @Test
+  public void testObjectDestroyed() throws Exception {
+    int timeToLive = 3; // seconds
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterDestroy(EntryEvent event) {
+        logger.info("Invoking objectDestroyed listener");
+        sharedCountersRule.increment(DESTROYS);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.EXPIRE_DESTROY));
+      }
+    };
+
+    // Create in Master VM
+    createEntry(name, timeToLive, ExpirationAction.DESTROY, listener);
+
+    // Create in other VMs
+    invokeInEveryVM(() -> createEntry(name, timeToLive, ExpirationAction.DESTROY, listener));
+
+    // Wait for invalidation
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES).until(() -> assertThat(sharedCountersRule.getTotal(DESTROYS))
+        .isGreaterThanOrEqualTo(getHost(0).getVMCount() + 1));
+
+    assertThat(newValue).isNull();
+    assertThat(oldValue).isEqualTo(0);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmOldValue = getHost(0).getVM(i).invoke(() -> oldValue);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmOldValue).as("oldValue is wrong in vm " + i).isEqualTo(0);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+  }
+
+  @Test
+  public void testInvalidatedViaExpiration() throws Exception {
+    int timeToLive = 6; // seconds
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterInvalidate(EntryEvent event) {
+        Object key = event.getKey();
+        boolean isPresentLocally = event.getRegion().getEntry(key).getValue() != null;
+        logger.info("Invoking test's invalidate listener (via expiration) isPresentLocally="
+            + isPresentLocally + "; newValue=" + event.getNewValue());
+        sharedCountersRule.increment(INVALIDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        errorCollector.checkThat(event.isOriginRemote(), equalTo(false));
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(cacheRule.getSystem().getDistributedMember()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.EXPIRE_LOCAL_INVALIDATE));
+      }
+    };
+
+    // Create in controller VM
+    createEntry(name, timeToLive, ExpirationAction.LOCAL_INVALIDATE, listener);
+
+    // Create in other VMs
+    invokeInEveryVM(
+        () -> createEntry(name, timeToLive, ExpirationAction.LOCAL_INVALIDATE, listener));
+
+    // Wait for invalidation
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES).until(() -> assertThat(sharedCountersRule.getTotal(INVALIDATES))
+        .isEqualTo(getHost(0).getVMCount() + 1));
+
+    // not present locally
+    Region region = getRegion().getSubregion(name);
+    Region.Entry entry = region.getEntry(name);
+    assertThat(entry).isNotNull();
+    assertThat(entry.getValue()).isNull();
+
+    assertThat(oldValue).isEqualTo(0);
+    assertThat(newValue).isNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmOldValue = getHost(0).getVM(i).invoke(() -> oldValue);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmOldValue).as("oldValue is wrong in vm " + i).isEqualTo(0);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+  }
+
+  /**
+   * Create a region with one entry in this test's region with the given name and attributes.
+   */
+  private void createEntry(String name, int timeToLive, ExpirationAction expirationAction,
+      CacheEventListener listener) {
+    Region region = getRegion();
+
+    AttributesFactory factory = new AttributesFactory(region.getAttributes());
+    factory.setStatisticsEnabled(true);
+    factory.setEntryTimeToLive(new ExpirationAttributes(timeToLive, expirationAction));
+    factory.setScope(Scope.DISTRIBUTED_ACK);
+    factory.setCacheListener(listener);
+
+    Region subregion = region.createSubregion(name, factory.create());
+    subregion.create(name, 0, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  /**
+   * Create an entry in this test's region with the given name
+   */
+  private void createEntry(String name, CacheEventListener listener) {
+    createEntry(name, 0, ExpirationAction.INVALIDATE, listener);
+  }
+
+  private void replaceEntry(String name, Object value) {
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.put(name, value, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  /**
+   * Gets or creates a region used in this test
+   */
+  private Region getRegion() {
+    Region region = cacheRule.getCache().getRegion("root");
+    Region subregion = region.getSubregion(REGION_NAME);
+    if (subregion == null) {
+      AttributesFactory factory = new AttributesFactory();
+      factory.setScope(Scope.DISTRIBUTED_ACK);
+      subregion = region.createSubregion(REGION_NAME, factory.create());
+    }
+
+    return subregion;
+  }
+
+  /**
+   * Overridden within tests to increment shared counters.
+   */
+  public static class CacheEventListener extends CacheListenerAdapter implements Serializable {
+
+    @Override
+    public void close() {
+      // nothing
+    }
+
+    @Override
+    public void afterCreate(EntryEvent event) {
+      fail("Unexpected listener callback: afterCreate");
+    }
+
+    @Override
+    public void afterInvalidate(EntryEvent event) {
+      fail("Unexpected listener callback: afterInvalidate");
+    }
+
+    @Override
+    public void afterDestroy(EntryEvent event) {
+      fail("Unexpected listener callback: afterDestroy");
+    }
+
+    @Override
+    public void afterUpdate(EntryEvent event) {
+      fail("Unexpected listener callback: afterUpdate");
+    }
+
+    @Override
+    public void afterRegionInvalidate(RegionEvent event) {
+      fail("Unexpected listener callback: afterRegionInvalidate");
+    }
+
+    @Override
+    public void afterRegionDestroy(RegionEvent event) {
+      // nothing
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEventsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionEventsDUnitTest.java
@@ -1,0 +1,786 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.Serializable;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.InterestPolicy;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.SubscriptionAttributes;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.test.dunit.cache.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.dunit.rules.SharedCountersRule;
+import org.apache.geode.test.dunit.rules.SharedErrorCollector;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+/**
+ * This class tests event triggering and handling in partitioned regions. Most of this class is a
+ * copy of {@link CacheEventListenerDUnitTest}.
+ *
+ * <p>
+ * Converted from JUnit 3.
+ *
+ * @since 5.1
+ */
+@Category(DistributedTest.class)
+@SuppressWarnings("serial")
+public class PartitionedRegionEventsDUnitTest implements Serializable {
+
+  private static final Logger logger = LogService.getLogger();
+
+  private static final String REGION_NAME = PartitionedRegionEventsDUnitTest.class.getSimpleName();
+
+  private static final String CREATES = "CREATES";
+  private static final String UPDATES = "UPDATES";
+  private static final String INVALIDATES = "INVALIDATES";
+  private static final String DESTROYS = "DESTROYS";
+
+  private static volatile Object newValue;
+  private static volatile Object oldValue;
+
+  private String name;
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Rule
+  public CacheRule cacheRule = CacheRule.builder().createCacheInAll().build();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Rule
+  public SharedCountersRule sharedCountersRule = SharedCountersRule.builder().build();
+
+  @Rule
+  public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+  @Before
+  public void setUp() throws Exception {
+    name = testName.getMethodName();
+
+    sharedCountersRule.initialize(CREATES);
+    sharedCountersRule.initialize(DESTROYS);
+    sharedCountersRule.initialize(INVALIDATES);
+    sharedCountersRule.initialize(UPDATES);
+
+    cacheRule.getCache().createRegionFactory().setScope(Scope.DISTRIBUTED_ACK).create("root");
+    invokeInEveryVM(() -> {
+      cacheRule.getCache().createRegionFactory().setScope(Scope.DISTRIBUTED_ACK).create("root");
+    });
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    newValue = null;
+    oldValue = null;
+    invokeInEveryVM(() -> {
+      newValue = null;
+      oldValue = null;
+    });
+  }
+
+  @Test
+  public void testObjectAddedReplaced() throws Exception {
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        logger.info("Invoking afterCreate on listener; event={}", event);
+        sharedCountersRule.increment(CREATES);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.CREATE));
+        errorCollector.checkThat(event.getNewValue(), equalTo(0));
+        errorCollector.checkThat(event.getOldValue(), nullValue());
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        logger.info("Invoking afterUpdate on listener; name={}", event.getKey());
+        sharedCountersRule.increment(UPDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+        logger.info("update event new value is: {}", newValue);
+        logger.info("update event old value is: {}", oldValue);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.UPDATE));
+        if (((EntryEventImpl) event).getInvokePRCallbacks()) {
+          errorCollector.checkThat(event.getOldValue(), notNullValue());
+        }
+      }
+    };
+
+    int expectedCreates = 1;
+    int expectedUpdates = 0;
+
+    // Create in controller VM
+    createEntry(name, new SubscriptionAttributes(InterestPolicy.ALL), listener);
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    // Create in other VMs
+
+    // the expected number of update events is dependent on the number of VMs.
+    // Each "createEntry" does a put which fires a update event in each of
+    // the other VMs that have that entry already defined at that time.
+    // The first createEntry causes 0 update events.
+    // The second createEntry causes 1 update events (in the first VM)
+    // The third createEntry causes 2 update events, etc (in the first 2 VMs)
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      getHost(0).getVM(i).invoke(
+          () -> updateEntry(name, new SubscriptionAttributes(InterestPolicy.ALL), listener));
+      expectedUpdates += (i + 2); // with InterestPolicy.ALL, all listeners should be invoked
+    }
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(newValue).isEqualTo(0);
+
+    // test replace events
+    int replaceValue = 1;
+    replaceEntry(name, replaceValue);
+    expectedUpdates += getHost(0).getVMCount() + 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(newValue).isEqualTo(replaceValue);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isEqualTo(replaceValue);
+    }
+
+    replaceValue++;
+    int finalReplaceValue = replaceValue;
+    getHost(0).getVM(0).invoke(() -> replaceEntry(name, finalReplaceValue));
+    expectedUpdates += getHost(0).getVMCount() + 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(newValue).isEqualTo(replaceValue);
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isEqualTo(replaceValue);
+    }
+  }
+
+  @Test
+  public void testUpdateIsCreate() throws Exception {
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        logger.info("Invoking afterCreate on listener; event={}", event);
+        sharedCountersRule.increment(CREATES);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.CREATE));
+        if (!((EntryEventImpl) event).getInvokePRCallbacks()) {
+          errorCollector.checkThat(event.getOldValue(), nullValue());
+          errorCollector.checkThat(event.isOldValueAvailable(), equalTo(false));
+        } else {
+          errorCollector.checkThat(event.getOldValue(), nullValue());
+        }
+        errorCollector.checkThat(event.getNewValue(), equalTo(0));
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        logger.info("Invoking afterUpdate on listener; name={}", event.getKey());
+        sharedCountersRule.increment(UPDATES);
+
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.UPDATE));
+      }
+    };
+
+    // Create in controller vm
+    createRegion(name, new SubscriptionAttributes(InterestPolicy.ALL), listener);
+
+    // Create in dunit VMs
+    for (int i = 1; i < getHost(0).getVMCount(); i++) {
+      getHost(0).getVM(i).invoke(
+          () -> createRegion(name, new SubscriptionAttributes(InterestPolicy.ALL), listener));
+    }
+
+    int expectedCreates = getHost(0).getVMCount() + 1;
+    int expectedUpdates = 0;
+
+    getHost(0).getVM(0).invoke(
+        () -> updateNewEntry(name, new SubscriptionAttributes(InterestPolicy.ALL), listener));
+
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+  }
+
+  @Test
+  public void testObjectInvalidated() throws Exception {
+    int timeToLive = 0; // 5; // seconds expiration isn't supported in PR (yet??)
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterInvalidate(EntryEvent event) {
+        logger.info("Invoking tests invalidated listener");
+        sharedCountersRule.increment(INVALIDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.INVALIDATE));
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+    };
+
+    // Create in controller VM
+    createEntry(name, timeToLive, ExpirationAction.INVALIDATE,
+        new SubscriptionAttributes(InterestPolicy.ALL), listener);
+
+    // create region and listeners in other VMs
+    invokeInEveryVM(
+        () -> createSubregion(name, new SubscriptionAttributes(InterestPolicy.ALL), listener));
+
+    // Wait for expiration
+
+    // Invalidate the entry
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.invalidate(name);
+
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES).until(() -> assertThat(sharedCountersRule.getTotal(INVALIDATES))
+        .isGreaterThanOrEqualTo(getHost(0).getVMCount() + 1));
+
+    assertThat(getRegion().getSubregion(name).get(name)).isNull();
+
+    assertThat(newValue).isNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+  }
+
+  @Test
+  public void testObjectDestroyed() throws Exception {
+    int timeToLive = 0; // 3; expiration isn't supported by PRs (yet???)
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterDestroy(EntryEvent event) {
+        logger.info("Invoking objectDestroyed listener");
+        sharedCountersRule.increment(DESTROYS);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation().isDestroy(), equalTo(true));
+      }
+    };
+
+    // Create in Master VM
+    createEntry(name, timeToLive, ExpirationAction.DESTROY,
+        new SubscriptionAttributes(InterestPolicy.ALL), listener);
+
+    // create region and listeners in other VMs
+    invokeInEveryVM(
+        () -> createSubregionWhenDestroy(name, new SubscriptionAttributes(InterestPolicy.ALL),
+            listener, timeToLive, ExpirationAction.DESTROY));
+
+    // Wait for expiration
+
+    // destroy entry
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.destroy(name);
+
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES).until(() -> assertThat(sharedCountersRule.getTotal(DESTROYS))
+        .isGreaterThanOrEqualTo(getHost(0).getVMCount() + 1));
+
+    assertThat(newValue).isNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+  }
+
+  @Test
+  public void testObjectAddedReplacedCACHECONTENT() throws Exception {
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        logger.info("Invoking afterCreate on listener; name={}", event.getKey());
+        sharedCountersRule.increment(CREATES);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.CREATE));
+        errorCollector.checkThat(event.getOldValue(), nullValue());
+        errorCollector.checkThat(event.getNewValue(), equalTo(0));
+        errorCollector.checkThat(event.getOldValue(), nullValue());
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        logger.info("Invoking afterUpdate on listener; name={}", event.getKey());
+        sharedCountersRule.increment(UPDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+        logger.info("update event new value is: {}", newValue);
+        logger.info("update event old value is: {}", oldValue);
+
+        errorCollector.checkThat(event.getDistributedMember(),
+            equalTo(event.getCallbackArgument()));
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.UPDATE));
+        errorCollector.checkThat(event.getOldValue(), notNullValue());
+      }
+    };
+
+    int expectedCreates = 1;
+    int expectedUpdates = 0;
+
+    // Create in controller VM
+    createEntry(name, new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener);
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    // Create in other VMs
+
+    // the expected number of update events is dependent on the number of VMs.
+    // Each "createEntry" does a put which fires a update event in each of
+    // the other VMs that have that entry already defined at that time.
+    // The first createEntry causes 0 update events.
+    // The second createEntry causes 1 update events (in the first VM)
+    // The third createEntry causes 2 update events, etc (in the first 2 VMs)
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      getHost(0).getVM(i).invoke(() -> updateEntry(name,
+          new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener));
+      expectedUpdates += 1;
+    }
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    assertThat(newValue).isEqualTo(0);
+
+    // test replace events
+    int replaceValue = 1;
+    replaceEntry(name, replaceValue);
+    expectedUpdates += 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+
+    assertThat(newValue).isEqualTo(replaceValue);
+
+    // find the vm that should have the bucket and see if it has the correct new value
+    DistributedMember bucketOwner = ((PartitionedRegion) subregion).getMemberOwning(name);
+    assertThat(bucketOwner).isNotNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object id = getHost(0).getVM(i).invoke(() -> cacheRule.getSystem().getDistributedMember());
+      assertThat(bucketOwner).isNotEqualTo(id);
+      Object vmNewValue = getHost(0).getVM(i).invoke(() -> newValue);
+      assertThat(vmNewValue).as("newValue is wrong in vm " + i).isNull();
+    }
+
+    replaceValue++;
+    int finalReplaceValue = replaceValue;
+    getHost(0).getVM(0).invoke(() -> replaceEntry(name, finalReplaceValue));
+    expectedUpdates += 1;
+
+    assertThat(sharedCountersRule.getTotal(CREATES)).isEqualTo(expectedCreates);
+    assertThat(sharedCountersRule.getTotal(UPDATES)).isEqualTo(expectedUpdates);
+
+    bucketOwner = ((PartitionedRegion) subregion).getMemberOwning(name);
+    assertThat(bucketOwner).isNotNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object id = getHost(0).getVM(i).invoke(() -> cacheRule.getSystem().getDistributedMember());
+      assertThat(bucketOwner).isNotEqualTo(id);
+    }
+  }
+
+  @Test
+  public void testObjectInvalidatedCACHECONTENT() throws Exception {
+    int timeToLive = 0; // 5; // seconds expiration isn't supported in PR (yet??)
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterInvalidate(EntryEvent event) {
+        logger.info("Invoking tests invalidated listener");
+        sharedCountersRule.increment(INVALIDATES);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation(), equalTo(Operation.INVALIDATE));
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+    };
+
+    // Create in controller VM
+    createEntry(name, timeToLive, ExpirationAction.INVALIDATE,
+        new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener);
+
+    // create region and listeners in other VMs
+    invokeInEveryVM(() -> createSubregion(name,
+        new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener));
+
+    // Wait for expiration
+
+    // Invalidate the entry
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.invalidate(name);
+
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES)
+        .until(() -> assertThat(sharedCountersRule.getTotal(INVALIDATES)).isEqualTo(1));
+
+    assertThat(getRegion().getSubregion(name).get(name)).isNull();
+
+    DistributedMember bucketOwner = ((PartitionedRegion) subregion).getMemberOwning(name);
+    assertThat(bucketOwner).isNotNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object id = getHost(0).getVM(i).invoke(() -> cacheRule.getSystem().getDistributedMember());
+      assertThat(bucketOwner).isNotEqualTo(id);
+    }
+  }
+
+  @Test
+  public void testObjectDestroyedCACHECONTENT() throws Exception {
+    int timeToLive = 0; // 3; expiration isn't supported by PRs (yet???)
+
+    CacheEventListener listener = new CacheEventListener() {
+
+      @Override
+      public void afterCreate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterUpdate(EntryEvent event) {
+        // ignore
+      }
+
+      @Override
+      public void afterDestroy(EntryEvent event) {
+        logger.info("Invoking objectDestroyed listener");
+        sharedCountersRule.increment(DESTROYS);
+        newValue = event.getNewValue();
+        oldValue = event.getOldValue();
+
+        if (event.isOriginRemote()) {
+          errorCollector.checkThat(event.getDistributedMember(),
+              not(cacheRule.getSystem().getDistributedMember()));
+        } else {
+          errorCollector.checkThat(event.getDistributedMember(),
+              equalTo(cacheRule.getSystem().getDistributedMember()));
+        }
+        errorCollector.checkThat(event.getOperation().isDestroy(), equalTo(true));
+      }
+    };
+
+    // Create in Master VM
+    createEntry(name, timeToLive, ExpirationAction.DESTROY,
+        new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener);
+
+    // create region and listeners in other VMs
+    invokeInEveryVM(() -> createSubregionWhenDestroy(name,
+        new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT), listener, timeToLive,
+        ExpirationAction.DESTROY));
+
+    // Wait for expiration
+
+    // destroy the entry
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.destroy(name);
+
+    // invoked at least once
+    // invoked no more than once
+    await().atMost(1, MINUTES)
+        .until(() -> assertThat(sharedCountersRule.getTotal(DESTROYS)).isEqualTo(1));
+
+    DistributedMember bucketOwner = ((PartitionedRegion) subregion).getMemberOwning(name);
+    assertThat(bucketOwner).isNotNull();
+
+    for (int i = 0; i < getHost(0).getVMCount(); i++) {
+      Object id = getHost(0).getVM(i).invoke(() -> cacheRule.getSystem().getDistributedMember());
+      assertThat(bucketOwner).isNotEqualTo(id);
+    }
+  }
+
+  /**
+   * Create a region and install the given listener
+   */
+  private void createSubregion(String name, SubscriptionAttributes subscriptionAttributes,
+      CacheEventListener listener) {
+    AttributesFactory factory = new AttributesFactory();
+    factory.setStatisticsEnabled(true);
+    factory.setSubscriptionAttributes(subscriptionAttributes);
+    factory.addCacheListener(listener);
+    factory.setPartitionAttributes((new PartitionAttributesFactory()).create());
+
+    Region region = getRegion();
+    region.createSubregion(name, factory.create());
+  }
+
+  /**
+   * Create a region and install the given listener
+   */
+  private void createSubregionWhenDestroy(String name,
+      SubscriptionAttributes subscriptionAttributes, CacheEventListener listener, int timeToLive,
+      ExpirationAction expirationAction) {
+    AttributesFactory factory = new AttributesFactory();
+    factory.setStatisticsEnabled(true);
+    factory.setSubscriptionAttributes(subscriptionAttributes);
+    factory.setEntryTimeToLive(new ExpirationAttributes(timeToLive, expirationAction));
+    factory.addCacheListener(listener);
+    factory.setPartitionAttributes((new PartitionAttributesFactory()).create());
+
+    Region region = getRegion();
+    region.createSubregion(name, factory.create());
+  }
+
+  /**
+   * Create a region with one entry in this test's region with the given name and attributes.
+   */
+  private void createEntry(String name, int timeToLive, ExpirationAction expirationAction,
+      SubscriptionAttributes subscriptionAttributes, CacheEventListener listener) {
+    Region subregion =
+        createRegion(name, timeToLive, expirationAction, subscriptionAttributes, listener);
+    subregion.create(name, 0, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  private Region createRegion(String name, int timeToLive, ExpirationAction expirationAction,
+      SubscriptionAttributes subscriptionAttributes, CacheEventListener listener) {
+    AttributesFactory factory = new AttributesFactory();
+    factory.setStatisticsEnabled(true);
+    factory.setEntryTimeToLive(new ExpirationAttributes(timeToLive, expirationAction));
+    factory.setSubscriptionAttributes(subscriptionAttributes);
+    factory.addCacheListener(listener);
+    factory.setPartitionAttributes((new PartitionAttributesFactory()).create());
+
+    Region region = getRegion();
+    return region.createSubregion(name, factory.create());
+  }
+
+  /**
+   * Create an entry in this test's region with the given name
+   */
+  private void createEntry(String name, SubscriptionAttributes subscriptionAttributes,
+      CacheEventListener listener) {
+    createEntry(name, 0, ExpirationAction.INVALIDATE, subscriptionAttributes, listener);
+  }
+
+  /**
+   * Create an entry in this test's region with the given name
+   */
+  private void createRegion(String name, SubscriptionAttributes subscriptionAttributes,
+      CacheEventListener listener) {
+    createRegion(name, 0, ExpirationAction.INVALIDATE, subscriptionAttributes, listener);
+  }
+
+  /**
+   * Create a region and update one entry in this test's region with the given name and attributes.
+   */
+  private void updateEntry(String name, int timeToLive, ExpirationAction expirationAction,
+      SubscriptionAttributes subscriptionAttributes, CacheEventListener listener) {
+    Region subregion =
+        createRegion(name, timeToLive, expirationAction, subscriptionAttributes, listener);
+    subregion.put(name, 0, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  /**
+   * Update an entry in this test's region with the given name
+   */
+  private void updateEntry(String name, SubscriptionAttributes subscriptionAttributes,
+      CacheEventListener listener) {
+    updateEntry(name, 0, ExpirationAction.INVALIDATE, subscriptionAttributes, listener);
+  }
+
+  /**
+   * Update an entry in this test's region with the given name, assuming that the update is actually
+   * causing creation of the entry
+   */
+  private void updateNewEntry(String name, SubscriptionAttributes subscriptionAttributes,
+      CacheEventListener listener) {
+    Region subregion =
+        createRegion(name, 0, ExpirationAction.INVALIDATE, subscriptionAttributes, listener);
+    subregion.put(name, 0, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  private void replaceEntry(String name, Object value) {
+    Region region = getRegion();
+    Region subregion = region.getSubregion(name);
+    subregion.put(name, value, subregion.getCache().getDistributedSystem().getDistributedMember());
+  }
+
+  /**
+   * Gets or creates a region used in this test
+   */
+  private Region getRegion() {
+    Region region = cacheRule.getCache().getRegion("root");
+    Region subregion = region.getSubregion(REGION_NAME);
+    if (subregion == null) {
+      subregion = region.createSubregion(REGION_NAME, new AttributesFactory().create());
+    }
+    return subregion;
+  }
+
+  /**
+   * Overridden within tests to increment shared counters.
+   */
+  public static class CacheEventListener extends CacheListenerAdapter implements Serializable {
+
+    @Override
+    public void close() {
+      // nothing
+    }
+
+    @Override
+    public void afterCreate(EntryEvent event) {
+      fail("Unexpected listener callback: afterCreate");
+    }
+
+    @Override
+    public void afterInvalidate(EntryEvent event) {
+      fail("Unexpected listener callback: afterInvalidated");
+    }
+
+    @Override
+    public void afterDestroy(EntryEvent event) {
+      fail("Unexpected listener callback: afterDestroy");
+    }
+
+    @Override
+    public void afterUpdate(EntryEvent event) {
+      fail("Unexpected listener callback: afterUpdate");
+    }
+
+    @Override
+    public void afterRegionInvalidate(RegionEvent event) {
+      fail("Unexpected listener callback: afterRegionInvalidate");
+    }
+
+    @Override
+    public void afterRegionDestroy(RegionEvent event) {
+      // nothing
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/cache/rules/CacheRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/cache/rules/CacheRule.java
@@ -80,7 +80,7 @@ public class CacheRule extends DistributedExternalResource {
   @Override
   protected void before() {
     if (createCacheInAll) {
-      invoker().invokeInEveryVM(() -> createCache(config));
+      invoker().invokeInEveryVMAndController(() -> createCache(config));
     } else {
       if (createCache) {
         createCache(config);
@@ -94,7 +94,7 @@ public class CacheRule extends DistributedExternalResource {
   @Override
   protected void after() {
     closeAndNullCache();
-    invoker().invokeInEveryVM(() -> closeAndNullCache());
+    invoker().invokeInEveryVMAndController(() -> closeAndNullCache());
 
     if (disconnectAfter) {
       Disconnect.disconnectAllFromDS();

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedDisconnectRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedDisconnectRule.java
@@ -71,14 +71,14 @@ public class DistributedDisconnectRule extends DistributedExternalResource {
   @Override
   protected void before() throws Throwable {
     if (this.disconnectBefore) {
-      invoker().invokeInEveryVM(serializableRunnable());
+      invoker().invokeInEveryVMAndController(serializableRunnable());
     }
   }
 
   @Override
   protected void after() {
     if (this.disconnectAfter) {
-      invoker().invokeInEveryVM(serializableRunnable());
+      invoker().invokeInEveryVMAndController(serializableRunnable());
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedRestoreSystemProperties.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedRestoreSystemProperties.java
@@ -46,7 +46,7 @@ public class DistributedRestoreSystemProperties extends RestoreSystemProperties
   @Override
   public void before() throws Throwable {
     super.before();
-    this.invoker.invokeInEveryVM(new SerializableRunnable() {
+    this.invoker.invokeInEveryVMAndController(new SerializableRunnable() {
       @Override
       public void run() {
         if (originalProperties == null) {
@@ -60,7 +60,7 @@ public class DistributedRestoreSystemProperties extends RestoreSystemProperties
   @Override
   public void after() {
     super.after();
-    this.invoker.invokeInEveryVM(new SerializableRunnable() {
+    this.invoker.invokeInEveryVMAndController(new SerializableRunnable() {
       @Override
       public void run() {
         if (originalProperties != null) {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedUseJacksonForJsonPathRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/DistributedUseJacksonForJsonPathRule.java
@@ -32,12 +32,12 @@ public class DistributedUseJacksonForJsonPathRule extends UseJacksonForJsonPathR
 
   @Override
   public void before() {
-    this.invoker.invokeInEveryVM(DistributedUseJacksonForJsonPathRule::invokeBefore);
+    this.invoker.invokeInEveryVMAndController(DistributedUseJacksonForJsonPathRule::invokeBefore);
   }
 
   @Override
   public void after() {
-    this.invoker.invokeInEveryVM(DistributedUseJacksonForJsonPathRule::invokeAfter);
+    this.invoker.invokeInEveryVMAndController(DistributedUseJacksonForJsonPathRule::invokeAfter);
   }
 
   private static void invokeBefore() {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/RemoteInvoker.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/RemoteInvoker.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
+import org.apache.geode.test.dunit.VM;
 
 /**
  * Provides remote invocation support to a {@code TestRule}. These methods will invoke a
@@ -29,14 +30,17 @@ public class RemoteInvoker implements Serializable {
 
   private static final long serialVersionUID = -1759722991299584649L;
 
-  // controller VM
-  // dunit VMs
-  // locator VM
-
   /**
    * Invokes in these VMs: controller VM and dunit VMs but not the dunit locator VM
    */
   public void invokeInEveryVM(final SerializableRunnableIF runnable) {
+    Invoke.invokeInEveryVM(runnable);
+  }
+
+  /**
+   * Invokes in these VMs: controller VM and dunit VMs but not the dunit locator VM
+   */
+  public void invokeInEveryVMAndController(final SerializableRunnableIF runnable) {
     try {
       runnable.run();
     } catch (Exception e) {
@@ -51,5 +55,23 @@ public class RemoteInvoker implements Serializable {
   public void invokeInEveryVMAndLocator(final SerializableRunnableIF runnable) {
     Invoke.invokeInEveryVM(runnable);
     invokeInLocator(runnable);
+  }
+
+  /**
+   * Invokes in specified VM
+   */
+  public void invoke(final SerializableRunnableIF runnable, final VM vm) {
+    vm.invoke(runnable);
+  }
+
+  /**
+   * Invokes in local VM (controller VM)
+   */
+  public void invoke(final SerializableRunnableIF runnable) {
+    try {
+      runnable.run();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/SharedCountersRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/SharedCountersRule.java
@@ -77,16 +77,16 @@ public class SharedCountersRule extends DistributedExternalResource {
 
   @Override
   protected void before() throws Exception {
-    invoker().invokeInEveryVM(() -> counters = new ConcurrentHashMap<>());
+    invoker().invokeInEveryVMAndController(() -> counters = new ConcurrentHashMap<>());
     for (Serializable id : idsToInitInBefore) {
-      invoker().invokeInEveryVM(() -> initialize(id));
+      invoker().invokeInEveryVMAndController(() -> initialize(id));
     }
     idsToInitInBefore.clear();
   }
 
   @Override
   protected void after() {
-    invoker().invokeInEveryVM(() -> counters = null);
+    invoker().invokeInEveryVMAndController(() -> counters = null);
   }
 
   /**
@@ -95,7 +95,7 @@ public class SharedCountersRule extends DistributedExternalResource {
    */
   public SharedCountersRule initialize(final Serializable id) {
     AtomicInteger value = new AtomicInteger();
-    invoker().invokeInEveryVM(() -> counters.putIfAbsent(id, value));
+    invoker().invokeInEveryVMAndController(() -> counters.putIfAbsent(id, value));
     return this;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/SharedErrorCollector.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/SharedErrorCollector.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.hamcrest.Matcher;
+import org.junit.rules.ErrorCollector;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestRule;
+
+/**
+ * JUnit Rule that provides a shared ErrorCollector in all DistributedTest VMs. In particular, this
+ * is a useful way to add assertions to CacheListener callbacks which are then registered in
+ * multiple DistributedTest VMs.
+ *
+ * <p>
+ * {@code SharedErrorCollector} can be used in DistributedTests as a {@code Rule}:
+ *
+ * <pre>
+ * {@literal @}ClassRule
+ * public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+ *
+ * {@literal @}Rule
+ * public SharedErrorCollector errorCollector = new SharedErrorCollector();
+ *
+ * {@literal @}Test
+ * public void everyVMFailsAssertion() {
+ *   for (VM vm : Host.getHost(0).getAllVMs()) {
+ *     vm.invoke(() -> errorCollector.checkThat("Failure in VM-" + vm.getId(), false, is(true)));
+ *   }
+ * }
+ * </pre>
+ */
+@SuppressWarnings({"serial", "unused"})
+public class SharedErrorCollector implements SerializableTestRule {
+
+  private static volatile ProtectedErrorCollector errorCollector;
+
+  private final RemoteInvoker invoker;
+
+  public SharedErrorCollector() {
+    this(new RemoteInvoker());
+  }
+
+  SharedErrorCollector(final RemoteInvoker invoker) {
+    this.invoker = invoker;
+  }
+
+  @Override
+  public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        before();
+        try {
+          base.evaluate();
+        } finally {
+          after();
+        }
+      }
+    };
+  }
+
+  protected void before() throws Throwable {
+    invoker.invokeInEveryVMAndController(() -> errorCollector = new ProtectedErrorCollector());
+  }
+
+  protected void after() throws Throwable {
+    ProtectedErrorCollector allErrors = errorCollector;
+    try {
+      for (VM vm : Host.getHost(0).getAllVMs()) {
+        List<Throwable> remoteFailures = new ArrayList<>();
+        remoteFailures.addAll(vm.invoke(() -> errorCollector.errors()));
+        for (Throwable t : remoteFailures) {
+          allErrors.addError(t);
+        }
+      }
+      invoker.invokeInEveryVMAndController(() -> errorCollector = null);
+    } finally {
+      allErrors.verify();
+    }
+  }
+
+  /**
+   * @see ErrorCollector#addError(Throwable)
+   */
+  public void addError(Throwable error) {
+    errorCollector.addError(error);
+  }
+
+  /**
+   * @see ErrorCollector#checkThat(Object, Matcher)
+   */
+  public <T> void checkThat(final T value, final Matcher<T> matcher) {
+    errorCollector.checkThat(value, matcher);
+  }
+
+  /**
+   * @see ErrorCollector#checkThat(String, Object, Matcher)
+   */
+  public <T> void checkThat(final String reason, final T value, final Matcher<T> matcher) {
+    errorCollector.checkThat(reason, value, matcher);
+  }
+
+  /**
+   * @see ErrorCollector#checkSucceeds(Callable)
+   */
+  public <T> T checkSucceeds(Callable<T> callable) {
+    return errorCollector.checkSucceeds(callable);
+  }
+
+  /**
+   * Uses reflection to acquire access to the {@code List} of {@code Throwable}s in
+   * {@link ErrorCollector}.
+   */
+  private static class ProtectedErrorCollector extends ErrorCollector {
+
+    protected final List<Throwable> protectedErrors;
+
+    public ProtectedErrorCollector() {
+      super();
+      try {
+        Field superErrors = ErrorCollector.class.getDeclaredField("errors");
+        superErrors.setAccessible(true);
+        this.protectedErrors = (List<Throwable>) superErrors.get(this);
+      } catch (IllegalAccessException | NoSuchFieldException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public List<Throwable> errors() {
+      return protectedErrors;
+    }
+
+    @Override
+    public void verify() throws Throwable {
+      super.verify();
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedCountersRuleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedCountersRuleTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 
 @Category(DistributedTest.class)
 @SuppressWarnings("serial")
-public class SharedCountersDistributedTest implements Serializable {
+public class SharedCountersRuleTest implements Serializable {
 
   private static final int TWO_MINUTES_MILLIS = 2 * 60 * 1000;
   private static final String ID1 = "ID1";

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedErrorCollectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedErrorCollectorTest.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ErrorCollector;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.RMIException;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.dunit.rules.SharedErrorCollector;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.runners.TestRunner;
+
+@Category(DistributedTest.class)
+@SuppressWarnings("serial")
+public class SharedErrorCollectorTest {
+
+  static final String MESSAGE = "Failure message";
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Test
+  public void errorCollectorHasExpectedField() throws Exception {
+    Field errorsField = ErrorCollector.class.getDeclaredField("errors");
+    assertThat(errorsField.getDeclaringClass()).isEqualTo(ErrorCollector.class);
+  }
+
+  @Test
+  public void checkThatFailureInControllerIsReported() throws Exception {
+    Result result = TestRunner.runTest(CheckThatFailsInController.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(AssertionError.class)
+        .hasMessageContaining(MESSAGE);
+  }
+
+  @Test
+  public void addErrorInControllerIsReported() throws Exception {
+    Result result = TestRunner.runTest(AddErrorInController.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(NullPointerException.class)
+        .hasMessage(MESSAGE);
+  }
+
+  @Test
+  public void checkThatFailureInDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(CheckThatFailsInDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(AssertionError.class)
+        .hasMessageContaining(MESSAGE);
+  }
+
+  @Test
+  public void checkThatFailureInEveryDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(CheckThatFailsInEveryDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(4);
+    int i = 0;
+    for (Failure failure : failures) {
+      assertThat(failure.getException()).isInstanceOf(AssertionError.class)
+          .hasMessageContaining(MESSAGE + " in VM-" + i++);
+    }
+  }
+
+  @Test
+  public void checkThatFailureInEveryDUnitVMAndControllerIsReported() throws Exception {
+    Result result = TestRunner.runTest(CheckThatFailsInEveryDUnitVMAndController.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(5);
+    boolean first = true;
+    int i = 0;
+    for (Failure failure : failures) {
+      if (first) {
+        assertThat(failure.getException()).isInstanceOf(AssertionError.class)
+            .hasMessageContaining(MESSAGE + " in VM-CONTROLLER");
+        first = false;
+      } else {
+        assertThat(failure.getException()).isInstanceOf(AssertionError.class)
+            .hasMessageContaining(MESSAGE + " in VM-" + i++);
+      }
+    }
+  }
+
+  @Test
+  public void checkThatFailureInMethodInDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(CheckThatFailsInMethodInDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(AssertionError.class)
+        .hasMessageContaining(MESSAGE);
+  }
+
+  @Test
+  public void addErrorInDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(AddErrorInDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(NullPointerException.class)
+        .hasMessage(MESSAGE);
+  }
+
+  @Test
+  public void addErrorInEveryDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(AddErrorInEveryDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(4);
+    int i = 0;
+    for (Failure failure : failures) {
+      assertThat(failure.getException()).isInstanceOf(NullPointerException.class)
+          .hasMessageContaining(MESSAGE + " in VM-" + i++);
+    }
+  }
+
+  @Test
+  public void addErrorInEveryDUnitVMAndControllerIsReported() throws Exception {
+    Result result = TestRunner.runTest(AddErrorInEveryDUnitVMAndController.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(5);
+    boolean first = true;
+    int i = 0;
+    for (Failure failure : failures) {
+      if (first) {
+        assertThat(failure.getException()).isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(MESSAGE + " in VM-CONTROLLER");
+        first = false;
+      } else {
+        assertThat(failure.getException()).isInstanceOf(NullPointerException.class)
+            .hasMessageContaining(MESSAGE + " in VM-" + i++);
+      }
+    }
+  }
+
+  @Test
+  public void addErrorInMethodInDUnitVMIsReported() throws Exception {
+    Result result = TestRunner.runTest(AddErrorInMethodInDUnitVM.class);
+
+    assertThat(result.wasSuccessful()).isFalse();
+    List<Failure> failures = result.getFailures();
+    assertThat(failures).hasSize(1);
+    assertThat(failures.get(0).getException()).isInstanceOf(NullPointerException.class)
+        .hasMessage(MESSAGE);
+  }
+
+  /**
+   * Used by test {@link #checkThatFailureInControllerIsReported()}
+   */
+  public static class CheckThatFailsInController {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void assertionFailsInController() throws Exception {
+      errorCollector.checkThat(MESSAGE, false, is(true));
+    }
+  }
+
+  /**
+   * Used by test {@link #addErrorInControllerIsReported()}
+   */
+  public static class AddErrorInController {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void exceptionInController() throws Exception {
+      errorCollector.addError(new NullPointerException(MESSAGE));
+    }
+  }
+
+  /**
+   * Used by test {@link #checkThatFailureInDUnitVMIsReported()}
+   */
+  public static class CheckThatFailsInDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void assertionFailsInDUnitVM() throws Exception {
+      Host.getHost(0).getVM(0).invoke(() -> errorCollector.checkThat(MESSAGE, false, is(true)));
+    }
+  }
+
+  /**
+   * Used by test {@link #checkThatFailureInEveryDUnitVMIsReported()}
+   */
+  public static class CheckThatFailsInEveryDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void assertionFailsInEveryDUnitVM() throws Exception {
+      for (VM vm : Host.getHost(0).getAllVMs()) {
+        vm.invoke(
+            () -> errorCollector.checkThat(MESSAGE + " in VM-" + vm.getId(), false, is(true)));
+      }
+    }
+  }
+
+  /**
+   * Used by test {@link #checkThatFailureInEveryDUnitVMAndControllerIsReported()}
+   */
+  public static class CheckThatFailsInEveryDUnitVMAndController implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void assertionFailsInEveryDUnitVM() throws Exception {
+      errorCollector.checkThat(MESSAGE + " in VM-CONTROLLER", false, is(true));
+      for (VM vm : Host.getHost(0).getAllVMs()) {
+        vm.invoke(
+            () -> errorCollector.checkThat(MESSAGE + " in VM-" + vm.getId(), false, is(true)));
+      }
+    }
+  }
+
+  /**
+   * Used by test {@link #checkThatFailureInMethodInDUnitVMIsReported()}
+   */
+  public static class CheckThatFailsInMethodInDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void assertionFailsInDUnitVM() throws Exception {
+      Host.getHost(0).getVM(0).invoke(() -> checkThat());
+    }
+
+    private void checkThat() {
+      errorCollector.checkThat(MESSAGE, false, is(true));
+    }
+  }
+
+  /**
+   * Used by test {@link #addErrorInDUnitVMIsReported()}
+   */
+  public static class AddErrorInDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void exceptionInDUnitVM() throws Exception {
+      Host.getHost(0).getVM(0)
+          .invoke(() -> errorCollector.addError(new NullPointerException(MESSAGE)));
+    }
+  }
+
+  /**
+   * Used by test {@link #addErrorInEveryDUnitVMIsReported()}
+   */
+  public static class AddErrorInEveryDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void exceptionInEveryDUnitVM() throws Exception {
+      for (VM vm : Host.getHost(0).getAllVMs()) {
+        vm.invoke(() -> errorCollector
+            .addError(new NullPointerException(MESSAGE + " in VM-" + vm.getId())));
+      }
+    }
+  }
+
+  /**
+   * Used by test {@link #addErrorInEveryDUnitVMAndControllerIsReported()}
+   */
+  public static class AddErrorInEveryDUnitVMAndController implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void exceptionInEveryDUnitVM() throws Exception {
+      errorCollector.addError(new NullPointerException(MESSAGE + " in VM-CONTROLLER"));
+      for (VM vm : Host.getHost(0).getAllVMs()) {
+        vm.invoke(() -> errorCollector
+            .addError(new NullPointerException(MESSAGE + " in VM-" + vm.getId())));
+      }
+    }
+  }
+
+  /**
+   * Used by test {@link #addErrorInMethodInDUnitVMIsReported()}
+   */
+  public static class AddErrorInMethodInDUnitVM implements Serializable {
+
+    @Rule
+    public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+    @Test
+    public void exceptionInDUnitVM() throws Exception {
+      Host.getHost(0).getVM(0).invoke(() -> addError());
+    }
+
+    private void addError() {
+      errorCollector.addError(new NullPointerException(MESSAGE));
+    }
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableExternalResource.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableExternalResource.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.test.junit.rules.serializable;
 
-import java.io.Serializable;
-
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;


### PR DESCRIPTION
* add CacheEventListenerDUnitTest
* add PartitionedRegionEventsDUnitTest

Also:

GEODE-3747: add SharedErrorCollector rule
    
* use for assertions in callbacks and in multiple JVMs
* minor cleanup of related classes