### PR TITLE
GEODE-3736: CompactRangeIndex getSizeEstimate should not throw ClassC…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -429,6 +429,11 @@ public class CompactRangeIndex extends AbstractIndex {
           }
           break;
       }
+    } catch (ClassCastException e) {
+      //no values will match in this index because the key types are not the same
+      //This means that there will be 0 results and it will be fast to use this index
+      //because it has filtered everything out
+      return 0;
     } catch (EntryDestroyedException ignore) {
       return Integer.MAX_VALUE;
     } finally {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -430,9 +430,9 @@ public class CompactRangeIndex extends AbstractIndex {
           break;
       }
     } catch (ClassCastException e) {
-      //no values will match in this index because the key types are not the same
-      //This means that there will be 0 results and it will be fast to use this index
-      //because it has filtered everything out
+      // no values will match in this index because the key types are not the same
+      // This means that there will be 0 results and it will be fast to use this index
+      // because it has filtered everything out
       return 0;
     } catch (EntryDestroyedException ignore) {
       return Integer.MAX_VALUE;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/CorruptedIndexIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/CorruptedIndexIntegrationTest.java
@@ -63,14 +63,11 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
 
     IntStream.rangeClosed(1, 3).forEach(i -> region.put(i, new Portfolio(i)));
 
-
     assertEquals("Uncorrupted index must have all the entries", 3,
         idIndex.getStatistics().getNumberOfValues());
     assertEquals("Corrupted index should not have indexed any entries", 0,
         exceptionIndex.getStatistics().getNumberOfValues());
-
     SelectResults results = (SelectResults) queryService.newQuery(queryString).execute();
-
     assertEquals("Query execution must be successful ", 1, results.size());
   }
 
@@ -100,9 +97,7 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
 
     assertEquals("Uncorrupted index must have all the entries ", 3,
         idIndex.getStatistics().getNumberOfValues());
-
     SelectResults results = (SelectResults) queryService.newQuery(queryString).execute();
-
     assertEquals("Query execution must be successful ", 1, results.size());
   }
 
@@ -155,12 +150,9 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
     map2.put("APPL", 3);
     map2.put("AOL", "hello");
     p2.positions = map2;
-
     region.put(2, p2);
 
     assertEquals("Put must be successful", 2, region.size());
-
-
     assertEquals("Index must be invalid at this point ", false, keyIndex1.isValid());
 
     QueryObserverImpl observer = new QueryObserverImpl();
@@ -170,12 +162,9 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
         .newQuery(
             "select * from /portfolio p where p.positions['AOL'] = 'hello' OR p.positions['IBM'] = 2")
         .execute();
-
     assertEquals("Correct results expected from the query execution ", 2, results.size());
-
     assertEquals("No index must be used while executing the query ", 0,
         observer.indexesUsed.size());
-
   }
 
   @Test
@@ -203,7 +192,6 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
     map2.put("APPL", 3);
     map2.put("AOL", "hello");
     p2.positions = map2;
-
     region.put(2, p2);
 
     assertEquals("Put must be successful", 2, region.size());
@@ -226,12 +214,9 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
         .newQuery(
             "select * from /portfolio p where p.positions['AOL'] = 'hello' OR p.positions['IBM'] = 2")
         .execute();
-
     assertEquals("Current results expected from the query execution ", 2, results.size());
-
     assertEquals("No index must be used while executing the query ", 0,
         observer.indexesUsed.size());
-
   }
 
   @Test
@@ -239,7 +224,6 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
       throws Exception {
     String regionName = "portfolio";
     String INDEX_NAME = "key_index1";
-
 
     Cache cache = getCache();
     Region region =
@@ -258,19 +242,13 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
     map2.put("APPL", 3);
     map2.put("AOL", "hello");
     p2.positions = map2;
-
     region.put(2, p2);
 
     assertEquals("Put must be successful", 2, region.size());
 
     QueryService queryService = cache.getQueryService();
-
-    try {
-      Index keyIndex1 = queryService.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
-      assertEquals("Index must be valid", true, keyIndex1.isValid());
-    } catch (Exception exception) {
-      fail();
-    }
+    Index keyIndex1 = queryService.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    assertEquals("Index must be valid", true, keyIndex1.isValid());
 
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);
@@ -279,11 +257,8 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
         .newQuery(
             "select * from /portfolio p where p.positions['AOL'] = 'hello' OR p.positions['IBM'] = 2")
         .execute();
-
     assertEquals("Current results expected from the query execution ", 2, results.size());
-
     assertEquals("Index must be used while executing the query ", 2, observer.indexesUsed.size());
-
   }
 
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
@@ -108,28 +108,26 @@ public class CompactRangeIndexQueryIntegrationTest {
   }
 
   @Test
-  public void getSizeEstimateShouldNotThrowClassCastException()
-      throws Exception {
+  // getSizeEstimate will be called only when having a choice between two indexes
+  public void getSizeEstimateShouldNotThrowClassCastException() throws Exception {
     String regionName = "portfolio";
 
     Cache cache = serverStarterRule.getCache();
     assertNotNull(cache);
-    Region region = cache.createRegionFactory().setDataPolicy(DataPolicy.REPLICATE).create(regionName);
+    Region region =
+        cache.createRegionFactory().setDataPolicy(DataPolicy.REPLICATE).create(regionName);
 
-    Portfolio p = new Portfolio(1, 2);
+    Portfolio p = new Portfolio(1);
     region.put(1, p);
-
-    Portfolio p2 = new Portfolio(3, 4);
+    Portfolio p2 = new Portfolio(3);
     region.put(2, p2);
 
     QueryService queryService = cache.getQueryService();
-    CompactRangeIndex statusIndex = (CompactRangeIndex)queryService.createIndex("statusIndex", "status", "/portfolio");
-    CompactRangeIndex idIndex = (CompactRangeIndex)queryService.createIndex("idIndex", "ID", "/portfolio");
+    queryService.createIndex("statusIndex", "status", "/portfolio");
+    queryService.createIndex("idIndex", "ID", "/portfolio");
 
     SelectResults results = (SelectResults) queryService
-        .newQuery(
-            "select * from /portfolio where status = 4 AND ID = 'StringID'")
-        .execute();
+        .newQuery("select * from /portfolio where status = 4 AND ID = 'StringID'").execute();
 
     assertNotNull(results);
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
@@ -14,7 +14,8 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,27 +28,11 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
-import org.apache.geode.cache.client.internal.Op;
-import org.apache.geode.cache.query.CacheUtils;
-import org.apache.geode.cache.query.Index;
 import org.apache.geode.cache.query.Query;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.data.PortfolioPdx;
-
-import org.apache.geode.cache.query.dunit.CorruptedIndexIntegrationTest;
-import org.apache.geode.cache.query.internal.QueryObserverHolder;
-import org.apache.geode.cache.query.internal.index.CompactRangeIndex;
-import org.apache.geode.cache.query.internal.index.IndexProtocol;
-import org.apache.geode.internal.cache.LocalRegion;
-import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.Invoke;
-import org.apache.geode.test.dunit.SerializableRunnable;
-import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 


### PR DESCRIPTION
…astExceptions

  * Minor refactor of CorruptedIndexIntegrationTest
  * Refactored CompactRangeIndexQueryIntegrationTest to use ServerStarterRule

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
