### PR TITLE
GEODE-3567: correctly set the serverPortSetByUser flag

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -2040,13 +2040,26 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * @see #getServerPort()
      */
     public Builder setServerPort(final Integer serverPort) {
-      if (serverPort != null && (serverPort < 0 || serverPort > 65535)) {
+      if (serverPort == null) {
+        this.serverPort = null;
+        this.serverPortSetByUser = false;
+        return this;
+      }
+
+      if ((serverPort < 0 || serverPort > 65535)) {
         throw new IllegalArgumentException(
             LocalizedStrings.Launcher_Builder_INVALID_PORT_ERROR_MESSAGE
                 .toLocalizedString("Server"));
       }
-      this.serverPort = serverPort;
-      this.serverPortSetByUser = true;
+
+      if (serverPort == 0) {
+        this.serverPort = 0;
+        this.serverPortSetByUser = false;
+      } else {
+        this.serverPort = serverPort;
+        this.serverPortSetByUser = true;
+      }
+
       return this;
     }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
@@ -562,24 +562,34 @@ public class ServerLauncherBuilderTest {
     assertThat(builder.getServerPort()).isEqualTo(Integer.valueOf(CacheServer.DEFAULT_PORT));
   }
 
+
   @Test
   public void setServerPortToZeroOrGreaterUsesValue() throws Exception {
     Builder builder = new Builder();
 
     builder.setServerPort(0);
     assertThat(builder.getServerPort().intValue()).isEqualTo(0);
+    assertThat(builder.isServerPortSetByUser()).isFalse();
 
     builder.setServerPort(1);
     assertThat(builder.getServerPort().intValue()).isEqualTo(1);
+    assertThat(builder.isServerPortSetByUser()).isTrue();
 
     builder.setServerPort(80);
     assertThat(builder.getServerPort().intValue()).isEqualTo(80);
+    assertThat(builder.isServerPortSetByUser()).isTrue();
 
     builder.setServerPort(1024);
     assertThat(builder.getServerPort().intValue()).isEqualTo(1024);
+    assertThat(builder.isServerPortSetByUser()).isTrue();
 
     builder.setServerPort(65535);
     assertThat(builder.getServerPort().intValue()).isEqualTo(65535);
+    assertThat(builder.isServerPortSetByUser()).isTrue();
+
+    builder.setServerPort(0);
+    assertThat(builder.getServerPort().intValue()).isEqualTo(0);
+    assertThat(builder.isServerPortSetByUser()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Because this flag is set incorrectly, resulting in two cache servers been added while applying the cluster config xml.