### PR TITLE
GEODE-3612 Document new gfsh option

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -362,7 +362,7 @@ See [Gateway Receivers](../../../topologies_and_comm/topology_concepts/multisite
 create gateway-receiver [--groups=value(,value)*] [--members=value(,value)*] 
   [--manual-start=value] [--start-port=value] [--end-port=value] [--bind-address=value] 
   [--maximum-time-between-pings=value] [--socket-buffer-size=value]
-  [--gateway-transport-filter=value(,value)*]
+  [--gateway-transport-filter=value(,value)*] [--hostname-for-senders=value]
 ```
 
 **Parameters, create gateway-receiver:**
@@ -427,6 +427,11 @@ create gateway-receiver [--groups=value(,value)*] [--members=value(,value)*]
 <td><span class="keyword parmname">\-\-maximum-time-between-pings</span></td>
 <td>Integer value that specifies the time interval (in milliseconds) to use between pings to connected WAN sites. This value determines the maximum amount of time that can elapse before a remote WAN site is considered offline.</td>
 <td>60000</td>
+</tr>
+<tr class="even">
+<td><span class="keyword parmname">\-\-hostname-for-senders</span></td>
+<td>The host name or IP address where this gateway receiver is listening. The locator will inform gateway senders of this value.</td>
+<td> </td>
 </tr>
 </tbody>
 </table>

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -430,7 +430,7 @@ create gateway-receiver [--groups=value(,value)*] [--members=value(,value)*]
 </tr>
 <tr class="even">
 <td><span class="keyword parmname">\-\-hostname-for-senders</span></td>
-<td>The host name or IP address where this gateway receiver is listening. The locator will inform gateway senders of this value.</td>
+<td>The host name or IP address told to gateway senders as the address for them to connect to. The locator informs gateway senders of this value.</td>
 <td> </td>
 </tr>
 </tbody>

--- a/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
+++ b/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
@@ -247,7 +247,8 @@ To configure a gateway receiver, you can use gfsh, cache.xml or Java API configu
 -   **gfsh configuration command**
 
     ``` pre
-    gfsh>create gateway-receiver --start-port=1530 --end-port=1551 
+    gfsh>create gateway-receiver --start-port=1530 --end-port=1551 \
+        hostname-for-senders=gateway1.mycompany.com
     ```
 
 -   **cache.xml Configuration**
@@ -256,7 +257,8 @@ To configure a gateway receiver, you can use gfsh, cache.xml or Java API configu
 
     ``` pre
     <cache>
-      <gateway-receiver start-port="1530" end-port="1551" hostname-for-senders="gateway1.mycompany.com" /> 
+      <gateway-receiver start-port="1530" end-port="1551"
+                        hostname-for-senders="gateway1.mycompany.com" /> 
        ... 
     </cache>
     ```

--- a/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
+++ b/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
@@ -248,7 +248,7 @@ To configure a gateway receiver, you can use gfsh, cache.xml or Java API configu
 
     ``` pre
     gfsh>create gateway-receiver --start-port=1530 --end-port=1551 \
-        hostname-for-senders=gateway1.mycompany.com
+        --hostname-for-senders=gateway1.mycompany.com
     ```
 
 -   **cache.xml Configuration**


### PR DESCRIPTION
The gfsh create gateway-receiver command now accepts a
hostname-for-senders option.

@ladyVader @upthewaterspout @davebarnes97 @joeymcallister Please review.
