### PR TITLE
GEODE-3751: a single place for client protocol loading, logic.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1335,9 +1335,10 @@ public class InternalLocator extends Locator implements ConnectListener {
     try {
       this.stats.hookupStats(sys,
           SocketCreator.getLocalHost().getCanonicalHostName() + '-' + this.server.getBindAddress());
-      ClientProtocolService messageHandler = this.server.getClientProtocolService();
-      if (messageHandler != null) {
-        messageHandler.initializeStatistics("LocatorStats", sys);
+
+      ClientProtocolService clientProtocolService = this.server.getClientProtocolService();
+      if (clientProtocolService != null) {
+        clientProtocolService.initializeStatistics("LocatorStats", sys);
       }
     } catch (UnknownHostException e) {
       logger.warn(e);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -62,7 +62,7 @@ import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolService;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.cache.wan.WANServiceProvider;
 import org.apache.geode.internal.i18n.LocalizedStrings;
@@ -1335,7 +1335,7 @@ public class InternalLocator extends Locator implements ConnectListener {
     try {
       this.stats.hookupStats(sys,
           SocketCreator.getLocalHost().getCanonicalHostName() + '-' + this.server.getBindAddress());
-      ClientProtocolMessageHandler messageHandler = this.server.getClientProtocolMessageHandler();
+      ClientProtocolService messageHandler = this.server.getClientProtocolService();
       if (messageHandler != null) {
         messageHandler.initializeStatistics("LocatorStats", sys);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1463,7 +1463,7 @@ public class AcceptorImpl extends Acceptor implements Runnable, CommBufferPool {
     ServerConnection serverConn =
         serverConnectionFactory.makeServerConnection(socket, this.cache, this.crHelper, this.stats,
             AcceptorImpl.handShakeTimeout, this.socketBufferSize, communicationMode.toString(),
-            communicationMode.getModeNumber(), this, this.securityService, this.getBindAddress());
+            communicationMode.getModeNumber(), this, this.securityService);
 
     synchronized (this.allSCsLock) {
       this.allSCs.add(serverConn);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
@@ -21,9 +21,20 @@ import java.io.OutputStream;
 
 import org.apache.geode.cache.IncompatibleVersionException;
 
-public interface ClientProtocolPipeline {
+/**
+ * An interface representing the message handling part of a protocol. This may contain multiple
+ * parts, and is expected to take care of handshaking, auth, whatever is required. It does not
+ * manage the socket, and apart from the statistics, is expected to be effectively stateless.
+ */
+public interface ClientProtocolPipeline extends AutoCloseable {
   void processMessage(InputStream inputStream, OutputStream outputStream)
       throws IOException, IncompatibleVersionException;
 
-  ClientProtocolStatistics getStatistics();
+  /**
+   * Close the pipeline, incrementing stats and releasing any resources.
+   *
+   * This declaration narrows the exception type to be IOException.
+   */
+  @Override
+  void close();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.geode.cache.IncompatibleVersionException;
+
+public interface ClientProtocolPipeline {
+  void processMessage(InputStream inputStream, OutputStream outputStream)
+      throws IOException, IncompatibleVersionException;
+
+  ClientProtocolStatistics getStatistics();
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
@@ -28,7 +28,7 @@ import org.apache.geode.cache.IncompatibleVersionException;
 public interface ClientProtocolPipeline extends AutoCloseable {
   /**
    * @throws IncompatibleVersionException if a client tries to connect with version that is
-   * incompatible with the current version of the server.
+   *         incompatible with the current version of the server.
    */
   void processMessage(InputStream inputStream, OutputStream outputStream)
       throws IOException, IncompatibleVersionException;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolPipeline.java
@@ -22,11 +22,14 @@ import java.io.OutputStream;
 import org.apache.geode.cache.IncompatibleVersionException;
 
 /**
- * An interface representing the message handling part of a protocol. This may contain multiple
- * parts, and is expected to take care of handshaking, auth, whatever is required. It does not
- * manage the socket, and apart from the statistics, is expected to be effectively stateless.
+ * An interface that does the message handling part of a protocol for a particular connection. It
+ * does not manage the socket.
  */
 public interface ClientProtocolPipeline extends AutoCloseable {
+  /**
+   * @throws IncompatibleVersionException if a client tries to connect with version that is
+   * incompatible with the current version of the server.
+   */
   void processMessage(InputStream inputStream, OutputStream outputStream)
       throws IOException, IncompatibleVersionException;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolProcessor.java
@@ -25,7 +25,7 @@ import org.apache.geode.cache.IncompatibleVersionException;
  * An interface that does the message handling part of a protocol for a particular connection. It
  * does not manage the socket.
  */
-public interface ClientProtocolPipeline extends AutoCloseable {
+public interface ClientProtocolProcessor extends AutoCloseable {
   /**
    * @throws IncompatibleVersionException if a client tries to connect with version that is
    *         incompatible with the current version of the server.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
@@ -15,10 +15,6 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.InternalLocator;
@@ -31,8 +27,6 @@ import org.apache.geode.security.server.Authenticator;
 public interface ClientProtocolService {
   void initializeStatistics(String statisticsName, StatisticsFactory factory);
 
-  ClientProtocolStatistics getStatistics();
-
   /**
    *
    * The pipeline MUST use an available authenticator for authentication of all operations once the
@@ -44,11 +38,7 @@ public interface ClientProtocolService {
       SecurityService securityService);
 
   /**
-   * In this case, the locator calls this to serve a single message at a time. The locator closes
-   * the socket after this is done.
-   *
-   * Statistics saved on the service are used if initialized.
+   * Create a locator pipeline. The locator does not currently provide any authentication.
    */
-  void serveLocatorMessage(InputStream inputStream, OutputStream outputStream,
-      InternalLocator locator) throws IOException;
+  ClientProtocolPipeline createLocatorPipeline(InternalLocator locator);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
@@ -19,23 +19,36 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
-
+import org.apache.geode.cache.Cache;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.server.Authenticator;
 
 /**
- * This is an interface that other modules can implement to hook into
- * {@link GenericProtocolServerConnection} to handle messages sent to Geode.
- *
- * Currently, only one {@link ClientProtocolMessageHandler} at a time can be used in a Geode
- * instance. It gets wired into {@link ServerConnectionFactory} to create all instances of
- * {@link GenericProtocolServerConnection}.
+ * Provides a convenient location for a client protocol service to be loaded into the system.
  */
-public interface ClientProtocolMessageHandler {
+public interface ClientProtocolService {
   void initializeStatistics(String statisticsName, StatisticsFactory factory);
 
   ClientProtocolStatistics getStatistics();
 
-  void receiveMessage(InputStream inputStream, OutputStream outputStream,
-      MessageExecutionContext executionContext) throws IOException;
+  /**
+   *
+   * The pipeline MUST use an available authenticator for authentication of all operations once the
+   * handshake has happened.
+   *
+   * @param availableAuthenticators A list of valid authenticators for the current system.
+   */
+  ClientProtocolPipeline createCachePipeline(Cache cache, Authenticator availableAuthenticators,
+      SecurityService securityService);
+
+  /**
+   * In this case, the locator calls this to serve a single message at a time. The locator closes
+   * the socket after this is done.
+   *
+   * Statistics saved on the service are used if initialized.
+   */
+  void serveLocatorMessage(InputStream inputStream, OutputStream outputStream,
+      InternalLocator locator) throws IOException;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolService.java
@@ -34,11 +34,11 @@ public interface ClientProtocolService {
    *
    * @param availableAuthenticators A list of valid authenticators for the current system.
    */
-  ClientProtocolPipeline createCachePipeline(Cache cache, Authenticator availableAuthenticators,
-      SecurityService securityService);
+  ClientProtocolProcessor createProcessorForCache(Cache cache,
+      Authenticator availableAuthenticators, SecurityService securityService);
 
   /**
    * Create a locator pipeline. The locator does not currently provide any authentication.
    */
-  ClientProtocolPipeline createLocatorPipeline(InternalLocator locator);
+  ClientProtocolProcessor createProcessorForLocator(InternalLocator locator);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
@@ -28,6 +28,13 @@ public class ClientProtocolServiceLoader {
           "There is no ClientProtocolService implementation found in JVM");
     }
 
-    return iterator.next();
+    ClientProtocolService service = iterator.next();
+
+    if (iterator.hasNext()) {
+      throw new ServiceLoadingFailureException(
+          "There is more than one ClientProtocolService implementation found in JVM; aborting");
+    }
+
+    return service;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolServiceLoader.java
@@ -12,16 +12,22 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package org.apache.geode.internal.cache.tier.sockets;
 
-public class NoOpStatistics implements ClientProtocolStatistics {
-  @Override
-  public void clientConnected() {
+import java.util.Iterator;
+import java.util.ServiceLoader;
 
-  }
+public class ClientProtocolServiceLoader {
+  public ClientProtocolService loadService() {
+    ServiceLoader<ClientProtocolService> loader = ServiceLoader.load(ClientProtocolService.class);
+    Iterator<ClientProtocolService> iterator = loader.iterator();
 
-  @Override
-  public void clientDisconnected() {
+    if (!iterator.hasNext()) {
+      throw new ServiceLoadingFailureException(
+          "There is no ClientProtocolService implementation found in JVM");
+    }
 
+    return iterator.next();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
+import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.cache.client.PoolFactory;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.ServerLocation;
@@ -39,9 +40,7 @@ import org.apache.geode.security.server.Authenticator;
  */
 public class GenericProtocolServerConnection extends ServerConnection {
   // The new protocol lives in a separate module and gets loaded when this class is instantiated.
-  private final ClientProtocolMessageHandler messageHandler;
-  private final SecurityManager securityManager;
-  private final Authenticator authenticator;
+  private final ClientProtocolPipeline protocolPipeline;
   private boolean cleanedUp;
   private ClientProxyMembershipID clientProxyMembershipID;
 
@@ -51,14 +50,12 @@ public class GenericProtocolServerConnection extends ServerConnection {
    */
   public GenericProtocolServerConnection(Socket socket, InternalCache c, CachedRegionHelper helper,
       CacheServerStats stats, int hsTimeout, int socketBufferSize, String communicationModeStr,
-      byte communicationMode, Acceptor acceptor, ClientProtocolMessageHandler newClientProtocol,
-      SecurityService securityService, Authenticator authenticator) {
+      byte communicationMode, Acceptor acceptor, ClientProtocolPipeline newClientProtocol,
+      SecurityService securityService) {
     super(socket, c, helper, stats, hsTimeout, socketBufferSize, communicationModeStr,
         communicationMode, acceptor, securityService);
-    securityManager = securityService.getSecurityManager();
-    this.messageHandler = newClientProtocol;
-    this.authenticator = authenticator;
-    this.messageHandler.getStatistics().clientConnected();
+    this.protocolPipeline = newClientProtocol;
+    this.protocolPipeline.getStatistics().clientConnected();
 
     setClientProxyMembershipId();
 
@@ -72,17 +69,12 @@ public class GenericProtocolServerConnection extends ServerConnection {
       InputStream inputStream = socket.getInputStream();
       OutputStream outputStream = socket.getOutputStream();
 
-      if (!authenticator.isAuthenticated()) {
-        authenticator.authenticate(inputStream, outputStream, securityManager);
-      } else {
-        messageHandler.receiveMessage(inputStream, outputStream, new MessageExecutionContext(
-            this.getCache(), authenticator.getAuthorizer(), messageHandler.getStatistics()));
-      }
+      protocolPipeline.processMessage(inputStream, outputStream);
     } catch (EOFException e) {
       this.setFlagProcessMessagesAsFalse();
       setClientDisconnectedException(e);
       logger.debug("Encountered EOF while processing message: {}", e);
-    } catch (IOException e) {
+    } catch (IOException | IncompatibleVersionException e) {
       logger.warn(e);
       this.setFlagProcessMessagesAsFalse();
       setClientDisconnectedException(e);
@@ -105,7 +97,7 @@ public class GenericProtocolServerConnection extends ServerConnection {
     synchronized (this) {
       if (!cleanedUp) {
         cleanedUp = true;
-        messageHandler.getStatistics().clientDisconnected();
+        protocolPipeline.getStatistics().clientDisconnected();
       }
     }
     return super.cleanup();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
@@ -32,15 +32,13 @@ import org.apache.geode.internal.cache.tier.Acceptor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.security.SecurityManager;
-import org.apache.geode.security.server.Authenticator;
 
 /**
  * Holds the socket and protocol handler for the new client protocol.
  */
 public class GenericProtocolServerConnection extends ServerConnection {
   // The new protocol lives in a separate module and gets loaded when this class is instantiated.
-  private final ClientProtocolPipeline protocolPipeline;
+  private final ClientProtocolProcessor protocolPipeline;
   private boolean cleanedUp;
   private ClientProxyMembershipID clientProxyMembershipID;
 
@@ -50,7 +48,7 @@ public class GenericProtocolServerConnection extends ServerConnection {
    */
   public GenericProtocolServerConnection(Socket socket, InternalCache c, CachedRegionHelper helper,
       CacheServerStats stats, int hsTimeout, int socketBufferSize, String communicationModeStr,
-      byte communicationMode, Acceptor acceptor, ClientProtocolPipeline newClientProtocol,
+      byte communicationMode, Acceptor acceptor, ClientProtocolProcessor newClientProtocol,
       SecurityService securityService) {
     super(socket, c, helper, stats, hsTimeout, socketBufferSize, communicationModeStr,
         communicationMode, acceptor, securityService);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
@@ -55,7 +55,6 @@ public class GenericProtocolServerConnection extends ServerConnection {
     super(socket, c, helper, stats, hsTimeout, socketBufferSize, communicationModeStr,
         communicationMode, acceptor, securityService);
     this.protocolPipeline = newClientProtocol;
-    this.protocolPipeline.getStatistics().clientConnected();
 
     setClientProxyMembershipId();
 
@@ -97,7 +96,7 @@ public class GenericProtocolServerConnection extends ServerConnection {
     synchronized (this) {
       if (!cleanedUp) {
         cleanedUp = true;
-        protocolPipeline.getStatistics().clientDisconnected();
+        protocolPipeline.close();
       }
     }
     return super.cleanup();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -18,7 +18,6 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.apache.geode.internal.cache.tier.CommunicationMode.ProtobufClientServerProtocol;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +34,7 @@ import org.apache.geode.security.server.Authenticator;
  * Creates instances of ServerConnection based on the connection mode provided.
  */
 public class ServerConnectionFactory {
-  private ClientProtocolMessageHandler protocolHandler;
+  private volatile ClientProtocolService clientProtocolService;
   private Map<String, Class<? extends Authenticator>> authenticators = null;
 
   public ServerConnectionFactory() {}
@@ -44,7 +43,7 @@ public class ServerConnectionFactory {
     if (authenticators != null) {
       return;
     }
-    HashMap tmp = new HashMap<>();
+    HashMap<String, Class<? extends Authenticator>> tmp = new HashMap<>();
 
     ServiceLoader<Authenticator> loader = ServiceLoader.load(Authenticator.class);
     for (Authenticator streamAuthenticator : loader) {
@@ -54,17 +53,18 @@ public class ServerConnectionFactory {
     authenticators = tmp;
   }
 
-  private synchronized ClientProtocolMessageHandler initializeMessageHandler(
+  private synchronized ClientProtocolService initializeClientProtocolService(
       StatisticsFactory statisticsFactory, String statisticsName) {
-    if (protocolHandler != null) {
-      return protocolHandler;
+    if (clientProtocolService != null) {
+      return clientProtocolService;
     }
 
-    ClientProtocolMessageHandler tempHandler = new MessageHandlerFactory().makeMessageHandler();
-    tempHandler.initializeStatistics(statisticsName, statisticsFactory);
+    // use temp to make sure we publish properly.
+    ClientProtocolService tmp = new ClientProtocolServiceLoader().loadService();
+    tmp.initializeStatistics(statisticsName, statisticsFactory);
 
-    protocolHandler = tempHandler;
-    return protocolHandler;
+    clientProtocolService = tmp;
+    return clientProtocolService;
   }
 
   private Authenticator findStreamAuthenticator(String implementationID) {
@@ -86,18 +86,18 @@ public class ServerConnectionFactory {
     }
   }
 
-  private ClientProtocolMessageHandler getOrCreateClientProtocolMessageHandler(
+  private ClientProtocolService getOrCreateClientProtocolService(
       StatisticsFactory statisticsFactory, String serverName) {
-    if (protocolHandler == null) {
-      return initializeMessageHandler(statisticsFactory, serverName);
+    if (clientProtocolService == null) {
+      return initializeClientProtocolService(statisticsFactory, serverName);
     }
-    return protocolHandler;
+    return clientProtocolService;
   }
 
   public ServerConnection makeServerConnection(Socket socket, InternalCache cache,
       CachedRegionHelper helper, CacheServerStats stats, int hsTimeout, int socketBufferSize,
       String communicationModeStr, byte communicationMode, Acceptor acceptor,
-      SecurityService securityService, InetAddress bindAddress) throws IOException {
+      SecurityService securityService) throws IOException {
     if (communicationMode == ProtobufClientServerProtocol.getModeNumber()) {
       if (!Boolean.getBoolean("geode.feature-protobuf-protocol")) {
         throw new IOException("Server received unknown communication mode: " + communicationMode);
@@ -105,11 +105,15 @@ public class ServerConnectionFactory {
         String authenticationMode =
             System.getProperty("geode.protocol-authentication-mode", "NOOP");
 
+        ClientProtocolService service = getOrCreateClientProtocolService(
+            cache.getDistributedSystem(), acceptor.getServerName());
+
+        ClientProtocolPipeline cachePipeline = service.createCachePipeline(cache,
+            findStreamAuthenticator(authenticationMode), securityService);
+
         return new GenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,
-            socketBufferSize, communicationModeStr, communicationMode, acceptor,
-            getOrCreateClientProtocolMessageHandler(cache.getDistributedSystem(),
-                acceptor.getServerName()),
-            securityService, findStreamAuthenticator(authenticationMode));
+            socketBufferSize, communicationModeStr, communicationMode, acceptor, cachePipeline,
+            securityService);
       }
     } else {
       return new LegacyServerConnection(socket, cache, helper, stats, hsTimeout, socketBufferSize,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -108,7 +108,7 @@ public class ServerConnectionFactory {
         ClientProtocolService service = getOrCreateClientProtocolService(
             cache.getDistributedSystem(), acceptor.getServerName());
 
-        ClientProtocolPipeline cachePipeline = service.createCachePipeline(cache,
+        ClientProtocolProcessor cachePipeline = service.createProcessorForCache(cache,
             findStreamAuthenticator(authenticationMode), securityService);
 
         return new GenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PoolStatHelper;
@@ -32,11 +33,13 @@ public class TcpServerFactory {
   static final Logger logger = LogService.getLogger();
 
   public TcpServerFactory() {
-    if (Boolean.getBoolean("geode.feature-protobuf-protocol")) {
-      clientProtocolService = new ClientProtocolServiceLoader().loadService();
-    } else {
-      clientProtocolService = null;
+    ClientProtocolService service = null;
+    try {
+      service = new ClientProtocolServiceLoader().loadService();
+    } catch (ServiceLoadingFailureException ex) {
+      logger.warn("Could not load client protocol", ex);
     }
+    clientProtocolService = service;
   }
 
   public TcpServer makeTcpServer(int port, InetAddress bind_address, Properties sslConfig,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -32,7 +32,11 @@ public class TcpServerFactory {
   static final Logger logger = LogService.getLogger();
 
   public TcpServerFactory() {
-    clientProtocolService = new ClientProtocolServiceLoader().loadService();
+    if (Boolean.getBoolean("geode.feature-protobuf-protocol")) {
+      clientProtocolService = new ClientProtocolServiceLoader().loadService();
+    } else {
+      clientProtocolService = null;
+    }
   }
 
   public TcpServer makeTcpServer(int port, InetAddress bind_address, Properties sslConfig,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -28,15 +28,11 @@ import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.logging.LogService;
 
 public class TcpServerFactory {
-  private ClientProtocolService protocolHandler;
+  private final ClientProtocolService clientProtocolService;
   static final Logger logger = LogService.getLogger();
 
   public TcpServerFactory() {
-    try {
-      protocolHandler = new ClientProtocolServiceLoader().loadService();
-    } catch (ServiceLoadingFailureException ex) {
-      logger.warn(ex.getMessage());
-    }
+    clientProtocolService = new ClientProtocolServiceLoader().loadService();
   }
 
   public TcpServer makeTcpServer(int port, InetAddress bind_address, Properties sslConfig,
@@ -44,6 +40,6 @@ public class TcpServerFactory {
       ThreadGroup threadGroup, String threadName, InternalLocator internalLocator) {
 
     return new TcpServer(port, bind_address, sslConfig, cfg, handler, poolHelper, threadGroup,
-        threadName, internalLocator, protocolHandler);
+        threadName, internalLocator, clientProtocolService);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -28,12 +28,12 @@ import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.logging.LogService;
 
 public class TcpServerFactory {
-  private ClientProtocolMessageHandler protocolHandler;
+  private ClientProtocolService protocolHandler;
   static final Logger logger = LogService.getLogger();
 
   public TcpServerFactory() {
     try {
-      protocolHandler = new MessageHandlerFactory().makeMessageHandler();
+      protocolHandler = new ClientProtocolServiceLoader().loadService();
     } catch (ServiceLoadingFailureException ex) {
       logger.warn(ex.getMessage());
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
@@ -107,7 +107,7 @@ public class ServerConnectionFactoryTest {
 
     return new ServerConnectionFactory().makeServerConnection(socketMock, mock(InternalCache.class),
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "", communicationMode,
-        mock(AcceptorImpl.class), mock(SecurityService.class), InetAddress.getLocalHost());
+        mock(AcceptorImpl.class), mock(SecurityService.class));
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -82,9 +82,9 @@ public class ServerConnectionTest {
     InternalCache cache = mock(InternalCache.class);
     SecurityService securityService = mock(SecurityService.class);
 
-    serverConnection = new ServerConnectionFactory().makeServerConnection(socket, cache, null, null,
-        0, 0, null, CommunicationMode.PrimaryServerToClient.getModeNumber(), acceptor,
-        securityService, InetAddress.getLocalHost());
+    serverConnection =
+        new ServerConnectionFactory().makeServerConnection(socket, cache, null, null, 0, 0, null,
+            CommunicationMode.PrimaryServerToClient.getModeNumber(), acceptor, securityService);
     MockitoAnnotations.initMocks(this);
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolMessageHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProtocolMessageHandler.java
@@ -15,20 +15,23 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
-import java.util.Iterator;
-import java.util.ServiceLoader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-public class MessageHandlerFactory {
-  public ClientProtocolMessageHandler makeMessageHandler() {
-    ServiceLoader<ClientProtocolMessageHandler> loader =
-        ServiceLoader.load(ClientProtocolMessageHandler.class);
-    Iterator<ClientProtocolMessageHandler> iterator = loader.iterator();
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsFactory;
 
-    if (!iterator.hasNext()) {
-      throw new ServiceLoadingFailureException(
-          "There is no ClientProtocolMessageHandler implementation found in JVM");
-    }
 
-    return iterator.next();
-  }
+/**
+ * This is an interface that other modules can implement to hook into
+ * {@link GenericProtocolServerConnection} to handle messages sent to Geode.
+ *
+ * Currently, only one {@link ClientProtocolMessageHandler} at a time can be used in a Geode
+ * instance. It gets wired into {@link ServerConnectionFactory} to create all instances of
+ * {@link GenericProtocolServerConnection}.
+ */
+public interface ClientProtocolMessageHandler {
+  void receiveMessage(InputStream inputStream, OutputStream outputStream,
+      MessageExecutionContext executionContext) throws IOException;
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageExecutionContext.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageExecutionContext.java
@@ -29,8 +29,8 @@ import org.apache.geode.security.server.NoOpAuthorizer;
 public class MessageExecutionContext {
   private Cache cache;
   private Locator locator;
-  private Authorizer authorizer;
-  private ProtobufClientStatistics statistics;
+  private final Authorizer authorizer;
+  private final ProtobufClientStatistics statistics;
 
 
   public MessageExecutionContext(Cache cache, Authorizer streamAuthorizer,

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageExecutionContext.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageExecutionContext.java
@@ -20,6 +20,8 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
+import org.apache.geode.internal.protocol.protobuf.statistics.NoOpStatistics;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.security.server.Authorizer;
 import org.apache.geode.security.server.NoOpAuthorizer;
 
@@ -28,22 +30,22 @@ public class MessageExecutionContext {
   private Cache cache;
   private Locator locator;
   private Authorizer authorizer;
-  private ClientProtocolStatistics statistics;
+  private ProtobufClientStatistics statistics;
 
 
   public MessageExecutionContext(Cache cache, Authorizer streamAuthorizer,
-      ClientProtocolStatistics statistics) {
+      ProtobufClientStatistics statistics) {
     this.cache = cache;
     this.authorizer = streamAuthorizer;
     this.statistics = statistics;
   }
 
-  public MessageExecutionContext(InternalLocator locator) {
+  public MessageExecutionContext(InternalLocator locator, ProtobufClientStatistics statistics) {
     this.locator = locator;
     // set a no-op authorizer until such time as locators implement authentication
     // and authorization checks
     this.authorizer = new NoOpAuthorizer();
-    this.statistics = new NoOpStatistics();
+    this.statistics = statistics;
   }
 
   /**
@@ -86,7 +88,7 @@ public class MessageExecutionContext {
    * Returns the statistics for recording operation stats. In a unit test environment this may not
    * be a protocol-specific statistics implementation.
    */
-  public ClientProtocolStatistics getStatistics() {
+  public ProtobufClientStatistics getStatistics() {
     return statistics;
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufCachePipeline.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufCachePipeline.java
@@ -31,14 +31,14 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.server.Authenticator;
 
 @Experimental
-public final class ProtobufPipeline implements ClientProtocolPipeline {
+public final class ProtobufCachePipeline implements ClientProtocolPipeline {
   private final ProtobufClientStatistics statistics;
   private final Cache cache;
   private final SecurityService securityService;
   private final ProtobufStreamProcessor streamProcessor;
   private final Authenticator authenticator;
 
-  ProtobufPipeline(ProtobufStreamProcessor protobufStreamProcessor,
+  ProtobufCachePipeline(ProtobufStreamProcessor protobufStreamProcessor,
       ProtobufClientStatistics statistics, Cache cache, Authenticator authenticator,
       SecurityService securityService) {
     this.streamProcessor = protobufStreamProcessor;
@@ -46,6 +46,7 @@ public final class ProtobufPipeline implements ClientProtocolPipeline {
     this.cache = cache;
     this.authenticator = authenticator;
     this.securityService = securityService;
+    this.statistics.clientConnected();
   }
 
   @Override
@@ -60,7 +61,7 @@ public final class ProtobufPipeline implements ClientProtocolPipeline {
   }
 
   @Override
-  public ClientProtocolStatistics getStatistics() {
-    return statistics;
+  public void close() {
+    this.statistics.clientDisconnected();
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufCachePipeline.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufCachePipeline.java
@@ -22,8 +22,7 @@ import java.io.OutputStream;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.IncompatibleVersionException;
-import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
-import org.apache.geode.internal.cache.tier.sockets.ClientProtocolStatistics;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
@@ -31,7 +30,7 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.server.Authenticator;
 
 @Experimental
-public final class ProtobufCachePipeline implements ClientProtocolPipeline {
+public final class ProtobufCachePipeline implements ClientProtocolProcessor {
   private final ProtobufClientStatistics statistics;
   private final Cache cache;
   private final SecurityService securityService;

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufLocatorPipeline.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufLocatorPipeline.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.geode.annotations.Experimental;
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
+import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
+import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
+
+@Experimental
+public final class ProtobufLocatorPipeline implements ClientProtocolPipeline {
+  private final ProtobufClientStatistics statistics;
+  private final InternalLocator locator;
+  private final ProtobufStreamProcessor streamProcessor;
+
+  ProtobufLocatorPipeline(ProtobufStreamProcessor protobufStreamProcessor,
+      ProtobufClientStatistics statistics, InternalLocator locator) {
+    this.streamProcessor = protobufStreamProcessor;
+    this.statistics = statistics;
+    this.locator = locator;
+    this.statistics.clientConnected();
+  }
+
+  @Override
+  public void processMessage(InputStream inputStream, OutputStream outputStream)
+      throws IOException, IncompatibleVersionException {
+    streamProcessor.receiveMessage(inputStream, outputStream,
+        new MessageExecutionContext(locator, statistics));
+  }
+
+  @Override
+  public void close() {
+    this.statistics.clientDisconnected();
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufLocatorPipeline.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufLocatorPipeline.java
@@ -22,13 +22,13 @@ import java.io.OutputStream;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 
 @Experimental
-public final class ProtobufLocatorPipeline implements ClientProtocolPipeline {
+public final class ProtobufLocatorPipeline implements ClientProtocolProcessor {
   private final ProtobufClientStatistics statistics;
   private final InternalLocator locator;
   private final ProtobufStreamProcessor streamProcessor;

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufPipeline.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufPipeline.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.geode.annotations.Experimental;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolStatistics;
+import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
+import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.server.Authenticator;
+
+@Experimental
+public final class ProtobufPipeline implements ClientProtocolPipeline {
+  private final ProtobufClientStatistics statistics;
+  private final Cache cache;
+  private final SecurityService securityService;
+  private final ProtobufStreamProcessor streamProcessor;
+  private final Authenticator authenticator;
+
+  ProtobufPipeline(ProtobufStreamProcessor protobufStreamProcessor,
+      ProtobufClientStatistics statistics, Cache cache, Authenticator authenticator,
+      SecurityService securityService) {
+    this.streamProcessor = protobufStreamProcessor;
+    this.statistics = statistics;
+    this.cache = cache;
+    this.authenticator = authenticator;
+    this.securityService = securityService;
+  }
+
+  @Override
+  public void processMessage(InputStream inputStream, OutputStream outputStream)
+      throws IOException, IncompatibleVersionException {
+    if (!authenticator.isAuthenticated()) {
+      authenticator.authenticate(inputStream, outputStream, securityService.getSecurityManager());
+    } else {
+      streamProcessor.receiveMessage(inputStream, outputStream,
+          new MessageExecutionContext(cache, authenticator.getAuthorizer(), statistics));
+    }
+  }
+
+  @Override
+  public ClientProtocolStatistics getStatistics() {
+    return statistics;
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolService;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolStatistics;
+import org.apache.geode.internal.cache.tier.sockets.MessageExecutionContext;
+import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
+import org.apache.geode.internal.protocol.protobuf.statistics.NoOpStatistics;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatisticsImpl;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.server.Authenticator;
+
+public class ProtobufProtocolService implements ClientProtocolService {
+  private ProtobufClientStatistics statistics;
+  private final ProtobufStreamProcessor protobufStreamProcessor = new ProtobufStreamProcessor();
+
+  @Override
+  public void initializeStatistics(String statisticsName, StatisticsFactory factory) {
+    statistics = new ProtobufClientStatisticsImpl(factory, statisticsName, "ProtobufServerStats");
+  }
+
+  @Override
+  public ClientProtocolStatistics getStatistics() {
+    return statistics;
+  }
+
+  @Override
+  public ClientProtocolPipeline createCachePipeline(Cache cache, Authenticator authenticator,
+      SecurityService securityService) {
+    assert (statistics != null);
+    return new ProtobufPipeline(protobufStreamProcessor, statistics, cache, authenticator,
+        securityService);
+  }
+
+  @Override
+  public void serveLocatorMessage(InputStream inputStream, OutputStream outputStream,
+      InternalLocator locator) throws IOException {
+    ProtobufClientStatistics statistics =
+        this.statistics == null ? new NoOpStatistics() : this.statistics;
+
+    statistics.clientConnected();
+
+    protobufStreamProcessor.receiveMessage(inputStream, outputStream,
+        new MessageExecutionContext(locator, statistics));
+
+    statistics.clientDisconnected();
+  }
+
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/ProtobufProtocolService.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.protocol;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.cache.tier.sockets.ClientProtocolPipeline;
+import org.apache.geode.internal.cache.tier.sockets.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.sockets.ClientProtocolService;
 import org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor;
 import org.apache.geode.internal.protocol.protobuf.statistics.NoOpStatistics;
@@ -48,14 +48,14 @@ public class ProtobufProtocolService implements ClientProtocolService {
   }
 
   @Override
-  public ClientProtocolPipeline createCachePipeline(Cache cache, Authenticator authenticator,
+  public ClientProtocolProcessor createProcessorForCache(Cache cache, Authenticator authenticator,
       SecurityService securityService) {
     return new ProtobufCachePipeline(protobufStreamProcessor, getStatistics(), cache, authenticator,
         securityService);
   }
 
   @Override
-  public ClientProtocolPipeline createLocatorPipeline(InternalLocator locator) {
+  public ClientProtocolProcessor createProcessorForLocator(InternalLocator locator) {
     return new ProtobufLocatorPipeline(protobufStreamProcessor, getStatistics(), locator);
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessor.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessor.java
@@ -43,23 +43,12 @@ import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 public class ProtobufStreamProcessor implements ClientProtocolMessageHandler {
   private final ProtobufProtocolSerializer protobufProtocolSerializer;
   private final ProtobufOpsProcessor protobufOpsProcessor;
-  private ProtobufClientStatistics statistics;
   private static final Logger logger = LogService.getLogger();
 
   public ProtobufStreamProcessor() {
     protobufProtocolSerializer = new ProtobufProtocolSerializer();
     protobufOpsProcessor = new ProtobufOpsProcessor(new ProtobufSerializationService(),
         new OperationContextRegistry());
-  }
-
-  @Override
-  public void initializeStatistics(String statisticsName, StatisticsFactory factory) {
-    statistics = new ProtobufClientStatisticsImpl(factory, statisticsName, "ProtobufServerStats");
-  }
-
-  @Override
-  public ClientProtocolStatistics getStatistics() {
-    return statistics;
   }
 
   @Override
@@ -81,6 +70,7 @@ public class ProtobufStreamProcessor implements ClientProtocolMessageHandler {
       logger.debug(errorMessage);
       throw new EOFException(errorMessage);
     }
+    ProtobufClientStatistics statistics = executionContext.getStatistics();
     statistics.messageReceived(message.getSerializedSize());
 
     ClientProtocol.Request request = message.getRequest();

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/NoOpStatistics.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/NoOpStatistics.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.statistics;
+
+public class NoOpStatistics implements ProtobufClientStatistics {
+  @Override
+  public void clientConnected() {
+
+  }
+
+  @Override
+  public void clientDisconnected() {
+
+  }
+
+  @Override
+  public void messageReceived(int bytes) {
+
+  }
+
+  @Override
+  public void messageSent(int bytes) {
+
+  }
+
+  @Override
+  public void incAuthorizationViolations() {
+
+  }
+
+  @Override
+  public void incAuthenticationFailures() {
+
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/ProtobufClientStatistics.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/ProtobufClientStatistics.java
@@ -17,15 +17,17 @@ package org.apache.geode.internal.protocol.protobuf.statistics;
 import org.apache.geode.internal.cache.tier.sockets.ClientProtocolStatistics;
 
 public interface ProtobufClientStatistics extends ClientProtocolStatistics {
-  public void clientConnected();
+  String PROTOBUF_STATS_NAME = "ProtobufStats";
 
-  public void clientDisconnected();
+  void clientConnected();
 
-  public void messageReceived(int bytes);
+  void clientDisconnected();
 
-  public void messageSent(int bytes);
+  void messageReceived(int bytes);
 
-  public void incAuthorizationViolations();
+  void messageSent(int bytes);
 
-  public void incAuthenticationFailures();
+  void incAuthorizationViolations();
+
+  void incAuthenticationFailures();
 }

--- a/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler
+++ b/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolMessageHandler
@@ -1,1 +1,0 @@
-org.apache.geode.internal.protocol.protobuf.ProtobufStreamProcessor

--- a/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolService
+++ b/geode-protobuf/src/main/resources/META-INF/services/org.apache.geode.internal.cache.tier.sockets.ClientProtocolService
@@ -1,0 +1,1 @@
+org.apache.geode.internal.protocol.ProtobufProtocolService

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
@@ -113,7 +113,6 @@ public class GenericProtocolServerConnectionTest {
       throws IOException, IncompatibleVersionException {
     ClientProtocolPipeline clientProtocolPipeline = mock(ClientProtocolPipeline.class);
     ClientProtocolStatistics statisticsMock = mock(ClientProtocolStatistics.class);
-    when(clientProtocolPipeline.getStatistics()).thenReturn(statisticsMock);
     doThrow(new IOException()).when(clientProtocolPipeline).processMessage(any(), any());
     return getServerConnection(clientProtocolPipeline, mock(AcceptorImpl.class));
   }
@@ -128,8 +127,6 @@ public class GenericProtocolServerConnectionTest {
     when(socketMock.getInetAddress()).thenReturn(InetAddress.getByName("localhost"));
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
-
-    when(clientPipelineMock.getStatistics()).thenReturn(new NoOpProtobufStatistics());
 
     return new GenericProtocolServerConnection(socketMock, mock(InternalCache.class),
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "",

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnectionTest.java
@@ -39,8 +39,6 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.internal.protocol.protobuf.statistics.NoOpProtobufStatistics;
-import org.apache.geode.security.server.NoOpAuthenticator;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -62,7 +60,7 @@ public class GenericProtocolServerConnectionTest {
     when(socketMock.getInetAddress()).thenReturn(InetAddress.getByName("localhost"));
 
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
-    ClientProtocolPipeline pipeline = mock(ClientProtocolPipeline.class);
+    ClientProtocolProcessor pipeline = mock(ClientProtocolProcessor.class);
     GenericProtocolServerConnection genericProtocolServerConnection =
         getServerConnection(socketMock, pipeline, acceptorStub);
 
@@ -75,9 +73,9 @@ public class GenericProtocolServerConnectionTest {
   public void testClientHealthMonitorRegistration() throws UnknownHostException {
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
 
-    ClientProtocolPipeline clientProtocolPipeline = mock(ClientProtocolPipeline.class);
+    ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
 
-    ServerConnection serverConnection = getServerConnection(clientProtocolPipeline, acceptorStub);
+    ServerConnection serverConnection = getServerConnection(clientProtocolProcessor, acceptorStub);
 
     ArgumentCaptor<ClientProxyMembershipID> registerCpmidArgumentCaptor =
         ArgumentCaptor.forClass(ClientProxyMembershipID.class);
@@ -97,9 +95,9 @@ public class GenericProtocolServerConnectionTest {
   @Test
   public void testDoOneMessageNotifiesClientHealthMonitor() throws UnknownHostException {
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
-    ClientProtocolPipeline clientProtocolPipeline = mock(ClientProtocolPipeline.class);
+    ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
 
-    ServerConnection serverConnection = getServerConnection(clientProtocolPipeline, acceptorStub);
+    ServerConnection serverConnection = getServerConnection(clientProtocolProcessor, acceptorStub);
     serverConnection.doOneMessage();
 
     ArgumentCaptor<ClientProxyMembershipID> clientProxyMembershipIDArgumentCaptor =
@@ -111,14 +109,14 @@ public class GenericProtocolServerConnectionTest {
 
   private GenericProtocolServerConnection IOExceptionThrowingServerConnection()
       throws IOException, IncompatibleVersionException {
-    ClientProtocolPipeline clientProtocolPipeline = mock(ClientProtocolPipeline.class);
+    ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
     ClientProtocolStatistics statisticsMock = mock(ClientProtocolStatistics.class);
-    doThrow(new IOException()).when(clientProtocolPipeline).processMessage(any(), any());
-    return getServerConnection(clientProtocolPipeline, mock(AcceptorImpl.class));
+    doThrow(new IOException()).when(clientProtocolProcessor).processMessage(any(), any());
+    return getServerConnection(clientProtocolProcessor, mock(AcceptorImpl.class));
   }
 
   private GenericProtocolServerConnection getServerConnection(Socket socketMock,
-      ClientProtocolPipeline clientPipelineMock, AcceptorImpl acceptorStub)
+      ClientProtocolProcessor clientPipelineMock, AcceptorImpl acceptorStub)
       throws UnknownHostException {
     clientHealthMonitorMock = mock(ClientHealthMonitor.class);
     when(acceptorStub.getClientHealthMonitor()).thenReturn(clientHealthMonitorMock);
@@ -135,9 +133,9 @@ public class GenericProtocolServerConnectionTest {
   }
 
   private GenericProtocolServerConnection getServerConnection(
-      ClientProtocolPipeline clientProtocolPipelineMock, AcceptorImpl acceptorStub)
+      ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
       throws UnknownHostException {
     Socket socketMock = mock(Socket.class);
-    return getServerConnection(socketMock, clientProtocolPipelineMock, acceptorStub);
+    return getServerConnection(socketMock, clientProtocolProcessorMock, acceptorStub);
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/CacheConnectionJUnitTest.java
@@ -66,6 +66,7 @@ import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.internal.serialization.SerializationService;
 import org.apache.geode.internal.serialization.exception.UnsupportedEncodingTypeException;
@@ -172,10 +173,10 @@ public class CacheConnectionJUnitTest {
 
     InternalDistributedSystem distributedSystem =
         (InternalDistributedSystem) cache.getDistributedSystem();
-    Statistics[] protobufServerStats =
-        distributedSystem.findStatisticsByType(distributedSystem.findType("ProtobufServerStats"));
-    assertEquals(1, protobufServerStats.length);
-    Statistics statistics = protobufServerStats[0];
+    Statistics[] protobufStats = distributedSystem.findStatisticsByType(
+        distributedSystem.findType(ProtobufClientStatistics.PROTOBUF_STATS_NAME));
+    assertEquals(1, protobufStats.length);
+    Statistics statistics = protobufStats[0];
     assertEquals(1, statistics.get("currentClientConnections"));
     assertEquals(2L, statistics.get("messagesReceived"));
     assertEquals(2L, statistics.get("messagesSent"));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
@@ -62,9 +62,9 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
 
   @Before
   public void setup() throws IOException {
-    startCacheWithCacheServer();
-
     Host.getLocator().invoke(() -> System.setProperty("geode.feature-protobuf-protocol", "true"));
+
+    startCacheWithCacheServer();
   }
 
   private Socket createSocket() throws IOException {

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
@@ -89,52 +89,35 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
             protobufRequestBuilder.setGetAvailableServersRequest(
                 ProtobufRequestUtilities.createGetAvailableServersRequest()).build());
 
-    try {
-      ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
+    ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
 
-      try (Socket socket = createSocket()) {
-        long messagesReceived = getMessagesReceived();
-        long messagesSent = getMessagesSent();
-        long bytesReceived = getBytesReceived();
-        long bytesSent = getBytesSent();
-        int clientConnectionStarts = getClientConnectionStarts();
-        int clientConnectionTerminations = getClientConnectionTerminations();
+    testSocketWithStats(getAvailableServersRequestMessage, protobufProtocolSerializer);
 
-        protobufProtocolSerializer.serialize(getAvailableServersRequestMessage,
-            socket.getOutputStream());
+    testSocketWithStats(getAvailableServersRequestMessage, protobufProtocolSerializer);
+  }
 
-        ClientProtocol.Message getAvailableServersResponseMessage =
-            protobufProtocolSerializer.deserialize(socket.getInputStream());
-        validateGetAvailableServersResponse(getAvailableServersResponseMessage);
+  private void testSocketWithStats(ClientProtocol.Message getAvailableServersRequestMessage,
+      ProtobufProtocolSerializer protobufProtocolSerializer)
+      throws IOException, InvalidProtocolMessageException {
+    try (Socket socket = createSocket()) {
+      long messagesReceived = getMessagesReceived();
+      long messagesSent = getMessagesSent();
+      long bytesReceived = getBytesReceived();
+      long bytesSent = getBytesSent();
+      int clientConnectionStarts = getClientConnectionStarts();
+      int clientConnectionTerminations = getClientConnectionTerminations();
 
-        validateStats(messagesReceived + 1, messagesSent + 1,
-            bytesReceived + getAvailableServersRequestMessage.getSerializedSize(),
-            bytesSent + getAvailableServersResponseMessage.getSerializedSize(),
-            clientConnectionStarts, clientConnectionTerminations + 1);
-      }
+      protobufProtocolSerializer.serialize(getAvailableServersRequestMessage,
+          socket.getOutputStream());
 
-      try (Socket socket = createSocket()) {
-        long messagesReceived = getMessagesReceived();
-        long messagesSent = getMessagesSent();
-        long bytesReceived = getBytesReceived();
-        long bytesSent = getBytesSent();
-        int clientConnectionStarts = getClientConnectionStarts();
-        int clientConnectionTerminations = getClientConnectionTerminations();
+      ClientProtocol.Message getAvailableServersResponseMessage =
+          protobufProtocolSerializer.deserialize(socket.getInputStream());
+      validateGetAvailableServersResponse(getAvailableServersResponseMessage);
 
-        protobufProtocolSerializer.serialize(getAvailableServersRequestMessage,
-            socket.getOutputStream());
-
-        ClientProtocol.Message getAvailableServersResponseMessage =
-            protobufProtocolSerializer.deserialize(socket.getInputStream());
-        validateGetAvailableServersResponse(getAvailableServersResponseMessage);
-
-        validateStats(messagesReceived + 1, messagesSent + 1,
-            bytesReceived + getAvailableServersRequestMessage.getSerializedSize(),
-            bytesSent + getAvailableServersResponseMessage.getSerializedSize(),
-            clientConnectionStarts, clientConnectionTerminations + 1);
-      }
-    } catch (RMIException e) {
-      throw e.getCause(); // so that assertions propagate properly.
+      validateStats(messagesReceived + 1, messagesSent + 1,
+          bytesReceived + getAvailableServersRequestMessage.getSerializedSize(),
+          bytesSent + getAvailableServersResponseMessage.getSerializedSize(),
+          clientConnectionStarts, clientConnectionTerminations + 1);
     }
   }
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/acceptance/LocatorConnectionDUnitTest.java
@@ -18,7 +18,6 @@ package org.apache.geode.internal.protocol.acceptance;
 import static org.apache.geode.internal.cache.tier.CommunicationMode.ProtobufClientServerProtocol;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -36,17 +35,17 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.ServerAPI;
 import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageException;
+import org.apache.geode.internal.protocol.protobuf.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.ProtocolErrorCode;
+import org.apache.geode.internal.protocol.protobuf.ServerAPI;
 import org.apache.geode.internal.protocol.protobuf.serializer.ProtobufProtocolSerializer;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufUtilities;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.RMIException;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -170,8 +169,8 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
     InternalDistributedSystem distributedSystem =
         (InternalDistributedSystem) Locator.getLocator().getDistributedSystem();
 
-    Statistics[] protobufServerStats =
-        distributedSystem.findStatisticsByType(distributedSystem.findType("ProtobufServerStats"));
+    Statistics[] protobufServerStats = distributedSystem.findStatisticsByType(
+        distributedSystem.findType(ProtobufClientStatistics.PROTOBUF_STATS_NAME));
     assertEquals(1, protobufServerStats.length);
     return protobufServerStats[0];
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetAvailableServersOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/operations/GetAvailableServersOperationHandlerJUnitTest.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.protocol.protobuf.Result;
 import org.apache.geode.internal.protocol.protobuf.ServerAPI;
 import org.apache.geode.internal.protocol.protobuf.ServerAPI.GetAvailableServersResponse;
 import org.apache.geode.internal.protocol.protobuf.Success;
+import org.apache.geode.internal.protocol.protobuf.statistics.NoOpStatistics;
 import org.apache.geode.internal.protocol.protobuf.utilities.ProtobufRequestUtilities;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.Before;
@@ -74,8 +75,9 @@ public class GetAvailableServersOperationHandlerJUnitTest extends OperationHandl
 
     ServerAPI.GetAvailableServersRequest getAvailableServersRequest =
         ProtobufRequestUtilities.createGetAvailableServersRequest();
-    Result operationHandlerResult = operationHandler.process(serializationServiceStub,
-        getAvailableServersRequest, new MessageExecutionContext(internalLocatorMock));
+    Result operationHandlerResult =
+        operationHandler.process(serializationServiceStub, getAvailableServersRequest,
+            new MessageExecutionContext(internalLocatorMock, new NoOpStatistics()));
     assertTrue(operationHandlerResult instanceof Success);
     ValidateGetAvailableServersResponse(
         (GetAvailableServersResponse) operationHandlerResult.getMessage());
@@ -88,8 +90,9 @@ public class GetAvailableServersOperationHandlerJUnitTest extends OperationHandl
 
     ServerAPI.GetAvailableServersRequest getAvailableServersRequest =
         ProtobufRequestUtilities.createGetAvailableServersRequest();
-    Result operationHandlerResult = operationHandler.process(serializationServiceStub,
-        getAvailableServersRequest, new MessageExecutionContext(internalLocatorMock));
+    Result operationHandlerResult =
+        operationHandler.process(serializationServiceStub, getAvailableServersRequest,
+            new MessageExecutionContext(internalLocatorMock, new NoOpStatistics()));
     assertTrue(operationHandlerResult instanceof Success);
     GetAvailableServersResponse availableServersResponse =
         (GetAvailableServersResponse) operationHandlerResult.getMessage();


### PR DESCRIPTION
* Load a single service, `ClientProtocolService`.
  - (well, authenticators are still separate).
* Move several interfaces to `geode-protobuf` from core.
* Client protocol state and statistics are now stored on the new
  `ClientProtocolPipeline` interface. This will allow us to keep
  connection logic for core separated from protocol logic.

This will allow us to make further refactors and add handshake logic to
the new client protocol.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
