### PR TITLE
GEODE-3755: make resilient to variable number of dunit VMs

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/examples/BeforeClassExampleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/examples/BeforeClassExampleTest.java
@@ -34,6 +34,6 @@ public class BeforeClassExampleTest {
 
   @Test
   public void shouldHaveFourDUnitVMsByDefault() throws Exception {
-    assertThat(Host.getHost(0).getVMCount()).isEqualTo(4);
+    assertThat(Host.getHost(0).getVMCount()).isGreaterThan(0);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/examples/LocatorPortClusterExampleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/examples/LocatorPortClusterExampleTest.java
@@ -65,9 +65,10 @@ public class LocatorPortClusterExampleTest implements Serializable {
   }
 
   @Test
-  public void clusterHasSixVMsByDefault() throws Exception {
-    assertThat(cache.getDistributionManager().getViewMembers()).hasSize(6);
-    assertThat(Host.getHost(0).getVMCount()).isEqualTo(4);
-    assertThat(Host.getHost(0).getAllVMs()).hasSize(4);
+  public void clusterHasDUnitVMCountPlusTwoByDefault() throws Exception {
+    int dunitVMCount = Host.getHost(0).getVMCount();
+    assertThat(cache.getDistributionManager().getViewMembers()).hasSize(dunitVMCount + 2);
+    assertThat(Host.getHost(0).getVMCount()).isEqualTo(dunitVMCount);
+    assertThat(Host.getHost(0).getAllVMs()).hasSize(dunitVMCount);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/DistributedTestRuleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/DistributedTestRuleTest.java
@@ -32,6 +32,6 @@ public class DistributedTestRuleTest {
 
   @Test
   public void shouldHaveFourDUnitVMsByDefault() throws Exception {
-    assertThat(Host.getHost(0).getVMCount()).isEqualTo(4);
+    assertThat(Host.getHost(0).getVMCount()).isGreaterThan(0);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedCountersRuleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedCountersRuleTest.java
@@ -143,7 +143,11 @@ public class SharedCountersRuleTest implements Serializable {
       vm.invoke(() -> combined.get(timeoutMillis, MILLISECONDS));
     }
 
-    assertThat(sharedCountersRule.getTotal(ID1)).isEqualTo(50);
+    int dunitVMCount = Host.getHost(0).getVMCount();
+    int controllerPlusDUnitVMCount = dunitVMCount + 1;
+    int expectedIncrements = controllerPlusDUnitVMCount * numThreads;
+
+    assertThat(sharedCountersRule.getTotal(ID1)).isEqualTo(expectedIncrements);
   }
 
   private void givenSharedCounterFor(final Serializable id) {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedErrorCollectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/SharedErrorCollectorTest.java
@@ -30,7 +30,6 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 
 import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.RMIException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedTestRule;
 import org.apache.geode.test.dunit.rules.SharedErrorCollector;
@@ -91,7 +90,7 @@ public class SharedErrorCollectorTest {
 
     assertThat(result.wasSuccessful()).isFalse();
     List<Failure> failures = result.getFailures();
-    assertThat(failures).hasSize(4);
+    assertThat(failures).hasSize(Host.getHost(0).getVMCount());
     int i = 0;
     for (Failure failure : failures) {
       assertThat(failure.getException()).isInstanceOf(AssertionError.class)
@@ -105,7 +104,7 @@ public class SharedErrorCollectorTest {
 
     assertThat(result.wasSuccessful()).isFalse();
     List<Failure> failures = result.getFailures();
-    assertThat(failures).hasSize(5);
+    assertThat(failures).hasSize(Host.getHost(0).getVMCount() + 1);
     boolean first = true;
     int i = 0;
     for (Failure failure : failures) {
@@ -148,7 +147,7 @@ public class SharedErrorCollectorTest {
 
     assertThat(result.wasSuccessful()).isFalse();
     List<Failure> failures = result.getFailures();
-    assertThat(failures).hasSize(4);
+    assertThat(failures).hasSize(Host.getHost(0).getVMCount());
     int i = 0;
     for (Failure failure : failures) {
       assertThat(failure.getException()).isInstanceOf(NullPointerException.class)
@@ -162,7 +161,7 @@ public class SharedErrorCollectorTest {
 
     assertThat(result.wasSuccessful()).isFalse();
     List<Failure> failures = result.getFailures();
-    assertThat(failures).hasSize(5);
+    assertThat(failures).hasSize(Host.getHost(0).getVMCount() + 1);
     boolean first = true;
     int i = 0;
     for (Failure failure : failures) {


### PR DESCRIPTION
* use getVMCount instead of 4

These are dunit infrastructure tests that attempted to assert that the default VM count is 4 or attempted some unrelated assertion which would fail if the test class runs after any other dunit test that uses more than the default number of VMs.

This should prevent any further intermittent failures of any of the tests in this change set.