### PR TITLE
GEODE-3742: Added logging to help identify this issue

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -547,6 +547,7 @@ public class CacheClientNotifier {
       unsuccessfulMsg =
           LocalizedStrings.CacheClientNotifier_CACHECLIENTNOTIFIER_A_PREVIOUS_CONNECTION_ATTEMPT_FROM_THIS_CLIENT_IS_STILL_BEING_PROCESSED__0
               .toLocalizedString(new Object[] {proxyId});
+      logger.warn(unsuccessfulMsg);
     }
 
     // Tell the client that the proxy has been registered using the response
@@ -594,7 +595,7 @@ public class CacheClientNotifier {
     } else {
       logger.warn(LocalizedMessage.create(
           LocalizedStrings.CacheClientNotifier_CACHECLIENTNOTIFIER_UNSUCCESSFULLY_REGISTERED_CLIENT_WITH_IDENTIFIER__0,
-          proxyId));
+          new Object[] {proxyId, responseByte}));
     }
     return l_proxy;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
@@ -385,6 +385,13 @@ public class CacheClientUpdater extends Thread implements ClientUpdater, Disconn
         logger.warn(LocalizedMessage.create(LocalizedStrings.CacheClientUpdater_CLASS_NOT_FOUND,
             e.getMessage()));
       }
+    } catch (ServerRefusedConnectionException e) {
+      if (!quitting()) {
+        logger.warn(LocalizedMessage.create(
+            LocalizedStrings.CacheClientUpdater_0_CAUGHT_FOLLOWING_EXECPTION_WHILE_ATTEMPTING_TO_CREATE_A_SERVER_TO_CLIENT_COMMUNICATION_SOCKET_AND_WILL_EXIT_1,
+            new Object[] {this, e}), logger.isDebugEnabled() ? e : null);
+      }
+      throw e;
     } finally {
       this.connected = success;
       if (mySock != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -286,7 +286,7 @@ public class LocalizedStrings {
           "CacheClientNotifier: The requested durable client has the same identifier ( {0} ) as an existing durable client ( {1} ). Duplicate durable clients are not allowed.");
   public static final StringId CacheClientNotifier_CACHECLIENTNOTIFIER_UNSUCCESSFULLY_REGISTERED_CLIENT_WITH_IDENTIFIER__0 =
       new StringId(1143,
-          "CacheClientNotifier: Unsuccessfully registered client with identifier  {0}");
+          "CacheClientNotifier: Unsuccessfully registered client with identifier  {0} and response code {1}");
   public static final StringId CacheClientNotifier_CANNOT_NOTIFY_CLIENTS_TO_PERFORM_OPERATION_0_ON_EVENT_1 =
       new StringId(1144,
           "CacheClientNotifier: Cannot notify clients to perform operation {0} on event {1}");


### PR DESCRIPTION
This is logging changes that should already exist.

The change to CacheClientNotifier logs a warning on the serverin the one place that was logged before when the responseByte is not successful like:
```
[warn 2017/10/04 15:45:04.879 PDT <Handshaker 0.0.0.0/0.0.0.0:29869 Thread 0> tid=0x6e] A previous connection attempt from this client is still being processed: identity(192.168.2.5(28918:loner):52814:275690e9,connection=1,durableAttributes=DurableClientAttributes[id=testBug40165ClientReconnects_client; timeout=60])
```
The change to CacheClientUpdater logs and rethrows the ServerRefusedConnectionException on the client like:
```
[warn 2017/10/04 15:45:04.880 PDT <main> tid=0x1] Cache Client Updater Thread  on boglesbymac-2(28921)<v2>:32770 port 29869 (localhost:29869): Caught following exception while attempting to create a server-to-client communication socket and will exit: org.apache.geode.cache.client.ServerRefusedConnectionException: <null inet_addr hostname><ec>:29869 refused connection: A previous connection attempt from this client is still being processed: identity(192.168.2.5(28918:loner):52814:275690e9,connection=1,durableAttributes=DurableClientAttributes[id=testBug40165ClientReconnects_client; timeout=60])
```
