### PR TITLE
GEODE-3778: fix flakiness with Awaitility

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/process/FileProcessControllerIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/FileProcessControllerIntegrationTest.java
@@ -212,7 +212,7 @@ public class FileProcessControllerIntegrationTest {
     new StringFileWriter(statusFile).writeToFile(STATUS_JSON);
 
     // assert
-    assertThat(statusRequestFile).exists();
+    await().until(() -> assertThat(statusRequestFile).exists());
   }
 
   @Test


### PR DESCRIPTION
* main thread was completing the test and tearDown before
the executor thread could return the status
