### PR TITLE
GEODE-3500: Increase member timeout in tomcat session tests

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/session/tests/TomcatClientServerTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/session/tests/TomcatClientServerTest.java
@@ -66,6 +66,7 @@ public abstract class TomcatClientServerTest extends CargoTestBase {
     command.addOption(CliStrings.START_SERVER__CLASSPATH,
         binDirJars + File.pathSeparator + libDirJars);
     command.addOption(CliStrings.START_SERVER__LOCATORS, DUnitEnv.get().getLocatorString());
+    command.addOption(CliStrings.START_SERVER__J, "-Dgemfire.member-timeout=60000");
 
     // Start server
     gfsh.executeAndVerifyCommand(command.toString());


### PR DESCRIPTION
We saw a test fail where the cache server failed to connect to the
locator. Increasing the member timeout in hopes that the failure was due
to a lack of resources on the machine.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
