### PR TITLE
GEODE-3805: Use correct timestamplto check last modified time

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache30/CacheStatisticsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/CacheStatisticsDUnitTest.java
@@ -425,6 +425,7 @@ public class CacheStatisticsDUnitTest extends JUnit4CacheTestCase {
         assertEquals(0, hc);
         assertEquals(0, mc);
         lastAccessed = stats.getLastAccessedTime();
+        lastModified = stats.getLastModifiedTime();
       }
     });
 
@@ -439,7 +440,7 @@ public class CacheStatisticsDUnitTest extends JUnit4CacheTestCase {
         Region region = getRootRegion().getSubregion(name);
         CacheStatistics stats = region.getEntry(key).getStatistics();
         assertEquals(lastAccessed, stats.getLastAccessedTime());
-        assertEquals(lastAccessed, stats.getLastModifiedTime());
+        assertEquals(lastModified, stats.getLastModifiedTime());
         assertEquals(0, stats.getHitCount());
         assertEquals(0, stats.getMissCount());
       }


### PR DESCRIPTION
This test can fail when the last modified time and last accessed time are set in different milliseconds (i.e. when the time it takes between the setting the value of last modified time and getting a timestamp from the clock for the last accessed time span the change in the value of the clock).