### PR TITLE
GEODE-3720: Bounce DUnit VMs to give the test a clean environment

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/CleanupDUnitVMsRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/CleanupDUnitVMsRule.java
@@ -15,6 +15,7 @@
 package org.apache.geode.test.dunit.rules;
 
 import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.test.dunit.Host.getHostCount;
 
 import org.apache.geode.test.dunit.VM;
 import org.junit.After;
@@ -23,6 +24,13 @@ import org.junit.rules.ExternalResource;
 import java.io.Serializable;
 
 public class CleanupDUnitVMsRule extends ExternalResource implements Serializable {
+
+  @Override
+  public void before() {
+    if (getHostCount() > 0) {
+      getHost(0).getAllVMs().forEach(VM::bounce);
+    }
+  }
 
   @Override
   public void after() {


### PR DESCRIPTION
Bounce the VMs once at the beginning of the test so they start clean.
Rules in the test ensure the VMs are cleaned up after each test method.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
