### PR TITLE
GEODE-3708: Added a separate iterator for MemoryIndexStore which does…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -181,14 +181,16 @@ public class CompactRangeIndex extends AbstractIndex {
     long start = updateIndexUseStats();
     ((AbstractIndex) indx).updateIndexUseStats();
     List data = new ArrayList();
-    CloseableIterator<IndexStoreEntry> outer = null;
+    Iterator<IndexStoreEntry> outer = null;
     Iterator inner = null;
     try {
       // We will iterate over each of the index Map to obtain the keys
-      outer = indexStore.iterator(null);
+      outer = ((MemoryIndexStore) indexStore).getKeysIterator();
 
       if (indx instanceof CompactRangeIndex) {
-        inner = ((CompactRangeIndex) indx).getIndexStorage().iterator(null);
+        IndexStore indexStore = ((CompactRangeIndex) indx).getIndexStorage();
+        inner = ((MemoryIndexStore) indexStore).getKeysIterator();
+
       } else {
         inner = ((RangeIndex) indx).getValueToEntriesMap().entrySet().iterator();
       }
@@ -252,10 +254,8 @@ public class CompactRangeIndex extends AbstractIndex {
     } finally {
       ((AbstractIndex) indx).updateIndexUseEndStats(start);
       updateIndexUseEndStats(start);
-      if (outer != null) {
-        outer.close();
-      }
-      if (inner != null && indx instanceof CompactRangeIndex) {
+      if (inner != null && indx instanceof CompactRangeIndex
+          && inner instanceof CloseableIterator) {
         ((CloseableIterator<IndexStoreEntry>) inner).close();
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -420,6 +420,10 @@ public class MemoryIndexStore implements IndexStore {
         keysToRemove);
   }
 
+  public Iterator<IndexStoreEntry> getKeysIterator() {
+    return new MemoryIndexStoreKeyIterator(this.valueToEntriesMap);
+  }
+
   @Override
   public CloseableIterator<IndexStoreEntry> iterator(Collection keysToRemove) {
     return new MemoryIndexStoreIterator(this.valueToEntriesMap, null, keysToRemove);
@@ -558,6 +562,38 @@ public class MemoryIndexStore implements IndexStore {
   @Override
   public int size() {
     return numIndexKeys.get();
+  }
+
+  private class MemoryIndexStoreKeyIterator implements Iterator<IndexStoreEntry> {
+
+    final private Map valuesToEntriesMap;
+    private Object currKey;
+    private Iterator<Map.Entry> mapIterator;
+
+    public MemoryIndexStoreKeyIterator(Map valuesToEntriesMap) {
+      this.valuesToEntriesMap = valuesToEntriesMap;
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (mapIterator == null) {
+        mapIterator = this.valuesToEntriesMap.entrySet().iterator();
+      }
+      if (mapIterator.hasNext()) {
+        Map.Entry currentEntry = mapIterator.next();
+        currKey = currentEntry.getKey();
+        if (currKey == IndexManager.NULL || currKey == QueryService.UNDEFINED) {
+          return hasNext();
+        }
+        return currKey != null;
+      }
+      return false;
+    }
+
+    @Override
+    public MemoryIndexStoreKey next() {
+      return new MemoryIndexStoreKey(currKey);
+    }
   }
 
   /**
@@ -704,6 +740,34 @@ public class MemoryIndexStore implements IndexStore {
     return sb.toString();
   }
 
+  class MemoryIndexStoreKey implements IndexStoreEntry {
+    private Object indexKey;
+
+    public MemoryIndexStoreKey(Object indexKey) {
+      this.indexKey = indexKey;
+    }
+
+    @Override
+
+    public Object getDeserializedKey() {
+      return indexKey;
+    }
+
+    @Override
+    public Object getDeserializedValue() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getDeserializedRegionKey() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUpdateInProgress() {
+      throw new UnsupportedOperationException();
+    }
+  }
   /**
    * A wrapper over the entry in the CSL index map. It maps IndexKey -> RegionEntry
    */

--- a/geode-core/src/test/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
@@ -27,9 +27,6 @@ import org.junit.runner.RunWith;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.query.CacheUtils;
-import org.apache.geode.cache.query.QueryService;
-import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
 @Category(IntegrationTest.class)
@@ -63,9 +60,13 @@ public class JoinQueriesIntegrationTest {
 
 
   private static Object[] getQueryStrings() {
-    return new Object[] {new Object[] {
-        "<trace>select STA.id as STACID, STA.pkid as STAacctNum, STC.id as STCCID, STC.pkid as STCacctNum from /region1 STA, /region2 STC where STA.pkid = 1 AND STA.joinId = STC.joinId AND STA.id = STC.id",
-        20},};
+    return new Object[] {
+        new Object[] {
+            "<trace>select STA.id as STACID, STA.pkid as STAacctNum, STC.id as STCCID, STC.pkid as STCacctNum from /region1 STA, /region2 STC where STA.pkid = 1 AND STA.joinId = STC.joinId AND STA.id = STC.id",
+            20},
+        new Object[] {
+            "<trace>select STA.id as STACID, STA.pkid as STAacctNum, STC.id as STCCID, STC.pkid as STCacctNum from /region1 STA, /region2 STC where STA.pkid = 1 AND STA.joinId = STC.joinId OR STA.id = STC.id",
+            22}};
   }
 
   @Test


### PR DESCRIPTION
…n't iterate over the values in the Map.

	* The new iterator MemoryIndexStoreKeyIterator will only iterate over the keys
	* This is different from the previous iterator which iterates over the values too and sending out IndexStoreEntry pairs of the key and iterated value entry
	* This resulted in duplicate results in join queries with OR clause as the same key was being repeatedly sent if the value associated with the key is a collection.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
