### PR TITLE
GEODE-3826: Use system independent expected strings

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/CommandResultTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/CommandResultTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.result;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
@@ -39,7 +40,7 @@ public class CommandResultTest {
   public void resultWithOneLineHasOneLine() {
     CommandResult commandResult = new CommandResult(new InfoResultData("oneLine"));
 
-    assertThat(commandResult.nextLine()).isEqualTo("oneLine\n");
+    assertThat(commandResult.nextLine()).isEqualTo("oneLine" + LINE_SEPARATOR);
     assertThat(commandResult.hasNextLine()).isFalse();
   }
 
@@ -50,7 +51,8 @@ public class CommandResultTest {
     resultData.addLine("lineTwo");
     CommandResult commandResult = new CommandResult(resultData);
 
-    assertThat(commandResult.nextLine()).isEqualTo("lineOne\nlineTwo\n");
+    assertThat(commandResult.nextLine())
+        .isEqualTo("lineOne" + LINE_SEPARATOR + "lineTwo" + LINE_SEPARATOR);
     assertThat(commandResult.hasNextLine()).isFalse();
   }
 
@@ -67,7 +69,7 @@ public class CommandResultTest {
     CommandResult commandResult = new CommandResult(fileToDownload);
 
     assertThat(commandResult.hasFileToDownload()).isTrue();
-    assertThat(commandResult.nextLine()).isEqualTo(fileToDownload.toString() + '\n');
+    assertThat(commandResult.nextLine()).isEqualTo(fileToDownload.toString() + LINE_SEPARATOR);
     assertThat(commandResult.getFileToDownload()).isEqualTo(fileToDownload);
   }
 


### PR DESCRIPTION
Replace explicit newline in expected strings with
SystemUtils.LINE_SEPARATOR so tests can run on Windows

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
