### PR TITLE
GEODE-2046: use CALLS_REAL_METHODS instead of internal method

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteOperationMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteOperationMessageTest.java
@@ -14,34 +14,35 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.internal.stubbing.answers.CallsRealMethods;
 
 import org.apache.geode.distributed.internal.DistributionManager;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.TXManagerImpl;
-import org.apache.geode.internal.cache.TXStateProxy;
-import org.apache.geode.internal.cache.TXStateProxyImpl;
 import org.apache.geode.test.fake.Fakes;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 
 @Category(UnitTest.class)
 public class RemoteOperationMessageTest {
+
   private GemFireCacheImpl cache;
   private RemoteOperationMessage msg;
   private DistributionManager dm;
   private LocalRegion r;
   private TXManagerImpl txMgr;
   private long startTime = 0;
-  TXStateProxy tx;
+  private TXStateProxy tx;
 
   @Before
-  public void setUp() throws InterruptedException {
+  public void setUp() throws Exception {
     cache = Fakes.cache();
     dm = mock(DistributionManager.class);
     msg = mock(RemoteOperationMessage.class);
@@ -55,12 +56,11 @@ public class RemoteOperationMessageTest {
     when(msg.getRegionByPath(cache)).thenReturn(r);
     when(msg.getTXManager(cache)).thenReturn(txMgr);
 
-    doAnswer(new CallsRealMethods()).when(msg).process(dm);
+    doAnswer(CALLS_REAL_METHODS).when(msg).process(dm);
   }
 
   @Test
-  public void messageWithNoTXPerformsOnRegion()
-      throws InterruptedException, RemoteOperationException {
+  public void messageWithNoTXPerformsOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(null);
     msg.process(dm);
 
@@ -68,8 +68,7 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void messageForNotFinishedTXPerformsOnRegion()
-      throws InterruptedException, RemoteOperationException {
+  public void messageForNotFinishedTXPerformsOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(tx);
     when(tx.isInProgress()).thenReturn(true);
     msg.process(dm);
@@ -78,8 +77,7 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void messageForFinishedTXDoesNotPerformOnRegion()
-      throws InterruptedException, RemoteOperationException {
+  public void messageForFinishedTXDoesNotPerformOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(tx);
     when(tx.isInProgress()).thenReturn(false);
     msg.process(dm);
@@ -88,7 +86,7 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void noNewTxProcessingAfterTXManagerImplClosed() throws RemoteOperationException {
+  public void noNewTxProcessingAfterTXManagerImplClosed() throws Exception {
     txMgr = new TXManagerImpl(null, cache);
 
     when(msg.checkCacheClosing(dm)).thenReturn(false);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
@@ -15,17 +15,19 @@
 package org.apache.geode.internal.cache.partitioned;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.apache.geode.cache.CacheException;
-import org.apache.geode.cache.query.QueryException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.DataLocationException;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.TXManagerImpl;
@@ -33,12 +35,6 @@ import org.apache.geode.internal.cache.TXStateProxy;
 import org.apache.geode.internal.cache.TXStateProxyImpl;
 import org.apache.geode.test.fake.Fakes;
 import org.apache.geode.test.junit.categories.UnitTest;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mockito.internal.stubbing.answers.CallsRealMethods;
-
-import java.io.IOException;
 
 @Category(UnitTest.class)
 public class PartitionMessageTest {
@@ -49,10 +45,10 @@ public class PartitionMessageTest {
   private PartitionedRegion pr;
   private TXManagerImpl txMgr;
   private long startTime = 1;
-  TXStateProxy tx;
+  private TXStateProxy tx;
 
   @Before
-  public void setUp() throws PRLocallyDestroyedException, InterruptedException {
+  public void setUp() throws Exception {
     cache = Fakes.cache();
     dm = mock(DistributionManager.class);
     msg = mock(PartitionMessage.class);
@@ -67,7 +63,7 @@ public class PartitionMessageTest {
     when(msg.getStartPartitionMessageProcessingTime(pr)).thenReturn(startTime);
     when(msg.getTXManagerImpl(cache)).thenReturn(txMgr);
 
-    doAnswer(new CallsRealMethods()).when(msg).process(dm);
+    doAnswer(CALLS_REAL_METHODS).when(msg).process(dm);
   }
 
   @Test
@@ -82,8 +78,7 @@ public class PartitionMessageTest {
   }
 
   @Test
-  public void messageWithNoTXPerformsOnRegion() throws InterruptedException, CacheException,
-      QueryException, DataLocationException, IOException {
+  public void messageWithNoTXPerformsOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(null);
     msg.process(dm);
 
@@ -91,8 +86,7 @@ public class PartitionMessageTest {
   }
 
   @Test
-  public void messageForNotFinishedTXPerformsOnRegion() throws InterruptedException, CacheException,
-      QueryException, DataLocationException, IOException {
+  public void messageForNotFinishedTXPerformsOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(tx);
     when(tx.isInProgress()).thenReturn(true);
     msg.process(dm);
@@ -101,8 +95,7 @@ public class PartitionMessageTest {
   }
 
   @Test
-  public void messageForFinishedTXDoesNotPerformOnRegion() throws InterruptedException,
-      CacheException, QueryException, DataLocationException, IOException {
+  public void messageForFinishedTXDoesNotPerformOnRegion() throws Exception {
     when(txMgr.masqueradeAs(msg)).thenReturn(tx);
     when(tx.isInProgress()).thenReturn(false);
     msg.process(dm);
@@ -111,8 +104,7 @@ public class PartitionMessageTest {
   }
 
   @Test
-  public void noNewTxProcessingAfterTXManagerImplClosed() throws CacheException, QueryException,
-      DataLocationException, InterruptedException, IOException {
+  public void noNewTxProcessingAfterTXManagerImplClosed() throws Exception {
     txMgr = new TXManagerImpl(null, cache);
     when(msg.getPartitionedRegion()).thenReturn(pr);
     when(msg.getInternalCache()).thenReturn(cache);


### PR DESCRIPTION
I also made all variables private, organized imports and changed the test method signatures to throw Exception.

Reviewers + @nreich 