### PR TITLE
Parameterizing LuceneSerializer with a type

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneSerializer.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneSerializer.java
@@ -19,20 +19,27 @@ import java.util.Collection;
 
 import org.apache.geode.cache.Declarable;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 
 import org.apache.geode.annotations.Experimental;
 
 /**
  * An interface for writing the fields of an object into a lucene document
+ * 
+ * @param <T> The type of object supported by this lucene serializer
  */
 @Experimental
-public interface LuceneSerializer extends Declarable {
+public interface LuceneSerializer<T> extends Declarable {
 
   /**
    * Add the fields of the given value to a set of documents
+   *
+   * Added fields should be marked with {@link Field.Store#NO}. These fields are only used for
+   * searches. When doing a query, geode will return the value from the region, not any fields that
+   * are stored on the returned Documents.
    * 
    * @param index lucene index
    * @param value user object to be serialized into index
    */
-  Collection<Document> toDocuments(LuceneIndex index, Object value);
+  Collection<Document> toDocuments(LuceneIndex index, T value);
 }


### PR DESCRIPTION
User's may want to create LuceneSerializers that only support specific
types, eg LuceneSerializer<MyDomainObject>. Adding a parameterized type
to the LuceneSerializer interface.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
