### PR TITLE
GEODE-2405 Update docs with changes to export cluster-configuration

### DIFF
--- a/geode-docs/configuring/cluster_config/export-import.html.md.erb
+++ b/geode-docs/configuring/cluster_config/export-import.html.md.erb
@@ -33,7 +33,7 @@ in [Cluster Configuration Files and Troubleshooting](gfsh_config_troubleshooting
 To export a cluster configuration, run the `gfsh` `export cluster-configuration` command while connected to a <%=vars.product_name%> cluster. For example:
 
 ``` pre
-export cluster-configuration --zip-file-name=myClusterConfig.zip --dir=/home/username/configs
+export cluster-configuration --zip-file-name=/home/username/configs/myClusterConfig.zip
 ```
 
 See [export cluster-configuration](../../tools_modules/gfsh/command-pages/export.html#topic_mdv_jgz_ck).

--- a/geode-docs/configuring/cluster_config/persisting_configurations.html.md.erb
+++ b/geode-docs/configuring/cluster_config/persisting_configurations.html.md.erb
@@ -171,7 +171,7 @@ This section provides a walk-through example of configuring a simple <%=vars.pro
     You can use the `gfsh export cluster-configuration` command to create a zip file that contains the cluster's persisted configuration. The zip file contains a copy of the contents of the `cluster_config` directory. For example:
 
     ``` pre
-    gfsh>export cluster-configuration --zip-file-name=myClConfig.zip --dir=/Users/username
+    gfsh>export cluster-configuration --zip-file-name=/Users/username/myClConfig.zip
     ```
 
     <%=vars.product_name_long%> writes the cluster configuration to the specified zip file.

--- a/geode-docs/tools_modules/gfsh/command-pages/export.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/export.html.md.erb
@@ -58,34 +58,35 @@ See [Overview of the Cluster Configuration Service](../../../configuring/cluster
 **Syntax:**
 
 ``` pre
-export cluster-configuration --zip-file-name=value [--dir=value]
+export cluster-configuration --zip-file-name=value
 ```
 
 **Export Cluster-Configuration Parameters:**
 
 | Name                                                  | Description                                                                          | Default Value     |
 |-------------------------------------------------------|--------------------------------------------------------------------------------------|-------------------|
-| <span class="keyword parmname">\\-\\-zip-file-name</span> | *Required.* File name of the zip file to contain the exported cluster configuration. |                   |
-| <span class="keyword parmname">\\-\\-dir</span>           | Directory where the cluster configuration zip files is saved.                        | Locator directory |
+| <span class="keyword parmname">\\-\\-zip-file-name</span> | *Required.* Filename of the zip file to contain the exported cluster configuration. May also include an absolute or relative path. |                   |
 
 **Example Commands:**
 
 ``` pre
-gfsh>export cluster-configuration --zip-file-name=/home/username/gemfire/myClusterConfig.zip
+gfsh>export cluster-configuration --zip-file-name=/group/shared-configs/devClusterConfig.zip
+gfsh>export cluster-configuration --zip-file-name=my-configs/myClusterConfig.zip
+gfsh>export cluster-configuration --zip-file-name=myClusterConfig.zip
 ```
 
 **Sample Output:**
 
 ``` pre
 gfsh>export cluster-configuration --zip-file-name=mySharedConfig.zip
-Downloading cluster configuration : /home/username/gemfire/myClusterConfig.zip
+Downloading cluster configuration : /home/username/gemfire/mySharedConfig.zip
 ```
 
 ## <a id="topic_C7C69306F93743459E65D46537F4A1EE" class="no-quick-link"></a>export config
 
 Export configuration properties for a member or members.
 
-If you do not specify any parameters, all member configuration will be exported.
+If you do not specify any parameters, all member configurations will be exported.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 


### PR DESCRIPTION
gfsh command 'export cluster-configuration' no longer takes a '--dir' option. The '--zip-file-name' option does it all.
Request reviews from @jaredjstewart , @karensmolermiller , @joeymcallister 