### PR TITLE
GEODE-1319: Awaitility clause added.

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/PDXNewWanDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/PDXNewWanDUnitTest.java
@@ -14,11 +14,14 @@
  */
 package org.apache.geode.internal.cache.wan.misc;
 
+import org.awaitility.Awaitility;
 import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
@@ -604,7 +607,6 @@ public class PDXNewWanDUnitTest extends WANTestBase {
   }
 
 
-  @Category(FlakyTest.class) // GEODE-1319
   @Test
   public void testWANPDX_RR_SerialSenderWithFilter() {
     Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
@@ -713,9 +715,13 @@ public class PDXNewWanDUnitTest extends WANTestBase {
 
 
   public static void verifyFilterInvocation(int invocation) {
-    assertEquals(((PDXGatewayEventFilter) eventFilter).beforeEnqueueInvoked, invocation);
-    assertEquals(((PDXGatewayEventFilter) eventFilter).beforeTransmitInvoked, invocation);
-    assertEquals(((PDXGatewayEventFilter) eventFilter).afterAckInvoked, invocation);
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> assertEquals(((PDXGatewayEventFilter) eventFilter).beforeEnqueueInvoked, invocation));
+    Awaitility.await().atMost(60, TimeUnit.SECONDS)
+        .until(() -> assertEquals(((PDXGatewayEventFilter) eventFilter).beforeTransmitInvoked,
+            invocation));
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> assertEquals(((PDXGatewayEventFilter) eventFilter).afterAckInvoked, invocation));
   }
 
 


### PR DESCRIPTION
	* After the receiver's region size is checked, immediately the afterAcknowledgement stat is checked in the sender
	* In a slow system, the ack may not have arrived, or was not yet processed enough to call the listeners at the moment when the stats were checked.
	* Waiting for a little more time may result in the stat to be updated and test not failing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
