### PR TITLE
GEODE-3847: upgrade to AssertJ 3.8.0

### DIFF
--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -15,7 +15,7 @@
 
 # Dependency versions
 antlr.version = 2.7.7
-assertj-core.version = 3.6.2
+assertj-core.version = 3.8.0
 awaitility.version = 2.0.0
 bcel.version = 6.0
 catch-exception.version = 1.4.4


### PR DESCRIPTION
Precheckin for this change is GREEN. No code changes were required -- just updating the version number in the build.