### PR TITLE
GEODE-3870: regenerate Region Entry classes from Linux

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractDiskRegionEntry.java
@@ -53,7 +53,7 @@ public abstract class AbstractDiskRegionEntry extends AbstractRegionEntry implem
   public void handleValueOverflow(RegionEntryContext context) {
     if (context instanceof BucketRegionQueue
         || context instanceof SerialGatewaySenderQueue.SerialGatewaySenderQueueMetaRegion) {
-      GatewaySenderEventImpl.release(this._getValue()); // OFFHEAP _getValue ok
+      GatewaySenderEventImpl.release(this.getValue()); // OFFHEAP _getValue ok
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractLRURegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractLRURegionMap.java
@@ -181,7 +181,7 @@ public abstract class AbstractLRURegionMap extends AbstractRegionMap {
         // no need to worry about the value changing form with entry LRU.
         return false;
       }
-      Object curVal = le._getValue(); // OFFHEAP: _getValue ok
+      Object curVal = le.getValue(); // OFFHEAP: _getValue ok
       if (curVal != cd) {
         if (cd instanceof StoredObject) {
           if (!cd.equals(curVal)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractOplogDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractOplogDiskRegionEntry.java
@@ -37,9 +37,9 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
   abstract void setDiskId(RegionEntry oldRe);
 
   @Override
-  public void removePhase1(LocalRegion r, boolean isClear) throws RegionClearedException {
+  public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
     synchronized (this) {
-      Helper.removeFromDisk(this, r, isClear);
+      Helper.removeFromDisk(this, region, clear);
       _removePhase1();
     }
   }
@@ -56,14 +56,15 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
   }
 
   @Override
-  public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
+  public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in, DM mgr,
       final Version version) {
-    return Helper.fillInValue(this, entry, r.getDiskRegion(), mgr, in, r, version);
+    return Helper.fillInValue(this, entry, region.getDiskRegion(), mgr, in, region, version);
   }
 
   @Override
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
-    return Helper.isOverflowedToDisk(this, r.getDiskRegion(), dp, r);
+  public boolean isOverflowedToDisk(InternalRegion region,
+      DistributedRegion.DiskPosition diskPosition) {
+    return Helper.isOverflowedToDisk(this, region.getDiskRegion(), diskPosition, region);
   }
 
   @Override
@@ -78,45 +79,49 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
   }
 
   @Override
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-    return Helper.getValueInVMOrDiskWithoutFaultIn(this, owner);
+  public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
+    return Helper.getValueInVMOrDiskWithoutFaultIn(this, region);
   }
 
   @Retained
   @Override
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
-    return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, owner);
+  public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
+    return Helper.getValueOffHeapOrDiskWithoutFaultIn(this, region);
   }
 
   @Override
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
-    return Helper.getValueOnDisk(this, r.getDiskRegion());
+  public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
+    return Helper.getValueOnDisk(this, region.getDiskRegion());
   }
 
   @Override
-  public Object getSerializedValueOnDisk(LocalRegion r) throws EntryNotFoundException {
-    return Helper.getSerializedValueOnDisk(this, r.getDiskRegion());
+  public Object getSerializedValueOnDisk(InternalRegion region) throws EntryNotFoundException {
+    return Helper.getSerializedValueOnDisk(this, region.getDiskRegion());
   }
 
   @Override
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+  public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
     // @todo darrel if value is Token.REMOVED || Token.DESTROYED throw
     // EntryNotFoundException
-    return Helper.getValueOnDiskOrBuffer(this, r.getDiskRegion(), r);
+    return Helper.getValueOnDiskOrBuffer(this, region.getDiskRegion(), region);
   }
 
+  @Override
   public DiskEntry getPrev() {
     return getDiskId().getPrev();
   }
 
+  @Override
   public DiskEntry getNext() {
     return getDiskId().getNext();
   }
 
+  @Override
   public void setPrev(DiskEntry v) {
     getDiskId().setPrev(v);
   }
 
+  @Override
   public void setNext(DiskEntry v) {
     getDiskId().setNext(v);
   }
@@ -126,7 +131,7 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
    * tag
    */
   @Override
-  public void persistConflictingTag(LocalRegion region, VersionTag tag) {
+  public void persistConflictingTag(InternalRegion region, VersionTag tag) {
     // only persist region needs to persist conflict tag
     Helper.updateVersionOnly(this, region, tag);
     setRecentlyUsed();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -98,8 +98,8 @@ import org.apache.geode.pdx.internal.PeerTypeRegistration;
  * Takes care of RegionAttributes, AttributesMutator, and some no-brainer method implementations.
  */
 @SuppressWarnings("deprecation")
-public abstract class AbstractRegion implements Region, RegionAttributes, AttributesMutator,
-    CacheStatistics, DataSerializableFixedID, RegionEntryContext, Extensible<Region<?, ?>> {
+public abstract class AbstractRegion implements InternalRegion, AttributesMutator, CacheStatistics,
+    DataSerializableFixedID, Extensible<Region<?, ?>> {
 
   private static final Logger logger = LogService.getLogger();
 
@@ -427,8 +427,6 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   }
 
   abstract Map basicGetAll(Collection keys, Object callback);
-
-  public abstract RegionEntry basicGetEntry(Object key);
 
   protected StringBuilder getStringBuilder() {
     StringBuilder buf = new StringBuilder();
@@ -808,6 +806,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   /**
    * Get IndexManger for region
    */
+  @Override
   public IndexManager getIndexManager() {
     return this.indexManager;
   }
@@ -845,7 +844,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   // block
   // in case the value of the entry is "REMOVED" token. This prevents dead lock
   // caused by the Bug # 33336
-  boolean isIndexCreationThread() {
+  @Override
+  public boolean isIndexCreationThread() {
     Boolean value = isIndexCreator.get();
     return value != null ? value : false;
   }
@@ -1473,7 +1473,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
    *
    * @since GemFire 5.0
    */
-  protected boolean isProxy() {
+  @Override
+  public boolean isProxy() {
     return getDataPolicy().isEmpty();
   }
 
@@ -1515,7 +1516,8 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   /**
    * Returns true if this region could expire an entry
    */
-  boolean isEntryExpiryPossible() {
+  @Override
+  public boolean isEntryExpiryPossible() {
     return this.entryExpiryPossible;
   }
 
@@ -1760,6 +1762,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
     return this.cache;
   }
 
+  @Override
   public DM getDistributionManager() {
     return getSystem().getDistributionManager();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionEntry.java
@@ -47,6 +47,7 @@ import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.persistence.DiskStoreID;
 import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
@@ -202,8 +203,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModifiedAndAccessedTimes(currTime, currTime);
+  public void txDidDestroy(long currentTime) {
+    setLastModifiedAndAccessedTimes(currentTime, currentTime);
   }
 
   @Override
@@ -231,7 +232,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException {
+  public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
     _removePhase1();
   }
 
@@ -241,37 +242,38 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException {
-    assert r.getVersionVector() != null;
+  public void makeTombstone(InternalRegion region, VersionTag version)
+      throws RegionClearedException {
+    assert region.getVersionVector() != null;
     assert version != null;
-    if (r.getServerProxy() == null && r.getVersionVector().isTombstoneTooOld(version.getMemberID(),
-        version.getRegionVersion())) {
+    if (region.getServerProxy() == null && region.getVersionVector()
+        .isTombstoneTooOld(version.getMemberID(), version.getRegionVersion())) {
       // distributed gc with higher vector version preempts this operation
       if (!isTombstone()) {
-        basicMakeTombstone(r);
-        r.incTombstoneCount(1);
+        basicMakeTombstone(region);
+        region.getCachePerfStats().incTombstoneCount(1);
       }
-      r.getRegionMap().removeTombstone(this, version, false, true);
+      ((DiskRecoveryStore) region).getRegionMap().removeTombstone(this, version, false, true);
     } else {
       if (isTombstone()) {
         // unschedule the old tombstone
-        r.unscheduleTombstone(this);
+        region.unscheduleTombstone(this);
       }
       setRecentlyUsed();
       boolean newEntry = getValueAsToken() == Token.REMOVED_PHASE1;
-      basicMakeTombstone(r);
-      r.scheduleTombstone(this, version);
+      basicMakeTombstone(region);
+      region.scheduleTombstone(this, version);
       if (newEntry) {
         // bug #46631 - entry count is decremented by scheduleTombstone but this is a new entry
-        r.getCachePerfStats().incEntryCount(1);
+        region.getCachePerfStats().incEntryCount(1);
       }
     }
   }
 
-  private void basicMakeTombstone(LocalRegion r) throws RegionClearedException {
+  private void basicMakeTombstone(InternalRegion region) throws RegionClearedException {
     boolean setValueCompleted = false;
     try {
-      setValue(r, Token.TOMBSTONE);
+      setValue(region, Token.TOMBSTONE);
       setValueCompleted = true;
     } finally {
       if (!setValueCompleted && isTombstone()) {
@@ -326,7 +328,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean fillInValue(LocalRegion region,
+  public boolean fillInValue(InternalRegion region,
       @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in, DM mgr,
       final Version version) {
 
@@ -417,7 +419,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
+  public boolean isOverflowedToDisk(InternalRegion region,
+      DistributedRegion.DiskPosition diskPosition) {
     return false;
   }
 
@@ -425,7 +428,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   public Object getValue(RegionEntryContext context) {
     ReferenceCountHelper.createReferenceCountOwner();
     @Retained
-    Object result = _getValueRetain(context, true);
+    Object result = getValueRetain(context, true);
 
     // If the thread is an Index Creation Thread & the value obtained is
     // Token.REMOVED , we can skip synchronization block. This is required to prevent
@@ -450,7 +453,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   @Retained
   public Object getValueRetain(RegionEntryContext context) {
     @Retained
-    Object result = _getValueRetain(context, true);
+    Object result = getValueRetain(context, true);
     if (Token.isRemoved(result)) {
       return null;
     } else {
@@ -590,7 +593,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   public Object getValueInVM(RegionEntryContext context) {
     ReferenceCountHelper.createReferenceCountOwner();
     @Released
-    Object v = _getValueRetain(context, true);
+    Object v = getValueRetain(context, true);
 
     if (v == null) {
       // should only be possible if disk entry
@@ -602,27 +605,27 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-    return getValueInVM(owner);
+  public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
+    return getValueInVM(region);
   }
 
   @Override
   @Retained
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
+  public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
     @Retained
-    Object result = _getValueRetain(owner, true);
+    Object result = getValueRetain(region, true);
     return result;
   }
 
   @Override
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
+  public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
             .toLocalizedString());
   }
 
   @Override
-  public Object getSerializedValueOnDisk(final LocalRegion localRegion)
+  public Object getSerializedValueOnDisk(final InternalRegion region)
       throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
@@ -630,7 +633,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+  public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
             .toLocalizedString());
@@ -638,15 +641,16 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean initialImagePut(final LocalRegion region, final long lastModified, Object newValue,
-      boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException {
+  public boolean initialImagePut(final InternalRegion region, final long lastModified,
+      Object newValue, boolean wasRecovered, boolean acceptedVersionTag)
+      throws RegionClearedException {
     // note that the caller has already write synced this RegionEntry
     return initialImageInit(region, lastModified, newValue, this.isTombstone(), wasRecovered,
         acceptedVersionTag);
   }
 
   @Override
-  public boolean initialImageInit(final LocalRegion region, final long lastModified,
+  public boolean initialImageInit(final InternalRegion region, final long lastModified,
       final Object newValue, final boolean create, final boolean wasRecovered,
       final boolean acceptedVersionTag) throws RegionClearedException {
 
@@ -754,7 +758,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    */
   @Override
   @Released
-  public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+  public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
       boolean cacheWrite, @Unretained Object expectedOldValue, boolean forceDestroy,
       boolean removeRecoveredEntry) throws CacheWriterException, EntryNotFoundException,
       TimeoutException, RegionClearedException {
@@ -776,7 +780,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     ReferenceCountHelper.skipRefCountTracking();
     @Retained
     @Released
-    Object curValue = _getValueRetain(region, true);
+    Object curValue = getValueRetain(region, true);
     ReferenceCountHelper.unskipRefCountTracking();
     boolean proceed;
     try {
@@ -869,7 +873,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
 
       boolean removeEntry = false;
       VersionTag v = event.getVersionTag();
-      if (region.concurrencyChecksEnabled && !removeRecoveredEntry
+      if (region.isConcurrencyChecksEnabled() && !removeRecoveredEntry
           && !event.isFromRILocalDestroy()) {
         // bug #46780, don't retain tombstones for entries destroyed for register-interest
         // Destroy will write a tombstone instead
@@ -909,13 +913,13 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   static boolean checkExpectedOldValue(@Unretained Object expectedOldValue,
-      @Unretained Object actualValue, LocalRegion lr) {
+      @Unretained Object actualValue, InternalRegion region) {
 
     if (Token.isInvalid(expectedOldValue)) {
       return actualValue == null || Token.isInvalid(actualValue);
     } else {
       boolean isCompressedOffHeap =
-          lr.getAttributes().getOffHeap() && lr.getAttributes().getCompressor() != null;
+          region.getAttributes().getOffHeap() && region.getAttributes().getCompressor() != null;
       return checkEquals(expectedOldValue, actualValue, isCompressedOffHeap);
     }
   }
@@ -1386,7 +1390,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
 
   @Override
   @Unretained
-  public Object _getValue() {
+  public Object getValue() {
     return getValueField();
   }
 
@@ -1439,7 +1443,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public synchronized void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {
+  public synchronized void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
     if (TXManagerImpl.decRefCount(this)) {
       if (isInUseByTransaction()) {
         setInUseByTransaction(false);
@@ -1447,8 +1451,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
           // No more transactions, place in lru list
           lruList.appendEntry((LRUClockNode) this);
         }
-        if (lr != null && lr.isEntryExpiryPossible()) {
-          lr.addExpiryTaskIfAbsent(this);
+        if (region != null && region.isEntryExpiryPossible()) {
+          region.addExpiryTaskIfAbsent(this);
         }
       }
     }
@@ -1496,7 +1500,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   @Override
   @Retained
   public Object getTransformedValue() {
-    return _getValueRetain(null, false);
+    return getValueRetain(null, false);
   }
 
   @Override
@@ -1549,7 +1553,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   protected StringBuilder appendFieldsToString(final StringBuilder sb) {
     // OFFHEAP _getValue ok: the current toString on ObjectChunk is safe to use without incing
     // refcount.
-    sb.append("key=").append(getKey()).append("; rawValue=").append(_getValue());
+    sb.append("key=").append(getKey()).append("; rawValue=").append(getValue());
     VersionStamp stamp = getVersionStamp();
     if (stamp != null) {
       sb.append("; version=").append(stamp.asVersionTag()).append(";member=")
@@ -1563,8 +1567,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    * versioning. It also sets the entry's version stamp to the tag's values.
    */
   @Override
-  public VersionTag generateVersionTag(VersionSource member, boolean withDelta, LocalRegion region,
-      EntryEventImpl event) {
+  public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
+      InternalRegion region, EntryEventImpl event) {
     VersionStamp stamp = this.getVersionStamp();
     if (stamp != null && region.getServerProxy() == null) {
       // clients do not generate versions
@@ -1774,7 +1778,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  protected void basicProcessVersionTag(LocalRegion region, VersionTag tag,
+  protected void basicProcessVersionTag(InternalRegion region, VersionTag tag,
       boolean isTombstoneFromGII, boolean deltaCheck, VersionSource dmId,
       InternalDistributedMember sender, boolean checkForConflict) {
 
@@ -1832,7 +1836,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  private void applyVersionTag(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private void applyVersionTag(InternalRegion region, VersionStamp stamp, VersionTag tag,
       InternalDistributedMember sender) {
     VersionSource mbr = tag.getMemberID();
     if (mbr == null) {
@@ -1852,7 +1856,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   /** perform conflict checking for a stamp/tag */
-  private boolean checkForConflict(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private boolean checkForConflict(InternalRegion region, VersionStamp stamp, VersionTag tag,
       boolean isTombstoneFromGII, boolean deltaCheck, VersionSource dmId,
       InternalDistributedMember sender, StringBuilder verbose) {
 
@@ -1960,12 +1964,12 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     return apply;
   }
 
-  private boolean isExpiredTombstone(LocalRegion region, long timestamp, boolean isTombstone) {
+  private boolean isExpiredTombstone(InternalRegion region, long timestamp, boolean isTombstone) {
     return isTombstone
         && timestamp + TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT <= region.cacheTimeMillis();
   }
 
-  private boolean overwritingOldTombstone(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private boolean overwritingOldTombstone(InternalRegion region, VersionStamp stamp, VersionTag tag,
       StringBuilder verbose) {
     // Tombstone GC does not use locking to stop operations when old tombstones
     // are being removed. Because of this we might get an operation that was applied
@@ -1985,7 +1989,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  protected void persistConflictingTag(LocalRegion region, VersionTag tag) {
+  protected void persistConflictingTag(InternalRegion region, VersionTag tag) {
     // only persist region needs to persist conflict tag
   }
 
@@ -1994,7 +1998,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    * stamp's member id and ensure that the version is only incremented by 1. Otherwise the delta is
    * being applied to a value that does not match the source of the delta.
    */
-  private void checkForDeltaConflict(LocalRegion region, long stampVersion, long tagVersion,
+  private void checkForDeltaConflict(InternalRegion region, long stampVersion, long tagVersion,
       VersionStamp stamp, VersionTag tag, VersionSource dmId, InternalDistributedMember sender,
       StringBuilder verbose) {
 
@@ -2195,11 +2199,11 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    */
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(RegionEntryContext context, boolean decompress) {
     if (decompress) {
-      return decompress(context, _getValue());
+      return decompress(context, getValue());
     } else {
-      return _getValue();
+      return getValue();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -255,7 +255,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     if (oldRe == null && (re instanceof OffHeapRegionEntry) && _isOwnerALocalRegion()
         && _getOwner().isThisRegionBeingClosedOrDestroyed()) {
       // prevent orphan during concurrent destroy (#48068)
-      Object v = re._getValue();
+      Object v = re.getValue();
       if (v != Token.REMOVED_PHASE1 && v != Token.REMOVED_PHASE2 && v instanceof StoredObject
           && ((StoredObject) v).hasRefCount()) {
         if (_getMap().remove(key, re)) {
@@ -404,7 +404,7 @@ public abstract class AbstractRegionMap implements RegionMap {
               // note: it.remove() did not reliably remove the entry so we use remove(K,V) here
               if (_getMap().remove(re.getKey(), re)) {
                 if (OffHeapRegionEntryHelper.doesClearNeedToCheckForOffHeap()) {
-                  GatewaySenderEventImpl.release(re._getValue()); // OFFHEAP _getValue ok
+                  GatewaySenderEventImpl.release(re.getValue()); // OFFHEAP _getValue ok
                 }
                 // If this is an overflow only region, we need to free the entry on
                 // disk at this point.
@@ -562,7 +562,7 @@ public abstract class AbstractRegionMap implements RegionMap {
         @Retained
         @Released
         Object value = oldRe
-            ._getValueRetain((RegionEntryContext) ((AbstractRegionMap) rm)._getOwnerObject(), true);
+            .getValueRetain((RegionEntryContext) ((AbstractRegionMap) rm)._getOwnerObject(), true);
 
         try {
           if (value == Token.NOT_AVAILABLE) {
@@ -2945,9 +2945,9 @@ public abstract class AbstractRegionMap implements RegionMap {
 
         @Retained
         @Released
-        Object oldValueInVM = re._getValueRetain(event.getLocalRegion(), true); // OFFHEAP: re
-                                                                                // synced so can use
-                                                                                // its ref.
+        Object oldValueInVM = re.getValueRetain(event.getLocalRegion(), true); // OFFHEAP: re
+                                                                               // synced so can use
+                                                                               // its ref.
 
         ReferenceCountHelper.unskipRefCountTracking();
         try {
@@ -2960,8 +2960,8 @@ public abstract class AbstractRegionMap implements RegionMap {
       // if the old value is in memory then if it is a GatewaySenderEventImpl then
       // we want to set the old value.
       @Unretained
-      Object ov = re._getValue(); // OFFHEAP _getValue is ok since re is synced and we only use it
-                                  // if its a GatewaySenderEventImpl.
+      Object ov = re.getValue(); // OFFHEAP _getValue is ok since re is synced and we only use it
+                                 // if its a GatewaySenderEventImpl.
       // Since GatewaySenderEventImpl is never stored in an off-heap region nor a compressed region
       // we don't need to worry about ov being compressed.
       if (ov instanceof GatewaySenderEventImpl) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -376,7 +376,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * Search the CM for keys. If found any, return the first found one Otherwise, save the keys into
    * the CM, and return null The thread will acquire the lock before searching.
    * 
-   * @param keys
    * @return first key found in CM null means not found
    */
   private LockObject searchAndLock(Object keys[]) {
@@ -416,8 +415,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   /**
    * After processed the keys, this method will remove them from CM. And notifyAll for each key. The
    * thread needs to acquire lock of CM first.
-   * 
-   * @param keys
    */
   public void removeAndNotifyKeys(Object keys[]) {
     final boolean isTraceEnabled = logger.isTraceEnabled();
@@ -447,8 +444,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * Keep checking if CM has contained any key in keys. If yes, wait for notify, then retry again.
    * This method will block current thread for long time. It only exits when current thread
    * successfully save its keys into CM.
-   * 
-   * @param keys
    */
   public void waitUntilLocked(Object keys[]) {
     final boolean isDebugEnabled = logger.isDebugEnabled();
@@ -587,10 +582,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   /**
    * Fix for Bug#45917 We are updating the seqNumber so that new seqNumbers are generated starting
    * from the latest in the system.
-   * 
-   * @param l
    */
-
   public void updateEventSeqNum(long l) {
     Atomics.setIfGreater(this.eventSeqNum, l);
     if (logger.isDebugEnabled()) {
@@ -720,8 +712,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * Checks to make sure that this node is primary, and locks the bucket to make sure the bucket
    * stays the primary bucket while the write is in progress. Any call to this method must be
    * followed with a call to endLocalWrite().
-   * 
-   * @param event
    */
   private boolean beginLocalWrite(EntryEventImpl event) {
     if (!needWriteLock(event)) {
@@ -1433,8 +1423,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   /**
    * Horribly plagiarized from the similar method in LocalRegion
    * 
-   * @param key
-   * @param updateStats
    * @param clientEvent holder for client version tag
    * @param returnTombstones whether Token.TOMBSTONE should be returned for destroyed entries
    * @return serialized form if present, null if the entry is not in the cache, or INVALID or
@@ -1489,10 +1477,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * <p>
    * Horribly plagiarized from the similar method in LocalRegion
    * 
-   * @param keyInfo
-   * @param generateCallbacks
    * @param clientEvent holder for the entry's version information
-   * @param returnTombstones TODO
    * @return serialized (byte) form
    * @throws IOException if the result is not serializable
    * @see LocalRegion#get(Object, Object, boolean, EntryEventImpl)
@@ -1998,7 +1983,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   @Override
-  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+  public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
 
     boolean origRemoteState = false;
@@ -2134,7 +2119,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
   @Override
   public int calculateRegionEntryValueSize(RegionEntry regionEntry) {
-    return calcMemSize(regionEntry._getValue()); // OFFHEAP _getValue ok
+    return calcMemSize(regionEntry.getValue()); // OFFHEAP _getValue ok
   }
 
   @Override
@@ -2155,7 +2140,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   @Override
-  int updateSizeOnEvict(Object key, int oldSize) {
+  public int updateSizeOnEvict(Object key, int oldSize) {
     int newDiskSize = oldSize;
     updateBucket2Size(oldSize, newDiskSize, SizeOp.EVICT);
     return newDiskSize;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
@@ -345,7 +345,7 @@ public class DiskRegion extends AbstractDiskRegion {
    *         completed successfully, resulting in the put operation to abort.
    * @throws IllegalArgumentException If <code>id</code> is less than zero
    */
-  void put(DiskEntry entry, LocalRegion region, ValueWrapper value, boolean async)
+  void put(DiskEntry entry, InternalRegion region, ValueWrapper value, boolean async)
       throws RegionClearedException {
     getDiskStore().put(region, entry, value, async);
   }
@@ -417,7 +417,7 @@ public class DiskRegion extends AbstractDiskRegion {
     getDiskStore().remove(region, entry, false, false);
   }
 
-  void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear)
+  void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear)
       throws RegionClearedException {
     getDiskStore().remove(region, entry, async, isClear);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -680,7 +680,7 @@ public class DiskStoreImpl implements DiskStore {
    *         completed successfully, resulting in the put operation to abort.
    * @throws IllegalArgumentException If {@code id} is less than zero
    */
-  void put(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async)
+  void put(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async)
       throws RegionClearedException {
     DiskRegion dr = region.getDiskRegion();
     DiskId id = entry.getDiskId();
@@ -748,7 +748,7 @@ public class DiskStoreImpl implements DiskStore {
     }
   }
 
-  void putVersionTagOnly(LocalRegion region, VersionTag tag, boolean async) {
+  void putVersionTagOnly(InternalRegion region, VersionTag tag, boolean async) {
     DiskRegion dr = region.getDiskRegion();
     // this method will only be called by backup oplog
     assert dr.isBackup();
@@ -1049,7 +1049,7 @@ public class DiskStoreImpl implements DiskStore {
    * @throws IllegalArgumentException If {@code id} is {@linkplain #INVALID_ID invalid}or is less
    *         than zero, no action is taken.
    */
-  void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear)
+  void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear)
       throws RegionClearedException {
     DiskRegion dr = region.getDiskRegion();
     if (!async) {
@@ -1238,7 +1238,7 @@ public class DiskStoreImpl implements DiskStore {
 
   private void handleFullAsyncQueue(Object o) {
     AsyncDiskEntry ade = (AsyncDiskEntry) o;
-    LocalRegion region = ade.region;
+    InternalRegion region = ade.region;
     try {
       VersionTag tag = ade.tag;
       if (ade.versionOnly) {
@@ -1273,7 +1273,7 @@ public class DiskStoreImpl implements DiskStore {
         if (dr.didClearCountChange() && !ade.versionOnly) {
           return;
         }
-        if (ade.region.isDestroyed) {
+        if (ade.region.isDestroyed()) {
           throw new RegionDestroyedException(ade.region.toString(), ade.region.getFullPath());
         }
       }
@@ -1706,7 +1706,7 @@ public class DiskStoreImpl implements DiskStore {
                     lr.getDiskRegion().writeRVVGC(lr);
                   } else {
                     AsyncDiskEntry ade = (AsyncDiskEntry) o;
-                    LocalRegion region = ade.region;
+                    InternalRegion region = ade.region;
                     VersionTag tag = ade.tag;
                     if (ade.versionOnly) {
                       DiskEntry.Helper.doAsyncFlush(tag, region);
@@ -3390,19 +3390,19 @@ public class DiskStoreImpl implements DiskStore {
   // }
 
   public static class AsyncDiskEntry {
-    public final LocalRegion region;
+    public final InternalRegion region;
     public final DiskEntry de;
     public final boolean versionOnly;
     public final VersionTag tag;
 
-    public AsyncDiskEntry(LocalRegion region, DiskEntry de, VersionTag tag) {
+    public AsyncDiskEntry(InternalRegion region, DiskEntry de, VersionTag tag) {
       this.region = region;
       this.de = de;
       this.tag = tag;
       this.versionOnly = false;
     }
 
-    public AsyncDiskEntry(LocalRegion region, VersionTag tag) {
+    public AsyncDiskEntry(InternalRegion region, VersionTag tag) {
       this.region = region;
       this.de = null;
       this.tag = tag;
@@ -3621,7 +3621,7 @@ public class DiskStoreImpl implements DiskStore {
     ArrayList<Object> result = new ArrayList<>();
     Pattern pattern = createPdxRenamePattern(oldBase);
     for (RegionEntry re : foundPdx.getRecoveredEntryMap().regionEntries()) {
-      Object value = re._getValueRetain(foundPdx, true);
+      Object value = re.getValueRetain(foundPdx, true);
       if (Token.isRemoved(value)) {
         continue;
       }
@@ -3698,7 +3698,7 @@ public class DiskStoreImpl implements DiskStore {
     PersistentOplogSet oplogSet = (PersistentOplogSet) getOplogSet(foundPdx);
     ArrayList<PdxType> result = new ArrayList<PdxType>();
     for (RegionEntry re : foundPdx.getRecoveredEntryMap().regionEntries()) {
-      Object value = re._getValueRetain(foundPdx, true);
+      Object value = re.getValueRetain(foundPdx, true);
       if (Token.isRemoved(value)) {
         continue;
       }
@@ -3745,7 +3745,7 @@ public class DiskStoreImpl implements DiskStore {
     recoverRegionsThatAreReady();
     ArrayList<PdxType> result = new ArrayList<PdxType>();
     for (RegionEntry re : foundPdx.getRecoveredEntryMap().regionEntries()) {
-      Object value = re._getValueRetain(foundPdx, true);
+      Object value = re.getValueRetain(foundPdx, true);
       if (Token.isRemoved(value)) {
         continue;
       }
@@ -3787,7 +3787,7 @@ public class DiskStoreImpl implements DiskStore {
     recoverRegionsThatAreReady();
     ArrayList<Object> result = new ArrayList<Object>();
     for (RegionEntry re : foundPdx.getRecoveredEntryMap().regionEntries()) {
-      Object value = re._getValueRetain(foundPdx, true);
+      Object value = re.getValueRetain(foundPdx, true);
       if (Token.isRemoved(value)) {
         continue;
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2356,7 +2356,7 @@ public class DistributedRegion extends LocalRegion implements CacheDistributionA
    * @return true if cacheWrite was performed
    */
   @Override
-  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+  public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
 
     boolean result = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1500,10 +1500,10 @@ public class EntryEventImpl
           Object ov;
           if (ReferenceCountHelper.trackReferenceCounts()) {
             ReferenceCountHelper.setReferenceCountOwner(new OldValueOwner());
-            ov = reentry._getValueRetain(owner, true);
+            ov = reentry.getValueRetain(owner, true);
             ReferenceCountHelper.setReferenceCountOwner(null);
           } else {
-            ov = reentry._getValueRetain(owner, true);
+            ov = reentry.getValueRetain(owner, true);
           }
           if (ov == null)
             ov = Token.NOT_AVAILABLE;
@@ -1802,7 +1802,7 @@ public class EntryEventImpl
       if (re == null)
         return false;
       ReferenceCountHelper.skipRefCountTracking();
-      Object v = re._getValueRetain(this.region, true);
+      Object v = re.getValueRetain(this.region, true);
       ReferenceCountHelper.unskipRefCountTracking();
       try {
         return setOldValue(v);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -14,7 +14,18 @@
  */
 package org.apache.geode.internal.cache;
 
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
+import org.apache.geode.cache.query.internal.index.IndexManager;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.cache.versions.VersionSource;
+import org.apache.geode.internal.cache.versions.VersionTag;
 
 /**
  * Interface to be used instead of type-casting to LocalRegion.
@@ -32,7 +43,65 @@ import org.apache.geode.cache.Region;
  * </pre>
  * </ul>
  */
-public interface InternalRegion extends Region, HasCachePerfStats {
+public interface InternalRegion
+    extends Region, HasCachePerfStats, RegionEntryContext, RegionAttributes {
 
   CachePerfStats getCachePerfStats();
+
+  RegionVersionVector getVersionVector();
+
+  long cacheTimeMillis();
+
+  Object getValueInVM(Object key) throws EntryNotFoundException;
+
+  Object getValueOnDisk(Object key) throws EntryNotFoundException;
+
+  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event);
+
+  boolean isUsedForPartitionedRegionAdmin();
+
+  ImageState getImageState();
+
+  VersionSource getVersionMember();
+
+  long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse);
+
+  FilterProfile getFilterProfile();
+
+  ServerRegionProxy getServerProxy();
+
+  void unscheduleTombstone(RegionEntry entry);
+
+  void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion);
+
+  boolean isEntryExpiryPossible();
+
+  void addExpiryTaskIfAbsent(RegionEntry entry);
+
+  DM getDistributionManager();
+
+  void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry);
+
+  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+      throws CacheWriterException, EntryNotFoundException, TimeoutException;
+
+  void recordEvent(InternalCacheEvent event);
+
+  boolean isProxy();
+
+  IndexManager getIndexManager();
+
+  boolean isConcurrencyChecksEnabled();
+
+  boolean isThisRegionBeingClosedOrDestroyed();
+
+  DiskRegion getDiskRegion();
+
+  CancelCriterion getCancelCriterion();
+
+  boolean isIndexCreationThread();
+
+  int updateSizeOnEvict(Object key, int oldSize);
+
+  RegionEntry basicGetEntry(Object key);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
@@ -41,8 +41,6 @@ import org.apache.geode.cache.EntryEvent;
 #endif
 #if defined(DISK) || defined(LRU)
 import org.apache.geode.internal.cache.lru.EnableLRU;
-#endif
-#ifdef DISK
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 #endif
 #ifdef STATS
@@ -66,32 +64,38 @@ import org.apache.geode.internal.offheap.annotations.Unretained;
 #endif
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK
+ * lru: LRU
+ * stats: STATS
+ * versioned: VERSIONED
+ * offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT
+ * key int: KEY_INT
+ * key long: KEY_LONG
+ * key uuid: KEY_UUID
+ * key string1: KEY_STRING1
+ * key string2: KEY_STRING2
+*/
 
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class LEAF_CLASS extends PARENT_CLASS {
-  public LEAF_CLASS  (RegionEntryContext context, KEY_TYPE key, 
+
+  public LEAF_CLASS (final RegionEntryContext context, final KEY_TYPE key,
 #ifdef OFFHEAP
       @Retained
 #endif
-      Object value
+      final Object value
 #if defined(KEY_STRING1) || defined(KEY_STRING2)
-      , boolean byteEncode
+      , final boolean byteEncode
 #endif
       ) {
     super(context, 
@@ -116,52 +120,52 @@ public class LEAF_CLASS extends PARENT_CLASS {
     this.keyLeastSigBits = key.getLeastSignificantBits();
 #elif defined(KEY_STRING1)
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
-      for (int i=key.length()-1; i >= 0; i--) {
+      for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to keep findbugs happy.
-        tmpBits1 |= (byte)key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1<<6;
+      tempBits1 |= 1<<6;
     } else {
-      for (int i=key.length()-1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
 #elif defined(KEY_STRING2)
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
-      for (int i=key.length()-1; i >= 0; i--) {
+      for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte)key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte)key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte)key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte)key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1<<6;
+      tempBits1 |= 1<<6;
     } else {
-      for (int i=key.length()-1; i >= 0; i--) {
+      for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
 #endif
   }
 
@@ -176,10 +180,10 @@ public class LEAF_CLASS extends PARENT_CLASS {
     = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "lastModified");
 #ifdef OFFHEAP
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell it is.
    */
   @SuppressWarnings("unused")
-  @Retained @Released private volatile long ohAddress;
+  @Retained @Released private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called while the re is synced.
    * But if I sync in that code it causes a lock ordering deadlock with the disk regions because they also get a rw lock in clear.
@@ -188,7 +192,7 @@ public class LEAF_CLASS extends PARENT_CLASS {
    * I don't know if we support any of the hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks
    * on disk regions.
    */
-  private final static AtomicLongFieldUpdater<LEAF_CLASS> ohAddrUpdater = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<LEAF_CLASS> offHeapAddressUpdater = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "offHeapAddress");
   
   @Override
   public Token getValueAsToken() {
@@ -201,31 +205,33 @@ public class LEAF_CLASS extends PARENT_CLASS {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
 #ifdef OFFHEAP
   @Unretained
-  protected void setValueField(@Unretained Object v) {
+  protected void setValueField(@Unretained final Object value) {
 #else
-  protected void setValueField(Object v) {
+  protected void setValueField(final Object value) {
 #endif
-    OffHeapRegionEntryHelper.setValue(this, v);
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
+
   @Override
 #ifdef OFFHEAP
   @Retained
 #endif
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
   
   @Override
@@ -238,107 +244,113 @@ public class LEAF_CLASS extends PARENT_CLASS {
   
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
-#else    
+#else
   private volatile Object value;
+
   @Override
   protected Object getValueField() {
     return this.value;
   }
+
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 #endif
+
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
-  protected void setEntryHash(int v) {
-    this.hash = v;
+
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 #ifdef DISK
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   // disk code
+
 #ifdef LRU
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion)drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
+
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
-    int newSize = capacityController.entrySize( getKeyForSizing(), null);
+    int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
     int delta = newSize - oldSize;
     return delta;
   }
 #else
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
+
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 #endif
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore)context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    //get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;//= new DiskId();
+  protected DiskId id;
+  
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
+  
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry)old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 #endif
   
@@ -346,46 +358,61 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
 #ifdef DISK
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
 #else
     // nothing needed for LRUs with no disk
 #endif
   }
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue());  // OFHEAP: _getValue ok w/o incing refcount because we are synced and only getting the size
+  
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
   
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  public synchronized int updateEntrySize(EnableLRU capacityController,
-                                                Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
-    int newSize = capacityController.entrySize( getKeyForSizing(), value);
+    int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
     int delta = newSize - oldSize;
     return delta;
   }
+  
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
+  
   @Override
   public void setRecentlyUsed() {
     setBits(RECENTLY_USED);
   }
+  
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
+  
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
+  
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
+  
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
@@ -393,24 +420,35 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
-  public void setNextLRUNode( LRUClockNode next ) {
-    this.nextLRU = next;
+  
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
+  
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
-  public void setPrevLRUNode( LRUClockNode prev ) {
-    this.prevLRU = prev;
+  
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
+  
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
+  
+  @Override
   public int getEntrySize() {
     return this.size;
   }
-  protected void setEntrySize(int size) {
+  
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -432,28 +470,32 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
     }
   }
+  
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) { 
       setLastAccessed(lastAccessed);
     }
   }
+  
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
   
   private static final AtomicIntegerFieldUpdater<LEAF_CLASS> hitCountUpdater 
     = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<LEAF_CLASS> missCountUpdater 
     = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "missCount");
   
@@ -461,23 +503,29 @@ public class LEAF_CLASS extends PARENT_CLASS {
   public long getLastAccessed() throws InternalStatisticsDisabledException {
     return this.lastAccessed;
   }
-  private void setLastAccessed(long lastAccessed) {
+  
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
+  
   @Override
   public long getHitCount() throws InternalStatisticsDisabledException {
     return this.hitCount & 0xFFFFFFFFL;
   }
+  
   @Override
   public long getMissCount() throws InternalStatisticsDisabledException {
     return this.missCount & 0xFFFFFFFFL;
   }
+  
   private void incrementHitCount() {
     hitCountUpdater.incrementAndGet(this);
   }
+  
   private void incrementMissCount() {
     missCountUpdater.incrementAndGet(this);
   }
+  
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
     hitCountUpdater.set(this,0);
@@ -487,12 +535,13 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
+  
   @Override
   public boolean hasStats() {
     return true;
@@ -503,60 +552,71 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
   
+  @Override
   public long getRegionVersion() {
     return (((long)regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);  
   }
-  
-  
+
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
   
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
+
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
-    this.entryVersionLowBytes = (short)(eVersion & 0xffff);
-    this.entryVersionHighByte = (byte)((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
+    this.entryVersionLowBytes = (short) (eVersion & 0xffff);
+    this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag() && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte)(tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID; 
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId; 
   }
 
   @Override
@@ -566,8 +626,9 @@ public class LEAF_CLASS extends PARENT_CLASS {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -575,25 +636,27 @@ public class LEAF_CLASS extends PARENT_CLASS {
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag,
-      boolean isTombstoneFromGII, boolean hasDelta,
-      VersionSource thisVM, InternalDistributedMember sender, boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender, checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
   
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
@@ -602,8 +665,10 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   // key code
+
 #ifdef KEY_OBJECT
   private final Object key;
+
   @Override
   public Object getKey() {
     return this.key;
@@ -611,28 +676,32 @@ public class LEAF_CLASS extends PARENT_CLASS {
 
 #elif defined(KEY_INT)
   private final int key;
+
   @Override
   public Object getKey() {
     return this.key;
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
   
 #elif defined(KEY_LONG)
   private final long key;
+
   @Override
   public Object getKey() {
     return this.key;
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
@@ -640,14 +709,16 @@ public class LEAF_CLASS extends PARENT_CLASS {
 #elif defined(KEY_UUID)
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
+
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
@@ -656,59 +727,67 @@ public class LEAF_CLASS extends PARENT_CLASS {
   
 #elif defined(KEY_STRING1)
   private final long bits1;
+
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
+
   private int getEncoding() {
     // 0 means encoded as char
     // 1 means encoded as bytes that are all <= 0x7f;
     return (int) (this.bits1 >> 6) & 0x03;
   }
+
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i=0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-      chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i=0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+      chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i=0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i=0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String)k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i=0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i=0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
@@ -716,44 +795,54 @@ public class LEAF_CLASS extends PARENT_CLASS {
   }
   
 #elif defined(KEY_STRING2)
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
+
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
+
   private int getEncoding() {
     // 0 means encoded as char
     // 1 means encoded as bytes that are all <= 0x7f;
     return (int) (this.bits1 >> 6) & 0x03;
   }
+
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i=0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i=0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -763,47 +852,51 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String)k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String)key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i=0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i=0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
 #endif
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
@@ -239,9 +239,6 @@ public class LEAF_CLASS extends PARENT_CLASS {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-//    if (this instanceof VMThinRegionEntryLongKey) {
-//      factory.returnToPool((VMThinRegionEntryLongKey)this);
-//    }
   }
 #else    
   private volatile Object value;
@@ -343,45 +340,6 @@ public class LEAF_CLASS extends PARENT_CLASS {
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry)old).getDiskId();
   }
-//  // inlining DiskId
-//  // always have these fields
-//  /**
-//   * id consists of
-//   * most significant
-//   * 1 byte = users bits
-//   * 2-8 bytes = oplog id
-//   * least significant.
-//   * 
-//   * The highest bit in the oplog id part is set to 1 if the oplog id
-//   * is negative.
-//   * @todo this field could be an int for an overflow only region
-//   */
-//  private long id;
-//  /**
-//   * Length of the bytes on disk.
-//   * This is always set. If the value is invalid then it will be set to 0.
-//   * The most significant bit is used by overflow to mark it as needing to be written.
-//   */
-//  protected int valueLength = 0;
-//  // have intOffset or longOffset
-//  // intOffset
-//  /**
-//   * The position in the oplog (the oplog offset) where this entry's value is
-//   * stored
-//   */
-//  private volatile int offsetInOplog;
-//  // longOffset
-//  /**
-//   * The position in the oplog (the oplog offset) where this entry's value is
-//   * stored
-//   */
-//  private volatile long offsetInOplog;
-//  // have overflowOnly or persistence
-//  // overflowOnly
-//  // no fields
-//  // persistent
-//  /** unique entry identifier * */
-//  private long keyId;
 #endif
   
 #ifdef LRU
@@ -395,7 +353,7 @@ public class LEAF_CLASS extends PARENT_CLASS {
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
 #else
-  // nothing needed for LRUs with no disk
+    // nothing needed for LRUs with no disk
 #endif
   }
   public synchronized int updateEntrySize(EnableLRU capacityController) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -535,6 +535,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return initializingRegion.get();
   }
 
+  @Override
   public CancelCriterion getCancelCriterion() {
     return this.stopper;
   }
@@ -689,6 +690,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   }
 
   /** returns the regions version-vector */
+  @Override
   public RegionVersionVector getVersionVector() {
     return this.versionVector;
   }
@@ -778,6 +780,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
 
   private final InternalDataView sharedDataView;
 
+  @Override
   public ServerRegionProxy getServerProxy() {
     return this.serverRegionProxy;
   }
@@ -837,6 +840,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return this.cache.getInternalDistributedSystem().getDistributedMember();
   }
 
+  @Override
   public VersionSource getVersionMember() {
     if (this.dataPolicy.withPersistence()) {
       return getDiskStore().getDiskStoreID();
@@ -1796,7 +1800,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    * {@link #isDestroyed()} this method will not return true if the cache is closing but has not yet
    * started closing this region.
    */
-  boolean isThisRegionBeingClosedOrDestroyed() {
+  @Override
+  public boolean isThisRegionBeingClosedOrDestroyed() {
     return this.isDestroyed;
   }
 
@@ -2898,7 +2903,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    * @return true if cacheWrite was performed
    * @see DistributedRegion#cacheWriteBeforeDestroy(EntryEventImpl, Object)
    */
-  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+  @Override
+  public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
     boolean result = false;
     // copy into local var to prevent race condition
@@ -3202,7 +3208,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return this.tombstoneCount.get();
   }
 
-  void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion) {
+  @Override
+  public void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion) {
     scheduleTombstone(entry, destroyedVersion, false);
   }
 
@@ -3235,7 +3242,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     scheduleTombstone(entry, version, true);
   }
 
-  void unscheduleTombstone(RegionEntry entry) {
+  @Override
+  public void unscheduleTombstone(RegionEntry entry) {
     unscheduleTombstone(entry, true);
   }
 
@@ -3378,6 +3386,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @since GemFire 3.2
    */
+  @Override
   public Object getValueInVM(Object key) throws EntryNotFoundException {
     return basicGetValueInVM(key, true);
   }
@@ -3448,6 +3457,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @since GemFire 3.2
    */
+  @Override
   public Object getValueOnDisk(Object key) throws EntryNotFoundException {
     // Ok for this to ignore tx state
     RegionEntry re = this.entries.getEntry(key);
@@ -5928,7 +5938,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * generate version tag if it does not exist and set it into the event.
    */
-  void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry) {
+  @Override
+  public void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry) {
     if (entry != null && event.getOperation().isEntry()) {
       EntryEventImpl entryEvent = (EntryEventImpl) event;
       if (!entryEvent.isOriginRemote() && shouldGenerateVersionTag(entry, entryEvent)) {
@@ -5945,8 +5956,14 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * record the event's sequenceId in Region's event state to prevent replay.
    */
+  @Override
   public void recordEvent(InternalCacheEvent event) {
     getEventTracker().recordEvent(event);
+  }
+
+  @Override
+  public boolean isConcurrencyChecksEnabled() {
+    return this.concurrencyChecksEnabled;
   }
 
   /**
@@ -6883,7 +6900,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return expTime != 0 && expTime <= cacheTimeMillis();
   }
 
-  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+  @Override
+  public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
     // Return if the inhibit all notifications flag is set
     boolean isEntryEvent = event instanceof EntryEventImpl;
     if (isEntryEvent) {
@@ -7063,7 +7081,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @return the actual lastModifiedTime used.
    */
-  long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse) {
+  @Override
+  public long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse) {
     long lastAccessed = cacheTimeMillis();
     if (lruRecentUse) {
       // fix for bug 31102
@@ -7773,8 +7792,9 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     }
   }
 
-  void addExpiryTaskIfAbsent(RegionEntry re) {
-    addExpiryTask(re, true);
+  @Override
+  public void addExpiryTaskIfAbsent(RegionEntry entry) {
+    addExpiryTask(entry, true);
   }
 
   void addExpiryTask(RegionEntry re) {
@@ -8141,7 +8161,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * get the ImageState for this region
    */
-  ImageState getImageState() {
+  @Override
+  public ImageState getImageState() {
     return this.imageState;
   }
 
@@ -8511,6 +8532,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
           return this.currentIterator != null && this.currentIterator.hasNext();
         }
 
+        @Override
         public Object next() {
           return next(false);
         }
@@ -8756,6 +8778,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * For internal use only.
    */
+  @Override
   public RegionMap getRegionMap() {
     // OK to ignore tx state
     return this.entries;
@@ -10220,10 +10243,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     // nothing needs to be done here since LocalRegion does not have an advisor.
   }
 
-  /**
-   * @return Returns the isUsedForPartitionedRegionAdmin.
-   */
-  boolean isUsedForPartitionedRegionAdmin() {
+  @Override
+  public boolean isUsedForPartitionedRegionAdmin() {
     return this.isUsedForPartitionedRegionAdmin;
   }
 
@@ -10486,6 +10507,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * Returns the CQ/interest profile for this region
    */
+  @Override
   public FilterProfile getFilterProfile() {
     return this.filterProfile;
   }
@@ -10695,7 +10717,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   }
 
   // TODO: return value is never used
-  int updateSizeOnEvict(Object key, int oldSize) {
+  @Override
+  public int updateSizeOnEvict(Object key, int oldSize) {
     // Only needed by BucketRegion
     return 0;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
@@ -50,10 +50,10 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(RegionEntry re, LocalRegion br, boolean allowTombstones) {
+  public NonLocalRegionEntry(RegionEntry re, InternalRegion br, boolean allowTombstones) {
     this.key = re.getKey();
-    if (allowTombstones && re.isTombstone()) { // client get() operations need to see tombstone
-                                               // values
+    if (allowTombstones && re.isTombstone()) {
+      // client get() operations need to see tombstone values
       this.value = Token.TOMBSTONE;
     } else {
       this.value = re.getValue(br); // OFFHEAP: copy into heap cd
@@ -72,22 +72,18 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(LocalRegion br, Object key, Object value) {
+  public NonLocalRegionEntry(InternalRegion br, Object key, Object value) {
     this.key = key;
     this.value = value;
     Assert.assertTrue(this.value != Token.NOT_AVAILABLE,
         "getEntry did not fault value in from disk");
-    // this.lastModified = re.getLastModified();
-    // this.isRemoved = re.isRemoved();
   }
-
-
 
   /**
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(Region.Entry re, LocalRegion br) {
+  public NonLocalRegionEntry(Region.Entry re, InternalRegion br) {
     this.key = re.getKey();
     this.value = re.getValue();
     if (this.value instanceof CachedDeserializable) {
@@ -114,27 +110,33 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
         + this.versionTag;
   }
 
-  public void makeTombstone(LocalRegion r, VersionTag isOperationRemote) {
+  @Override
+  public void makeTombstone(InternalRegion region, VersionTag version) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public boolean dispatchListenerEvents(EntryEventImpl event) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public VersionStamp getVersionStamp() {
     return this;
   }
 
+  @Override
   public boolean hasValidVersion() {
     return this.versionTag != null && this.versionTag.hasValidVersion();
   }
 
+  @Override
   public void setVersionTimeStamp(long time) {
     throw new UnsupportedOperationException();
   }
 
-  public void processVersionTag(EntryEvent ev) {
+  @Override
+  public void processVersionTag(EntryEvent event) {
     throw new UnsupportedOperationException();
   }
 
@@ -158,51 +160,63 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.versionTag = (VersionTag) DataSerializer.readObject(in);
   }
 
+  @Override
   public long getLastModified() {
     return this.lastModified;
   }
 
+  @Override
   public long getLastAccessed() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public long getHitCount() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public long getMissCount() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public boolean isRemoved() {
     return this.isRemoved;
   }
 
+  @Override
   public boolean isRemovedPhase2() {
     return this.isRemoved;
   }
 
+  @Override
   public boolean isTombstone() {
     return false;
   }
 
-  public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
-      final Version version) {
+  @Override
+  public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
+      DM distributionManager, final Version version) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
+  @Override
+  public boolean isOverflowedToDisk(InternalRegion region,
+      DistributedRegion.DiskPosition diskPosition) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public Object getKey() {
     return this.key;
   }
 
+  @Override
   public Object getValue(RegionEntryContext context) {
     return this.value;
   }
@@ -218,45 +232,53 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   // now for the fun part
+  @Override
   public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void setRecentlyUsed() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void updateStatsForGet(boolean hit, long time) throws StatisticsDisabledException {
     // this method has been made a noop to fix bug 37436
   }
 
-  public void txDidDestroy(long currTime) {
+  @Override
+  public void txDidDestroy(long currentTime) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void resetCounts() throws StatisticsDisabledException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public void removePhase1(LocalRegion r, boolean isClear) {
+  @Override
+  public void removePhase1(InternalRegion region, boolean clear) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void removePhase2() {
     throw new UnsupportedOperationException(
         "Not appropriate for PartitionedRegion.NonLocalRegionEntry");
   }
 
+  @Override
   public void setValue(RegionEntryContext context, Object value) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
@@ -264,7 +286,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public Object _getValue() {
+  public Object getValue() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
@@ -278,7 +300,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(RegionEntryContext context, boolean decompress) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
@@ -291,31 +313,36 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
             .toLocalizedString());
   }
 
+  @Override
   public Object getValueInVM(RegionEntryContext context) {
     return this.value;
   }
 
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
+  @Override
+  public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean initialImagePut(LocalRegion region, long lastModified1, Object newValue,
-      boolean wasRecovered, boolean versionTagAccepted) {
+  @Override
+  public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
+      boolean wasRecovered, boolean acceptedVersionTag) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean initialImageInit(LocalRegion region, long lastModified1, Object newValue,
-      boolean create, boolean wasRecovered, boolean versionTagAccepted) {
+  @Override
+  public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
+      boolean create, boolean wasRecovered, boolean acceptedVersionTag) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+  @Override
+  public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
       boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
       boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
@@ -324,48 +351,47 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
             .toLocalizedString());
   }
 
+  @Override
   public boolean getValueWasResultOfSearch() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public void setValueResultOfSearch(boolean v) {
+  @Override
+  public void setValueResultOfSearch(boolean value) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#getValueOnDiskOrBuffer(org.apache.geode.internal.
-   * cache.LocalRegion)
-   */
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+  @Override
+  public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public Object getSerializedValueOnDisk(LocalRegion localRegion) {
+  @Override
+  public Object getSerializedValueOnDisk(InternalRegion region) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
 
+  @Override
   public boolean hasStats() {
     return false;
   }
 
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
+  @Override
+  public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
     return this.value;
   }
 
   @Override
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
+  public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
     return this.value;
   }
 
@@ -373,41 +399,18 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.key = key2;
   }
 
-  // VersionStamp methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#generateVersionTag(org.apache.geode.distributed.
-   * DistributedMember, boolean)
-   */
-  public VersionTag generateVersionTag(VersionSource member, boolean withDelta, LocalRegion region,
-      EntryEventImpl event) {
+  @Override
+  public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
+      InternalRegion region, EntryEventImpl event) {
     throw new UnsupportedOperationException(); // no text needed - not a customer visible method
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#concurrencyCheck(org.apache.geode.internal.cache.
-   * LocalRegion, org.apache.geode.internal.cache.versions.VersionTag,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember)
-   */
-  public void processVersionTag(LocalRegion r, VersionTag tag, InternalDistributedMember thisVM,
+  public void processVersionTag(InternalRegion r, VersionTag tag, InternalDistributedMember thisVM,
       InternalDistributedMember sender) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getEntryVersion()
-   */
+  @Override
   public int getEntryVersion() {
     if (this.versionTag != null) {
       return this.versionTag.getEntryVersion();
@@ -415,6 +418,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return 0;
   }
 
+  @Override
   public long getRegionVersion() {
     if (this.versionTag != null) {
       return this.versionTag.getRegionVersion();
@@ -422,11 +426,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return 0;
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getMemberID()
-   */
+  @Override
   public VersionSource getMemberID() {
     if (this.versionTag != null) {
       return this.versionTag.getMemberID();
@@ -434,6 +434,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return null;
   }
 
+  @Override
   public int getDistributedSystemId() {
     if (this.versionTag != null) {
       return this.versionTag.getDistributedSystemId();
@@ -441,81 +442,45 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return -1;
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#setEntryVersion(int)
-   */
+  @Override
   public void setVersions(VersionTag tag) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.versions.VersionStamp#setMemberID(org.apache.geode.distributed.
-   * DistributedMember)
-   */
+  @Override
   public void setMemberID(VersionSource memberID) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.versions.VersionStamp#setPreviousMemberID(org.apache.geode.
-   * distributed.DistributedMember)
-   */
   public void setPreviousMemberID(DistributedMember previousMemberID) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#asVersionTag()
-   */
+  @Override
   public VersionTag asVersionTag() {
     return this.versionTag;
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#processVersionTag(org.apache.geode.
-   * internal.cache.LocalRegion, org.apache.geode.internal.cache.versions.VersionTag, boolean,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember)
-   */
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
+  @Override
+  public void processVersionTag(InternalRegion region, VersionTag tag, boolean isTombstoneFromGII,
+      boolean hasDelta, VersionSource versionSource, InternalDistributedMember sender,
+      boolean checkConflicts) {
     throw new UnsupportedOperationException();
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getVersionTimeStamp()
-   */
   @Override
   public long getVersionTimeStamp() {
     return this.versionTag != null ? this.versionTag.getVersionTimeStamp() : 0;
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.versionTag != null ? this.versionTag.getRegionVersionHighBytes() : 0;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.versionTag != null ? this.versionTag.getRegionVersionLowBytes() : 0;
   }
@@ -621,24 +586,33 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public void setInUseByTransaction(boolean v) {}
+  public void setInUseByTransaction(boolean inUseByTransaction) {
+    // nothing
+  }
 
   @Override
-  public void incRefCount() {}
+  public void incRefCount() {
+    // nothing
+  }
 
   @Override
-  public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+  public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+    // nothing
+  }
 
   @Override
-  public void resetRefCount(NewLRUClockHand lruList) {}
+  public void resetRefCount(NewLRUClockHand lruList) {
+    // nothing
+  }
 
   @Override
-  public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+  public Object prepareValueForCache(RegionEntryContext context, Object value,
+      boolean isEntryUpdate) {
     throw new IllegalStateException("Should never be called");
   }
 
   @Override
-  public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
+  public Object prepareValueForCache(RegionEntryContext context, Object value, EntryEventImpl event,
       boolean isEntryUpdate) {
     throw new IllegalStateException("Should never be called");
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
@@ -19,11 +19,11 @@ import org.apache.geode.internal.cache.DiskEntry.Helper.ValueWrapper;
 public interface OplogSet {
 
 
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
 
-  public void modify(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
 
   public CompactableOplog getChild(long oplogId);
 
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear);
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/OverflowOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/OverflowOplogSet.java
@@ -37,11 +37,9 @@ public class OverflowOplogSet implements OplogSet {
   private static final Logger logger = LogService.getLogger();
 
   private final AtomicInteger overflowOplogId = new AtomicInteger(0);
-  private OverflowOplog lastOverflowWrite = null;
-  private final ConcurrentMap<Integer, OverflowOplog> overflowMap =
-      new ConcurrentHashMap<Integer, OverflowOplog>();
-  private final Map<Integer, OverflowOplog> compactableOverflowMap =
-      new LinkedHashMap<Integer, OverflowOplog>();
+  private OverflowOplog lastOverflowWrite;
+  private final ConcurrentMap<Integer, OverflowOplog> overflowMap = new ConcurrentHashMap<>();
+  private final Map<Integer, OverflowOplog> compactibleOverflowMap = new LinkedHashMap<>();
 
   private int lastOverflowDir = 0;
 
@@ -51,14 +49,13 @@ public class OverflowOplogSet implements OplogSet {
     this.parent = parent;
   }
 
-
   OverflowOplog getActiveOverflowOplog() {
     return this.lastOverflowWrite;
   }
 
   @Override
-  public void modify(LocalRegion lr, DiskEntry entry, ValueWrapper value, boolean async) {
-    DiskRegion dr = lr.getDiskRegion();
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+    DiskRegion dr = region.getDiskRegion();
     synchronized (this.overflowMap) {
       if (this.lastOverflowWrite != null) {
         if (this.lastOverflowWrite.modify(dr, entry, value, async)) {
@@ -81,7 +78,6 @@ public class OverflowOplogSet implements OplogSet {
   private DirectoryHolder[] getDirectories() {
     return parent.directories;
   }
-
 
   /**
    * @param minSize the minimum size this oplog can be
@@ -163,8 +159,8 @@ public class OverflowOplogSet implements OplogSet {
 
   void removeOverflow(OverflowOplog oo) {
     if (!basicRemoveOverflow(oo)) {
-      synchronized (this.compactableOverflowMap) {
-        this.compactableOverflowMap.remove(oo.getOplogId());
+      synchronized (this.compactibleOverflowMap) {
+        this.compactibleOverflowMap.remove(oo.getOplogId());
       }
     }
   }
@@ -176,14 +172,12 @@ public class OverflowOplogSet implements OplogSet {
     return this.overflowMap.remove(oo.getOplogId(), oo);
   }
 
-
-
   public void closeOverflow() {
     for (OverflowOplog oo : this.overflowMap.values()) {
       oo.destroy();
     }
-    synchronized (this.compactableOverflowMap) {
-      for (OverflowOplog oo : this.compactableOverflowMap.values()) {
+    synchronized (this.compactibleOverflowMap) {
+      for (OverflowOplog oo : this.compactibleOverflowMap.values()) {
         oo.destroy();
       }
     }
@@ -204,8 +198,6 @@ public class OverflowOplogSet implements OplogSet {
       }
     }
   }
-
-
 
   void copyForwardForOverflowCompact(DiskEntry de, byte[] valueBytes, int length, byte userBits) {
     synchronized (this.overflowMap) {
@@ -232,37 +224,34 @@ public class OverflowOplogSet implements OplogSet {
   public OverflowOplog getChild(int oplogId) {
     OverflowOplog result = this.overflowMap.get(oplogId);
     if (result == null) {
-      synchronized (this.compactableOverflowMap) {
-        result = this.compactableOverflowMap.get(oplogId);
+      synchronized (this.compactibleOverflowMap) {
+        result = this.compactibleOverflowMap.get(oplogId);
       }
     }
     return result;
   }
 
-
   @Override
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     modify(region, entry, value, async);
   }
 
-
   @Override
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear) {
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear) {
     removeOverflow(region.getDiskRegion(), entry);
   }
 
   void addOverflowToBeCompacted(OverflowOplog oplog) {
-    synchronized (this.compactableOverflowMap) {
-      this.compactableOverflowMap.put(oplog.getOplogId(), oplog);
+    synchronized (this.compactibleOverflowMap) {
+      this.compactibleOverflowMap.put(oplog.getOplogId(), oplog);
     }
     basicRemoveOverflow(oplog);
     parent.scheduleCompaction();
   }
 
-
   public void getCompactableOplogs(List<CompactableOplog> l, int max) {
-    synchronized (this.compactableOverflowMap) {
-      Iterator<OverflowOplog> itr = this.compactableOverflowMap.values().iterator();
+    synchronized (this.compactibleOverflowMap) {
+      Iterator<OverflowOplog> itr = this.compactibleOverflowMap.values().iterator();
       while (itr.hasNext() && l.size() < max) {
         OverflowOplog oplog = itr.next();
         if (oplog.needsCompaction()) {
@@ -282,8 +271,8 @@ public class OverflowOplogSet implements OplogSet {
         }
       }
     }
-    synchronized (this.compactableOverflowMap) {
-      for (OverflowOplog oo : this.compactableOverflowMap.values()) {
+    synchronized (this.compactibleOverflowMap) {
+      for (OverflowOplog oo : this.compactibleOverflowMap.values()) {
         FileChannel oplogFileChannel = oo.getFileChannel();
         try {
           oplogFileChannel.close();
@@ -294,14 +283,14 @@ public class OverflowOplogSet implements OplogSet {
   }
 
   ArrayList<OverflowOplog> testHookGetAllOverflowOplogs() {
-    ArrayList<OverflowOplog> result = new ArrayList<OverflowOplog>();
+    ArrayList<OverflowOplog> result = new ArrayList<>();
     synchronized (this.overflowMap) {
       for (OverflowOplog oo : this.overflowMap.values()) {
         result.add(oo);
       }
     }
-    synchronized (this.compactableOverflowMap) {
-      for (OverflowOplog oo : this.compactableOverflowMap.values()) {
+    synchronized (this.compactibleOverflowMap) {
+      for (OverflowOplog oo : this.compactibleOverflowMap.values()) {
         result.add(oo);
       }
     }
@@ -315,13 +304,12 @@ public class OverflowOplogSet implements OplogSet {
         oo.close();
       }
     }
-    synchronized (this.compactableOverflowMap) {
-      for (OverflowOplog oo : this.compactableOverflowMap.values()) {
+    synchronized (this.compactibleOverflowMap) {
+      for (OverflowOplog oo : this.compactibleOverflowMap.values()) {
         oo.close();
       }
     }
   }
-
 
   public DiskStoreImpl getParent() {
     return parent;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -7699,7 +7699,7 @@ public class PartitionedRegion extends LocalRegion
   }
 
   @Override
-  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+  public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
     // don't dispatch the event if the interest policy forbids it
     if (hasListener()) {
       if (event.getOperation().isEntry()) {
@@ -7794,7 +7794,7 @@ public class PartitionedRegion extends LocalRegion
    * @see BucketRegion#cacheWriteBeforeDestroy(EntryEventImpl, Object)
    */
   @Override
-  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+  public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
     // return if notifications are inhibited
     if (event.inhibitAllNotifications()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -178,12 +178,12 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   @Override
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     getChild().create(region, entry, value, async);
   }
 
   @Override
-  public void modify(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     getChild().modify(region, entry, value, async);
   }
 
@@ -193,7 +193,7 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   @Override
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear) {
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear) {
     getChild().remove(region, entry, async, isClear);
   }
 
@@ -1034,9 +1034,6 @@ public class PersistentOplogSet implements OplogSet {
 
   /**
    * Add compactable oplogs to the list, up to the maximum size.
-   * 
-   * @param l
-   * @param max
    */
   public void getCompactableOplogs(List<CompactableOplog> l, int max) {
     synchronized (this.oplogIdToOplog) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ABSTRACT_REGION_ENTRY_FILL_IN_VALUE;
@@ -41,30 +40,19 @@ import org.apache.geode.internal.offheap.annotations.Unretained;
  * which has its own entry class. The "value" field of each of these entries will implement this
  * interface.
  *
+ * Our RegionEntry does not need to keep a reference to the key. It is being referenced by the
+ * Map.Entry whose value field references this RegionEntry.
+ *
  * @since GemFire 3.5.1
- *
- * 
- *        Implementations: (unshared) ThinEntry protected volatile long lastModified; StatsEntry
- *        extends ThinEntry private volatile long lastAccessed; private volatile int hitCount;
- *        private volatile int missCount; DiskThinEntry extends ThinEntry private volatile long id;
- *        DiskStatsEntry extends StatsEntry private volatile long id; ThinLRUEntry extends ThinEntry
- *        int bitField1; LRUClockNode nextLRU; int size; StatsLRUEntry extends StatsEntry int
- *        bitField1; LRUClockNode nextLRU; int size; DiskThinLRUEntry extends ThinLRUEntry private
- *        volatile long id; DiskStatsLRUEntry extends StatsLRUEntry private volatile long id;
- *
  */
 public interface RegionEntry {
-  // Our RegionEntry does not need to keep a reference to the key.
-  // It is being referenced by the Map.Entry whose value field
-  // references this RegionEntry.
-  // Object getKey();
 
   /**
    * returns the time of last modification. Prior to v7.0 this only reflected creation time of an
    * entry or the time it was last modified with an Update. In 7.0 and later releases it also
    * reflects invalidate and destroy.
    */
-  public long getLastModified();
+  long getLastModified();
 
   /**
    * Returns true if getLastAccessed, getHitCount, and getMissCount can be called without throwing
@@ -72,20 +60,20 @@ public interface RegionEntry {
    * 
    * @since GemFire 6.0
    */
-  public boolean hasStats();
+  boolean hasStats();
 
-  public long getLastAccessed() throws InternalStatisticsDisabledException;
+  long getLastAccessed() throws InternalStatisticsDisabledException;
 
-  public long getHitCount() throws InternalStatisticsDisabledException;
+  long getHitCount() throws InternalStatisticsDisabledException;
 
-  public long getMissCount() throws InternalStatisticsDisabledException;
+  long getMissCount() throws InternalStatisticsDisabledException;
 
-  public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime);
+  void updateStatsForPut(long lastModifiedTime, long lastAccessedTime);
 
   /**
    * @return the version information for this entry
    */
-  public VersionStamp getVersionStamp();
+  VersionStamp getVersionStamp();
 
   /**
    * @param member the member performing the change, or null if it's this member
@@ -94,7 +82,7 @@ public interface RegionEntry {
    * @param event the event causing this change
    * @return a new version tag for this entry (null if versions not supported)
    */
-  public VersionTag generateVersionTag(VersionSource member, boolean withDelta, LocalRegion region,
+  VersionTag generateVersionTag(VersionSource member, boolean withDelta, InternalRegion region,
       EntryEventImpl event);
 
   /**
@@ -104,75 +92,74 @@ public interface RegionEntry {
    * 
    * This is done within the RegionEntry synchronization lock.
    */
-  public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException;
+  boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException;
 
   /**
    * Used to mark an LRU entry as having been recently used.
    */
-  public void setRecentlyUsed();
+  void setRecentlyUsed();
 
-  public void updateStatsForGet(boolean hit, long time);
+  void updateStatsForGet(boolean hit, long time);
 
   /**
    * Resets any entry state as needed for a transaction that did a destroy to this entry.
    * 
-   * @param currTime Current Cache Time.
+   * @param currentTime Current Cache Time.
    */
-  public void txDidDestroy(long currTime);
+  void txDidDestroy(long currentTime);
 
-  public void resetCounts() throws InternalStatisticsDisabledException;
+  void resetCounts() throws InternalStatisticsDisabledException;
 
   /**
    * this is done instead of removePhase2 if the entry needs to be kept for concurrency control
    * 
-   * @param r the region holding the entry
+   * @param region the region holding the entry
    * @param version whether the operation is from another member or local
-   * @throws RegionClearedException
    */
-  public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException;
+  void makeTombstone(InternalRegion region, VersionTag version) throws RegionClearedException;
 
   /**
    * Mark this entry as being in the process of removal from the map that contains it by setting its
    * value to Token.REMOVED_PHASE1. An entry in this state may be resurrected by changing the value
    * under synchronization prior to the entry executing removePhase2.
-   * 
-   * @param r LocalRegion
+   *
+   * @param region the region
    * @param clear - if we removing this entry as a result of a region clear.
    * @throws RegionClearedException If operation got aborted due to a clear
    * 
    */
-  public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException;
+  void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException;
 
   /**
    * Mark this entry as having been removed from the map that contained it by setting its value to
    * Token.REMOVED_PHASE2
    */
-  public void removePhase2();
+  void removePhase2();
 
   /**
    * Returns true if this entry does not exist. This is true if removal has started (value ==
    * Token.REMOVED_PHASE1) or has completed (value == Token.REMOVED_PHASE2).
    */
-  public boolean isRemoved();
+  boolean isRemoved();
 
   /**
    * Returns true if this entry does not exist and will not be resurrected (value ==
    * Token.REMOVED_PHASE2)
    */
-  public boolean isRemovedPhase2();
+  boolean isRemovedPhase2();
 
   /**
    * Returns true if this entry is a tombstone, meaning that it has been removed but is being
    * retained for concurrent modification detection. Tombstones may be resurrected just like an
    * entry that is in REMOVED_PHASE1 state.
    */
-  public boolean isTombstone();
+  boolean isTombstone();
 
   /**
    * Fill in value, and isSerialized fields in this entry object (used for getInitialImage and sync
    * recovered) Also sets the lastModified time in cacheTime. Only called for DistributedRegions.
+   *
    * <p>
-   * 
    * This method returns tombstones so that they can be transferred with the initial image.
    *
    * @see InitialImageOperation.RequestImageMessage#chunkEntries
@@ -180,42 +167,41 @@ public interface RegionEntry {
    * @return false if map entry not found
    * @since GemFire 3.2.1
    */
-  public boolean fillInValue(LocalRegion r,
-      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in, DM mgr,
-      final Version version);
+  boolean fillInValue(InternalRegion region,
+      @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in,
+      DM distributionManager, final Version version);
 
   /**
    * Returns true if this entry has overflowed to disk.
    * 
-   * @param dp if overflowed then the position of the value is set in dp
+   * @param diskPosition if overflowed then the position of the value is set in dp
    */
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp);
+  boolean isOverflowedToDisk(InternalRegion region, DistributedRegion.DiskPosition diskPosition);
 
   /**
    * Gets the key for this entry.
    */
-  public Object getKey();
+  Object getKey();
 
   /**
    * Gets the value for this entry. For DiskRegions, faults in value and returns it
    */
-  public Object getValue(RegionEntryContext context);
+  Object getValue(RegionEntryContext context);
 
   /**
    * Just like getValue but the result may be a retained off-heap reference.
    */
   @Retained
-  public Object getValueRetain(RegionEntryContext context);
+  Object getValueRetain(RegionEntryContext context);
 
   @Released
-  public void setValue(RegionEntryContext context, @Unretained Object value)
-      throws RegionClearedException;
+  void setValue(RegionEntryContext context, @Unretained Object value) throws RegionClearedException;
 
   /**
    * This flavor of setValue was added so that the event could be passed down to Helper.writeToDisk.
    * The event can be used to cache the serialized form of the value we are writing. See bug 43781.
    */
-  public void setValue(RegionEntryContext context, Object value, EntryEventImpl event)
+  void setValue(RegionEntryContext context, Object value, EntryEventImpl event)
       throws RegionClearedException;
 
   /**
@@ -230,18 +216,19 @@ public interface RegionEntry {
    * @return possible OFF_HEAP_OBJECT (caller must release)
    */
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress);
+  Object getValueRetain(RegionEntryContext context, boolean decompress);
 
-  /** Gets the value field of this entry. */
-
+  /**
+   * Gets the value field of this entry.
+   */
   @Unretained
-  public Object _getValue();
+  Object getValue();
 
   /**
    * Returns a tokenized form of the value. If the value can not be represented as a token then
    * Token.NOT_A_TOKEN is returned.
    */
-  public Token getValueAsToken();
+  Token getValueAsToken();
 
   /**
    * Set the value of this entry and perform checks to see if a GC task needs to be scheduled.
@@ -250,7 +237,7 @@ public interface RegionEntry {
    * @param event the cache event that caused this change
    * @throws RegionClearedException thrown if the region is concurrently cleared
    */
-  public void setValueWithTombstoneCheck(@Unretained Object value, EntryEvent event)
+  void setValueWithTombstoneCheck(@Unretained Object value, EntryEvent event)
       throws RegionClearedException;
 
   /**
@@ -260,7 +247,7 @@ public interface RegionEntry {
    * @since GemFire 8.0
    */
   @Retained
-  public Object getTransformedValue();
+  Object getTransformedValue();
 
   /**
    * Returns the value of an entry as it resides in the VM.
@@ -268,46 +255,54 @@ public interface RegionEntry {
    * @return the value or EntryEvent.NOT_AVAILABLE token if it's not in the VM or null if the entry
    *         doesn't exist.
    *
-   * @see LocalRegion#getValueInVM
+   * @see InternalRegion#getValueInVM
    */
-  public Object getValueInVM(RegionEntryContext context);
+  Object getValueInVM(RegionEntryContext context);
 
   /**
    * Returns the value of an entry as it resides on disk. For testing purposes only.
    *
-   * @see LocalRegion#getValueOnDisk
+   * @see InternalRegion#getValueOnDisk
    */
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException;
+  Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException;
 
   /**
    * Returns the value of an entry as it resides on buffer or disk. For asynch mode a value is not
    * immediately written to the disk & so checking in asynch buffers is needed .For testing purposes
    * only.
    *
-   * @see LocalRegion#getValueOnDisk
+   * @see InternalRegion#getValueOnDisk
    */
-
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException;
-
-
+  Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException;
 
   /**
    * Used to modify an existing RegionEntry when processing the values obtained during a
    * getInitialImage.
    */
-  public boolean initialImagePut(LocalRegion region, long lastModified, Object newValue,
+  boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
       boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException;
 
   /**
    * Used to initialize a created RegionEntry when processing the values obtained during a
-   * getInitialImage. // put if LOCAL_INVALID and nonexistant // put if INVALID and nonexistant,
-   * recovered, or LOCAL_INVALID // put if valid and nonexistant, recovered, or LOCAL_INVALID // //
-   * REGION_INVALIDATED: (special case) // If the region itself has been invalidated since
-   * getInitialImage // started, and newValue is LOCAL_INVALID or valid, // then force creation of
-   * INVALID key if currently nonexistant // or invalidate if current recovered. // // must
-   * write-synchronize to protect agains puts from other // threads running this method
+   * getInitialImage.
+   *
+   * <p>
+   * put if LOCAL_INVALID and nonexistant<br>
+   * put if INVALID and nonexistant, recovered, or LOCAL_INVALID<br>
+   * put if valid and nonexistant, recovered, or LOCAL_INVALID
+   *
+   * <p>
+   * REGION_INVALIDATED: (special case)<br>
+   * If the region itself has been invalidated since getInitialImage<br>
+   * started, and newValue is LOCAL_INVALID or valid,<br>
+   * then force creation of INVALID key if currently nonexistent<br>
+   * or invalidate if current recovered.<br>
+   *
+   * <p>
+   * must write-synchronize to protect against puts from other<br>
+   * threads running this method
    */
-  public boolean initialImageInit(LocalRegion region, long lastModified, Object newValue,
+  boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
       boolean create, boolean wasRecovered, boolean acceptedVersionTag)
       throws RegionClearedException;
 
@@ -318,7 +313,7 @@ public interface RegionEntry {
    * @return true if destroy was done; false if not
    */
   @Released
-  public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+  boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
       boolean cacheWrite, @Unretained Object expectedOldValue, boolean forceDestroy,
       boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException, RegionClearedException;
@@ -327,29 +322,29 @@ public interface RegionEntry {
    * @return true if entry's value came from a netsearch
    * @since GemFire 6.5
    */
-  public boolean getValueWasResultOfSearch();
+  boolean getValueWasResultOfSearch();
 
   /**
-   * @param v true if entry's value should be marked as having been the result of a netsearch.
+   * @param value true if entry's value should be marked as having been the result of a netsearch.
    * @since GemFire 6.5
    */
-  public void setValueResultOfSearch(boolean v);
+  void setValueResultOfSearch(boolean value);
 
   /**
    * Get the serialized bytes from disk. This method only looks for the value on the disk, ignoring
    * heap data.
    * 
-   * @param localRegion the persistent region
+   * @param region the persistent region
    * @return the serialized value from disk
    * @since GemFire 5.7
    */
-  public Object getSerializedValueOnDisk(LocalRegion localRegion);
+  Object getSerializedValueOnDisk(InternalRegion region);
 
   /**
    * Gets the value for this entry. For DiskRegions, unlike {@link #getValue(RegionEntryContext)}
    * this will not fault in the value rather return a temporary copy.
    */
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner);
+  Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region);
 
   /**
    * Gets the value for this entry. For DiskRegions, unlike {@link #getValue(RegionEntryContext)}
@@ -357,7 +352,7 @@ public interface RegionEntry {
    * kept off heap (and compressed) if possible.
    */
   @Retained
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner);
+  Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region);
 
   /**
    * RegionEntry is underUpdate as soon as RegionEntry lock is help by an update thread to put a new
@@ -366,15 +361,13 @@ public interface RegionEntry {
    *
    * @return true if RegionEntry is under update during cache put operation.
    */
-  public boolean isUpdateInProgress();
+  boolean isUpdateInProgress();
 
   /**
    * Sets RegionEntry updateInProgress flag when put is happening for an existing Region.Entry.
    * Called ONLY in {@link AbstractRegionMap}.
-   *
-   * @param underUpdate
    */
-  public void setUpdateInProgress(final boolean underUpdate);
+  void setUpdateInProgress(final boolean underUpdate);
 
   /**
    * Event containing this RegionEntry is being passed through dispatchListenerEvent for
@@ -383,82 +376,80 @@ public interface RegionEntry {
    * 
    * @return true if Event is being dispatched to CacheListeners.
    */
-  public boolean isCacheListenerInvocationInProgress();
+  boolean isCacheListenerInvocationInProgress();
 
   /**
    * Sets RegionEntry isCacheListenerInvoked flag when put is happening for a Region.Entry. Called
-   * ONLY in {@link LocalRegion#dispatchListenerEvent}.
-   * 
-   * @param isListenerInvoked
+   * ONLY in {@link InternalRegion#dispatchListenerEvent}.
    */
-  public void setCacheListenerInvocationInProgress(final boolean isListenerInvoked);
+  void setCacheListenerInvocationInProgress(final boolean isListenerInvoked);
 
   /**
    * Returns true if the entry value is null.
    */
-  public boolean isValueNull();
+  boolean isValueNull();
 
   /**
    * Returns true if the entry value is equal to {@link Token#INVALID} or
    * {@link Token#LOCAL_INVALID}.
    */
-  public boolean isInvalid();
+  boolean isInvalid();
 
   /**
    * Returns true if the entry value is equal to {@link Token#DESTROYED}.
    */
-  public boolean isDestroyed();
+  boolean isDestroyed();
 
   /**
    * Returns true if the entry value is equal to {@link Token#DESTROYED} or
    * {@link Token#REMOVED_PHASE1} or {@link Token#REMOVED_PHASE2} or {@link Token#TOMBSTONE}.
    */
-  public boolean isDestroyedOrRemoved();
+  boolean isDestroyedOrRemoved();
 
   /**
    * Returns true if the entry value is equal to {@link Token#DESTROYED} or
    * {@link Token#REMOVED_PHASE1} or {@link Token#REMOVED_PHASE2}.
    */
-  public boolean isDestroyedOrRemovedButNotTombstone();
+  boolean isDestroyedOrRemovedButNotTombstone();
 
   /**
    * @see Token#isInvalidOrRemoved(Object)
    */
-  public boolean isInvalidOrRemoved();
+  boolean isInvalidOrRemoved();
 
   /**
    * Sets the entry value to null.
    */
-  public void setValueToNull();
+  void setValueToNull();
 
-  public void returnToPool();
+  void returnToPool();
 
-  public boolean isInUseByTransaction();
+  boolean isInUseByTransaction();
 
-  public void setInUseByTransaction(final boolean v);
+  void setInUseByTransaction(final boolean inUseByTransaction);
 
   /**
    * Increments the number of transactions that are currently referencing this node.
    */
-  public void incRefCount();
+  void incRefCount();
 
   /**
    * Decrements the number of transactions that are currently referencing this node.
    * 
-   * @param lr the local region that owns this region entry; null if no local region owner
+   * @param region the local region that owns this region entry; null if no local region owner
    */
-  public void decRefCount(NewLRUClockHand lruList, LocalRegion lr);
+  void decRefCount(NewLRUClockHand lruList, InternalRegion region);
 
   /**
    * Clear the number of transactions that are currently referencing this node and returns to LRU
    * list
    */
-  public void resetRefCount(NewLRUClockHand lruList);
+  void resetRefCount(NewLRUClockHand lruList);
 
   @Retained(ABSTRACT_REGION_ENTRY_PREPARE_VALUE_FOR_CACHE)
-  public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate);
+  Object prepareValueForCache(RegionEntryContext context, Object value, boolean isEntryUpdate);
 
   @Retained(ABSTRACT_REGION_ENTRY_PREPARE_VALUE_FOR_CACHE)
-  public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
+  Object prepareValueForCache(RegionEntryContext context, Object value, EntryEventImpl event,
       boolean isEntryUpdate);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +128,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +153,14 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +170,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +204,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +233,13 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +262,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
@@ -394,7 +301,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -408,14 +314,8 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -430,8 +330,5 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,41 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +84,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,62 +93,61 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -128,49 +155,60 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -178,6 +216,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -187,64 +226,83 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -252,8 +310,8 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -262,8 +320,10 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "missCount");
 
@@ -272,7 +332,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -301,10 +361,11 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -314,8 +375,13 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -324,11 +390,15 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +128,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +153,14 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +170,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +204,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +233,13 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +262,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> missCountUpdater =
@@ -394,7 +301,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -408,12 +314,8 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -428,8 +330,5 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,41 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +84,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,62 +93,61 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -128,49 +155,60 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -178,6 +216,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -187,64 +226,83 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -252,8 +310,8 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -262,8 +320,10 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "missCount");
 
@@ -272,7 +332,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -301,10 +361,11 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -314,8 +375,13 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -324,11 +390,15 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,42 +15,67 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,6 +84,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -67,62 +93,61 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -130,49 +155,60 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -180,6 +216,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -189,64 +226,83 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -254,8 +310,8 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -264,9 +320,11 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "missCount");
@@ -276,7 +334,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -305,10 +363,11 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -318,13 +377,22 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,70 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +59,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +104,8 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +130,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +155,14 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +172,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +206,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +235,13 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +264,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -396,7 +305,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -410,20 +318,13 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,28 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -44,34 +35,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -90,11 +65,9 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -103,7 +76,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -149,11 +121,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -178,9 +147,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -205,60 +172,14 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -268,7 +189,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -303,7 +223,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -333,21 +252,13 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -370,7 +281,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -412,7 +322,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -426,12 +335,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -464,7 +369,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -494,8 +398,5 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,59 +15,83 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -76,6 +100,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -84,62 +109,61 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -147,49 +171,60 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -197,6 +232,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -206,64 +242,83 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -271,8 +326,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -281,9 +336,11 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "missCount");
@@ -293,7 +350,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -322,10 +379,11 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -335,8 +393,13 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -351,52 +414,62 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,71 +15,95 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,6 +112,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -96,62 +121,61 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -159,49 +183,60 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -209,6 +244,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -218,64 +254,83 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -283,8 +338,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -293,9 +348,11 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "missCount");
@@ -305,7 +362,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -334,10 +391,11 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -347,13 +405,23 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -368,28 +436,30 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -397,47 +467,54 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,28 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -45,33 +36,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -102,11 +77,9 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -115,7 +88,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -161,11 +133,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -190,9 +159,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -217,60 +184,14 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -280,7 +201,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -315,7 +235,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -345,21 +264,13 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -382,7 +293,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -424,7 +334,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -438,12 +347,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -492,7 +397,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -535,7 +439,5 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,74 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +59,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -136,11 +104,8 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -165,9 +130,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -192,60 +155,14 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -255,7 +172,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -290,7 +206,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -320,21 +235,13 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -357,7 +264,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
@@ -397,7 +303,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -411,12 +316,8 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -434,8 +335,5 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,43 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,6 +87,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -67,62 +96,61 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -130,49 +158,60 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -180,6 +219,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -189,64 +229,83 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -254,8 +313,8 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -264,8 +323,10 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "missCount");
 
@@ -274,7 +335,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -303,10 +364,11 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -316,8 +378,13 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -327,13 +394,17 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +93,13 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +115,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +123,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +158,8 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +184,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +209,14 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +226,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +260,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +289,13 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +318,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -463,7 +359,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,14 +372,8 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -499,8 +388,5 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +90,15 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,8 +107,9 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,91 +122,99 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -184,49 +222,60 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -234,6 +283,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -243,64 +293,83 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -308,8 +377,8 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -318,9 +387,11 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "missCount");
@@ -330,7 +401,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -359,10 +430,11 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -372,8 +444,13 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -382,11 +459,15 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +93,13 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +115,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +123,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +158,8 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +184,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +209,14 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +226,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +260,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +289,13 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +318,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -463,7 +359,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,12 +372,8 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -497,8 +388,5 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +90,15 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,8 +107,9 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,91 +122,99 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -184,49 +222,60 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -234,6 +283,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -243,64 +293,83 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -308,8 +377,8 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -318,9 +387,11 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "missCount");
@@ -330,7 +401,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -359,10 +430,11 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -372,8 +444,13 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -382,11 +459,15 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,75 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +94,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +116,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +124,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +159,8 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +185,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +210,14 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +227,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +261,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +290,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +319,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -463,7 +360,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,20 +373,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +90,15 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,9 +107,9 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -93,91 +122,99 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -185,49 +222,60 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -235,6 +283,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -244,64 +293,83 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -309,8 +377,8 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -319,9 +387,11 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -331,7 +401,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -360,10 +430,11 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -373,13 +444,22 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,63 +15,89 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,13 +106,15 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -95,9 +123,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -110,91 +138,99 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -202,49 +238,60 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -252,6 +299,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -261,64 +309,83 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -326,8 +393,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -336,9 +403,11 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -348,7 +417,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -377,10 +446,11 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -390,8 +460,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -406,52 +481,62 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -95,11 +69,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -108,7 +80,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -140,19 +111,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -168,9 +133,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -178,9 +141,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -216,11 +176,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -245,9 +202,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -272,60 +227,14 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -335,7 +244,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -370,7 +278,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -400,21 +307,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -437,7 +336,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -479,7 +377,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -493,12 +390,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -531,7 +424,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -561,8 +453,5 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,75 +15,101 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,13 +118,15 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -107,9 +135,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -122,91 +150,99 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -214,49 +250,60 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -264,6 +311,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -273,64 +321,83 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -338,8 +405,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -348,9 +415,11 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -360,7 +429,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -389,10 +458,11 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -402,13 +472,23 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -423,28 +503,30 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -452,47 +534,54 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -107,11 +81,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -120,7 +92,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -152,19 +123,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -180,9 +145,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -190,9 +153,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -228,11 +188,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -257,9 +214,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -284,60 +239,14 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -347,7 +256,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -382,7 +290,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -412,21 +319,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -449,7 +348,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -491,7 +389,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -505,12 +402,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -559,7 +452,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -602,7 +494,5 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,79 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +95,13 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +117,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +125,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,11 +160,8 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -232,9 +186,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -259,60 +211,14 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -322,7 +228,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -357,7 +262,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -387,21 +291,13 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -424,7 +320,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -466,7 +361,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -480,12 +374,8 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -503,8 +393,5 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,48 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +93,15 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,8 +110,9 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -94,91 +125,99 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -186,49 +225,60 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -236,6 +286,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -245,64 +296,83 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -310,8 +380,8 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -320,9 +390,11 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "missCount");
@@ -332,7 +404,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -361,10 +433,11 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -374,8 +447,13 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -385,13 +463,17 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
@@ -15,68 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -144,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -171,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -237,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> missCountUpdater =
@@ -277,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -291,14 +212,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -313,8 +228,5 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
@@ -15,39 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +81,7 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,86 +90,90 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -150,8 +181,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -160,8 +191,10 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "missCount");
 
@@ -170,7 +203,7 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -199,10 +232,11 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -212,8 +246,13 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -222,11 +261,15 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
@@ -15,39 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +81,7 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,86 +90,90 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -150,8 +181,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -160,8 +191,10 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "missCount");
 
@@ -170,7 +203,7 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -199,10 +232,11 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -212,8 +246,13 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -222,11 +261,15 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
@@ -15,68 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -144,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -171,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -237,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> missCountUpdater =
@@ -277,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -291,12 +212,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -311,8 +228,5 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -143,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -170,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -236,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
@@ -276,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -290,20 +212,13 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
@@ -15,39 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +80,7 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,86 +89,90 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -150,8 +180,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -160,8 +190,10 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "missCount");
 
@@ -170,7 +202,7 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -199,10 +231,11 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -212,13 +245,22 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -41,34 +33,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -87,11 +63,9 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +73,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -145,11 +118,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -159,9 +129,7 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -186,50 +154,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +178,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
@@ -292,7 +217,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,12 +230,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -344,7 +264,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -374,8 +293,5 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
@@ -15,57 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -73,6 +96,7 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -81,86 +105,90 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -168,8 +196,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -178,8 +206,10 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "missCount");
 
@@ -188,7 +218,7 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -217,10 +247,11 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -230,8 +261,13 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -246,52 +282,62 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
@@ -15,69 +15,92 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,6 +108,7 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -93,86 +117,90 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -180,8 +208,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -190,8 +218,10 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "missCount");
 
@@ -200,7 +230,7 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -229,10 +259,11 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -242,13 +273,23 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -263,28 +304,30 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -292,47 +335,54 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -42,33 +34,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -99,11 +75,9 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -111,7 +85,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -157,11 +130,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -171,9 +141,7 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,50 +166,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -264,7 +190,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
@@ -304,7 +229,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -318,12 +242,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -372,7 +292,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,7 +334,5 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -147,9 +113,7 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -174,50 +138,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -240,7 +162,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
@@ -280,7 +201,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -294,12 +214,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -317,8 +233,5 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,41 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +84,7 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,86 +93,90 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -152,8 +184,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -162,8 +194,10 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "missCount");
 
@@ -172,7 +206,7 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -201,10 +235,11 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -214,8 +249,13 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -225,13 +265,17 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,73 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +90,13 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +112,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +120,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +155,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +166,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +191,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +215,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
@@ -343,7 +254,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -357,14 +267,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -379,8 +283,5 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,44 +15,70 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,13 +86,15 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -75,8 +103,9 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -89,115 +118,128 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -205,8 +247,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -215,8 +257,10 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "missCount");
 
@@ -225,7 +269,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -254,10 +298,11 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -267,8 +312,13 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -277,11 +327,15 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,73 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +90,13 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +112,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +120,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +155,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +166,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +191,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +215,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
@@ -343,7 +254,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -357,12 +267,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -377,8 +283,5 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,44 +15,70 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,13 +86,15 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -75,8 +103,9 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -89,115 +118,128 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -205,8 +247,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -215,8 +257,10 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "missCount");
 
@@ -225,7 +269,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -254,10 +298,11 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -267,8 +312,13 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -277,11 +327,15 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +91,13 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +113,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +121,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +156,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +167,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +192,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +216,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -345,7 +257,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -359,20 +270,13 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,44 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +86,15 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,8 +103,9 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -90,115 +118,128 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -206,8 +247,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -216,9 +257,11 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -228,7 +271,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -257,10 +300,11 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -270,13 +314,22 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,61 +15,85 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,13 +102,15 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -93,8 +119,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -107,115 +134,128 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -223,8 +263,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -233,9 +273,11 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -245,7 +287,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -274,10 +316,11 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -287,8 +330,13 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -303,52 +351,62 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -92,11 +67,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -105,7 +78,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -136,19 +108,13 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -164,9 +130,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -174,9 +138,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -212,11 +173,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -226,9 +184,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -253,50 +209,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +233,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -361,7 +274,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -375,12 +287,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -413,7 +321,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -443,8 +350,5 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -104,11 +79,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -117,7 +90,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -148,19 +120,13 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -176,9 +142,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -186,9 +150,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -224,11 +185,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -238,9 +196,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,50 +221,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -331,7 +245,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -373,7 +286,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -387,12 +299,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -441,7 +349,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -484,7 +391,5 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,73 +15,97 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,13 +114,15 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -105,8 +131,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -119,115 +146,128 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -235,8 +275,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -245,9 +285,11 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -257,7 +299,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -286,10 +328,11 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -299,13 +342,23 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -320,28 +373,30 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -349,47 +404,54 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMStatsDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,13 +89,15 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -77,8 +106,9 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -91,115 +121,128 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -207,8 +250,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -217,8 +260,10 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "missCount");
 
@@ -227,7 +272,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -256,10 +301,11 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -269,8 +315,13 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -280,13 +331,17 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +92,13 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +114,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +122,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,11 +157,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -213,9 +168,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -240,50 +193,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -306,7 +217,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -346,7 +256,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -360,12 +269,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -383,8 +288,5 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
@@ -15,39 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +82,7 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,58 +91,63 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -122,6 +155,7 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -131,64 +165,83 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -196,8 +249,8 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -206,8 +259,10 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "missCount");
 
@@ -216,7 +271,7 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -245,10 +300,11 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -258,8 +314,13 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -268,11 +329,15 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,14 +258,8 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -328,8 +274,5 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
@@ -15,39 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +82,7 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,58 +91,63 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -122,6 +155,7 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -131,64 +165,83 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -196,8 +249,8 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -206,8 +259,10 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "missCount");
 
@@ -216,7 +271,7 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -245,10 +300,11 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -258,8 +314,13 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -268,11 +329,15 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,12 +258,8 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -326,8 +274,5 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,20 +258,13 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
@@ -15,39 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +82,7 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,58 +91,63 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -122,6 +155,7 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -131,64 +165,83 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -196,8 +249,8 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -206,8 +259,10 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "missCount");
 
@@ -216,7 +271,7 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -245,10 +300,11 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -258,13 +314,22 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
@@ -15,26 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -42,32 +34,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -86,11 +63,9 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +73,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -144,18 +118,11 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -165,7 +132,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -200,7 +166,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -230,21 +195,13 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -267,7 +224,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> missCountUpdater =
@@ -307,7 +263,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -321,12 +276,8 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -359,7 +310,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -389,8 +339,5 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
@@ -15,57 +15,81 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -73,6 +97,7 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -81,58 +106,63 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -140,6 +170,7 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -149,64 +180,83 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -214,8 +264,8 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -224,8 +274,10 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "missCount");
 
@@ -234,7 +286,7 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -263,10 +315,11 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -276,8 +329,13 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -292,52 +350,62 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
@@ -15,69 +15,93 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,6 +109,7 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -93,58 +118,63 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -152,6 +182,7 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -161,64 +192,83 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -226,8 +276,8 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -236,8 +286,10 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "missCount");
 
@@ -246,7 +298,7 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -275,10 +327,11 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -288,13 +341,23 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -309,28 +372,30 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -338,47 +403,54 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
@@ -15,26 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -43,31 +35,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -98,11 +75,9 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +85,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -156,18 +130,11 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -177,7 +144,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -212,7 +178,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -242,21 +207,13 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -279,7 +236,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> missCountUpdater =
@@ -319,7 +275,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -333,12 +288,8 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -387,7 +338,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -430,7 +380,5 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
@@ -15,41 +15,67 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +83,7 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,58 +92,63 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -124,6 +156,7 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -133,64 +166,83 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -198,8 +250,8 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -208,8 +260,10 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "missCount");
 
@@ -218,7 +272,7 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -247,10 +301,11 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -260,8 +315,13 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -271,13 +331,17 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
@@ -15,68 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +57,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,18 +102,11 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -151,7 +116,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -186,7 +150,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -216,21 +179,13 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -253,7 +208,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
@@ -293,7 +247,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -307,12 +260,8 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -330,8 +279,5 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,18 +155,11 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -216,7 +169,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -251,7 +203,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -281,21 +232,13 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -318,7 +261,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
@@ -358,7 +300,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,14 +313,8 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -394,8 +329,5 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
@@ -15,44 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,13 +87,15 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -75,8 +104,8 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -89,87 +118,101 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -177,6 +220,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -186,64 +230,83 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -251,8 +314,8 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -261,8 +324,10 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "missCount");
 
@@ -271,7 +336,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -300,10 +365,11 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -313,8 +379,13 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -323,11 +394,15 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,18 +155,11 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -216,7 +169,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -251,7 +203,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -281,21 +232,13 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -318,7 +261,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
@@ -358,7 +300,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,12 +313,8 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -392,8 +329,5 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
@@ -15,44 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,13 +87,15 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -75,8 +104,9 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -89,87 +119,101 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -177,6 +221,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -186,64 +231,83 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -251,8 +315,8 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -261,8 +325,10 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "missCount");
 
@@ -271,7 +337,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -300,10 +366,11 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -313,8 +380,13 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -323,11 +395,15 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +91,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +113,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +121,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,18 +156,11 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -217,7 +170,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -252,7 +204,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -282,21 +233,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +262,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
@@ -360,7 +302,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -374,20 +315,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,44 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +88,15 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,8 +105,9 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -90,87 +120,101 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -178,6 +222,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -187,64 +232,83 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -252,8 +316,8 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -262,8 +326,10 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -273,7 +339,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -302,10 +368,11 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -315,13 +382,22 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,61 +15,86 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,13 +103,15 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -93,8 +120,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -107,87 +135,101 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -195,6 +237,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -204,64 +247,83 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -269,8 +331,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -279,9 +341,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -291,7 +355,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -320,10 +384,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -333,8 +398,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -349,52 +419,62 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -91,11 +67,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +78,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -135,19 +108,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -163,9 +130,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -173,9 +138,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -211,18 +173,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -232,7 +187,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -267,7 +221,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -297,21 +250,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -334,7 +279,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -376,7 +320,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -390,12 +333,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -428,7 +367,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -458,8 +396,5 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,73 +15,98 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,13 +115,15 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -105,8 +132,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -119,87 +147,101 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -207,6 +249,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -216,64 +259,83 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -281,8 +343,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -291,9 +353,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -303,7 +367,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -332,10 +396,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -345,13 +410,23 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -366,28 +441,30 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -395,47 +472,54 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -103,11 +79,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +90,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -147,19 +120,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -175,9 +142,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -185,9 +150,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -223,18 +185,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -244,7 +199,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -279,7 +233,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -309,21 +262,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -346,7 +291,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -388,7 +332,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -402,12 +345,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -456,7 +395,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -499,7 +437,5 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,73 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +62,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +92,13 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +114,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +122,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,18 +157,11 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -217,7 +171,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -252,7 +205,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -282,21 +234,13 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +263,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -359,7 +302,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -373,12 +315,8 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -396,8 +334,5 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,46 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,13 +88,15 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -77,8 +105,9 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -91,87 +120,101 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +222,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,64 +232,83 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -253,8 +316,8 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -263,8 +326,10 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "missCount");
 
@@ -273,7 +338,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -302,10 +367,11 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -315,8 +381,13 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -326,13 +397,17 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
@@ -15,36 +15,60 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -52,6 +76,7 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -60,49 +85,48 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -110,8 +134,8 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -120,8 +144,10 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "missCount");
 
@@ -130,7 +156,7 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -159,10 +185,11 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -172,8 +199,13 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -182,11 +214,15 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,14 +172,8 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -226,8 +188,5 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
@@ -15,36 +15,60 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -52,6 +76,7 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -60,49 +85,48 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -110,8 +134,8 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -120,8 +144,10 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "missCount");
 
@@ -130,7 +156,7 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -159,10 +185,11 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -172,8 +199,13 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -182,11 +214,15 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,12 +172,8 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -224,8 +188,5 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
@@ -15,36 +15,60 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -52,6 +76,7 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -60,49 +85,48 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -110,8 +134,8 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -120,8 +144,10 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "missCount");
 
@@ -130,7 +156,7 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -159,10 +185,11 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -172,13 +199,22 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,20 +172,13 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
@@ -15,54 +15,75 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -70,6 +91,7 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -78,49 +100,48 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -128,8 +149,8 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -138,8 +159,10 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "missCount");
 
@@ -148,7 +171,7 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -177,10 +200,11 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -190,8 +214,13 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -206,52 +235,62 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
@@ -15,21 +15,15 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -37,32 +31,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -81,11 +60,9 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +70,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,10 +115,7 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -165,7 +138,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> missCountUpdater =
@@ -205,7 +177,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -219,12 +190,8 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -257,7 +224,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -287,8 +253,5 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
@@ -15,66 +15,87 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,6 +103,7 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -90,49 +112,48 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -140,8 +161,8 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -150,8 +171,10 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "missCount");
 
@@ -160,7 +183,7 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -189,10 +212,11 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -202,13 +226,23 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -223,28 +257,30 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -252,47 +288,54 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
@@ -15,21 +15,15 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -38,31 +32,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -93,11 +72,9 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -105,7 +82,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -151,10 +127,7 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -177,7 +150,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> missCountUpdater =
@@ -217,7 +189,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -231,12 +202,8 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -285,7 +252,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -328,7 +294,5 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
@@ -15,38 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -54,6 +77,7 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -62,49 +86,48 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -112,8 +135,8 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -122,8 +145,10 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "missCount");
 
@@ -132,7 +157,7 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -161,10 +186,11 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -174,8 +200,13 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -185,13 +216,17 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
@@ -15,63 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +54,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -125,10 +99,7 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -151,7 +122,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> missCountUpdater =
@@ -191,7 +161,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -205,12 +174,8 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -228,8 +193,5 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,14 +227,8 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -292,8 +243,5 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
@@ -15,41 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,13 +81,15 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -72,8 +98,8 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -86,78 +112,86 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -165,8 +199,8 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -175,8 +209,10 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "missCount");
 
@@ -185,7 +221,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -214,10 +250,11 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -227,8 +264,13 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -237,11 +279,15 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
@@ -15,41 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,13 +81,15 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -72,8 +98,8 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -86,78 +112,86 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -165,8 +199,8 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -175,8 +209,10 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "missCount");
 
@@ -185,7 +221,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -214,10 +250,11 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -227,8 +264,13 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -237,11 +279,15 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,12 +227,8 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -290,8 +243,5 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
@@ -15,41 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,13 +81,15 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -72,8 +98,8 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -86,78 +112,86 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -165,8 +199,8 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -175,8 +209,10 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "missCount");
 
@@ -185,7 +221,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -214,10 +250,11 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -227,13 +264,22 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,20 +227,13 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
@@ -15,58 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,13 +96,15 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -89,8 +113,9 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -103,78 +128,86 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -182,8 +215,8 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -192,8 +225,10 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "missCount");
 
@@ -202,7 +237,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -231,10 +266,11 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -244,8 +280,13 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -260,52 +301,62 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
@@ -15,59 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -86,11 +64,9 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +74,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +104,13 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +126,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +134,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,10 +169,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -231,7 +192,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> missCountUpdater =
@@ -271,7 +231,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -285,12 +244,8 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -323,7 +278,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -353,8 +307,5 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
@@ -15,59 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -98,11 +76,9 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +86,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -141,19 +116,13 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -169,9 +138,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -179,9 +146,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -217,10 +181,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -243,7 +204,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> missCountUpdater =
@@ -283,7 +243,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -297,12 +256,8 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -351,7 +306,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -394,7 +348,5 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
@@ -15,70 +15,92 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,13 +108,15 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -101,8 +125,9 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -115,78 +140,86 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -194,8 +227,8 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -204,8 +237,10 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "missCount");
 
@@ -214,7 +249,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -243,10 +278,11 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -256,13 +292,23 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -277,28 +323,30 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -306,47 +354,54 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
@@ -15,43 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMStatsRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,13 +82,15 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -74,8 +99,8 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -88,78 +113,86 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -167,8 +200,8 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -177,8 +210,10 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "missCount");
 
@@ -187,7 +222,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -216,10 +251,11 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -229,8 +265,13 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -240,13 +281,17 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
@@ -15,68 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +59,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -115,19 +89,13 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -143,9 +111,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -153,9 +119,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -191,10 +154,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -217,7 +177,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -257,7 +216,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -271,12 +229,8 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -294,8 +248,5 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
@@ -15,40 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -56,6 +82,7 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -64,62 +91,61 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -127,49 +153,60 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -177,6 +214,7 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -186,60 +224,80 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -248,11 +306,15 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
@@ -15,69 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +56,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +101,8 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +127,7 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +152,14 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +169,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +203,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,25 +232,14 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -348,8 +254,5 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
@@ -15,69 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +56,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +101,8 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +127,7 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +152,14 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +169,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +203,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,23 +232,14 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -346,8 +254,5 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
@@ -15,40 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -56,6 +82,7 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -64,62 +91,61 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -127,49 +153,60 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -177,6 +214,7 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -186,60 +224,80 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -248,11 +306,15 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,68 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +103,8 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +129,7 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +154,14 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +171,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +205,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,31 +234,19 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,41 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -58,6 +82,7 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -66,62 +91,61 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -129,49 +153,60 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +214,7 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,65 +224,89 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,58 +15,81 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -75,6 +98,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -83,62 +107,61 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -146,49 +169,60 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -196,6 +230,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -205,60 +240,80 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -273,52 +328,62 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -42,34 +34,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +64,9 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +75,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,11 +120,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -176,9 +146,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -203,60 +171,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -266,7 +188,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -301,7 +222,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -331,23 +251,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -380,7 +291,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -410,8 +320,5 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -43,33 +35,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +76,9 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +87,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -159,11 +132,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -188,9 +158,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -215,60 +183,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -278,7 +200,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -313,7 +234,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -343,23 +263,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -408,7 +319,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -451,7 +361,5 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,70 +15,93 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,6 +110,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -95,62 +119,61 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -158,49 +181,60 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -208,6 +242,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -217,65 +252,90 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -290,28 +350,30 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -319,47 +381,54 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,27 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -43,44 +34,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +58,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +103,8 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -163,9 +129,7 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -190,60 +154,14 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -253,7 +171,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -288,7 +205,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -318,23 +234,14 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -352,8 +259,5 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,42 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -58,6 +85,7 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -66,62 +94,61 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -129,49 +156,60 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +217,7 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,60 +227,80 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -251,13 +310,17 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +92,13 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +114,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +122,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +157,8 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +183,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +208,14 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +225,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +259,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,25 +288,14 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -415,8 +310,5 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,45 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,13 +88,15 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -77,8 +105,9 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -91,91 +120,99 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -183,49 +220,60 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -233,6 +281,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -242,60 +291,80 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -304,11 +373,15 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,45 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,13 +88,15 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -77,8 +105,9 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -91,91 +120,99 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -183,49 +220,60 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -233,6 +281,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -242,60 +291,80 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -304,11 +373,15 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +92,13 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +114,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +122,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +157,8 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +183,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +208,14 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +225,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +259,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,23 +288,14 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -413,8 +310,5 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,73 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +158,8 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +184,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +209,14 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +226,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +260,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,31 +289,19 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,45 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,13 +88,15 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -77,9 +105,9 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,91 +120,99 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -184,49 +220,60 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -234,6 +281,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -243,65 +291,89 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +68,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +79,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -138,19 +110,13 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -166,9 +132,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -176,9 +140,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -214,11 +175,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -243,9 +201,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -270,60 +226,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -333,7 +243,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -368,7 +277,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -398,23 +306,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -447,7 +346,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -477,8 +375,5 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,62 +15,87 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,13 +104,15 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -94,9 +121,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -109,91 +136,99 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -201,49 +236,60 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -251,6 +297,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -260,60 +307,80 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -328,52 +395,62 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,74 +15,99 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,13 +116,15 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -106,9 +133,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -121,91 +148,99 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -213,49 +248,60 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -263,6 +309,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -272,65 +319,90 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -345,28 +417,30 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -374,47 +448,54 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +80,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +91,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -150,19 +122,13 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -178,9 +144,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -188,9 +152,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -226,11 +187,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -255,9 +213,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -282,60 +238,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -345,7 +255,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -380,7 +289,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -410,23 +318,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -475,7 +374,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -518,7 +416,5 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,47 +15,74 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,13 +91,15 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -79,8 +108,9 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -93,91 +123,99 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -185,49 +223,60 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -235,6 +284,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -244,60 +294,80 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -307,13 +377,17 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,77 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +64,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +94,13 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +116,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +124,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +159,8 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -230,9 +185,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -257,60 +210,14 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -320,7 +227,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -355,7 +261,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -385,23 +290,14 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -419,8 +315,5 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
@@ -15,64 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +53,6 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -126,11 +98,8 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -140,9 +109,7 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -167,54 +134,9 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -229,8 +151,5 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
@@ -15,37 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -53,6 +77,7 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -61,82 +86,87 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -145,11 +175,15 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
@@ -15,37 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -53,6 +77,7 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -61,82 +86,87 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -145,11 +175,15 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -35,44 +29,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +53,6 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -126,11 +98,8 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -140,9 +109,7 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -167,52 +134,9 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -227,8 +151,5 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
@@ -15,37 +15,60 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -53,6 +76,7 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -61,87 +85,96 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
@@ -15,63 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +53,6 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -125,11 +98,8 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -139,9 +109,7 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -166,60 +134,14 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -37,34 +31,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -83,11 +61,9 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +71,6 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +116,8 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -155,9 +127,7 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -182,52 +152,9 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -260,7 +187,6 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -290,8 +216,5 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
@@ -15,55 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -71,6 +92,7 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -79,82 +101,87 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -169,52 +196,62 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
@@ -15,67 +15,88 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,6 +104,7 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -91,87 +113,97 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -186,28 +218,30 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -215,47 +249,54 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -38,33 +32,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -95,11 +73,9 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -107,7 +83,6 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -153,11 +128,8 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -167,9 +139,7 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -194,52 +164,9 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -288,7 +215,6 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -331,7 +257,5 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
@@ -15,21 +15,14 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -38,44 +31,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,11 +100,8 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -143,9 +111,7 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -170,52 +136,9 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -233,8 +156,5 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
@@ -15,39 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +80,7 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,82 +89,87 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -148,13 +179,17 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +88,13 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +110,7 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +118,6 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +153,8 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +164,7 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,54 +189,9 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -295,8 +206,5 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
@@ -15,42 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -58,13 +82,15 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -73,8 +99,8 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -87,111 +113,125 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -200,11 +240,15 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +88,13 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +110,7 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +118,6 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +153,8 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +164,7 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,52 +189,9 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -293,8 +206,5 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
@@ -15,42 +15,66 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -58,13 +82,15 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -73,8 +99,9 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -87,111 +114,125 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -200,11 +241,15 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,42 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,13 +82,15 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -74,8 +99,9 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -88,116 +114,134 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +59,6 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +89,13 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +111,7 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +119,6 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +154,8 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +165,7 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,60 +190,14 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,59 +15,81 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -76,13 +98,15 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -91,8 +115,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -105,111 +130,125 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -224,52 +263,62 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +65,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +76,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -132,19 +106,13 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -160,9 +128,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -170,9 +136,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -208,11 +171,8 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -222,9 +182,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -249,52 +207,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -327,7 +242,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -357,8 +271,5 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +77,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +88,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -144,19 +118,13 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -172,9 +140,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -182,9 +148,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -220,11 +183,8 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -234,9 +194,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -261,52 +219,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -355,7 +270,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -398,7 +312,5 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,71 +15,93 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,13 +110,15 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -103,8 +127,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -117,116 +142,135 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -241,28 +285,30 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -270,47 +316,54 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,44 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VMThinDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,13 +85,15 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -75,8 +102,9 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -89,111 +117,125 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -203,13 +245,17 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,11 +155,8 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -209,9 +166,7 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -236,52 +191,9 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -299,8 +211,5 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,25 +176,14 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -246,8 +198,5 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
@@ -15,38 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -54,6 +80,7 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -62,58 +89,63 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -121,6 +153,7 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -130,60 +163,80 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -192,11 +245,15 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,23 +176,14 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -244,8 +198,5 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
@@ -15,38 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -54,6 +80,7 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -62,58 +89,63 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -121,6 +153,7 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -130,60 +163,80 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -192,11 +245,15 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
@@ -15,38 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -54,6 +80,7 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -62,58 +89,63 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -121,6 +153,7 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -130,65 +163,89 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,31 +176,19 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
@@ -15,23 +15,16 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -40,32 +33,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -84,11 +62,9 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +72,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,18 +117,11 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -163,7 +131,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -198,7 +165,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -228,23 +194,14 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -277,7 +234,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -307,8 +263,5 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
@@ -15,56 +15,79 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -72,6 +95,7 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -80,58 +104,63 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -139,6 +168,7 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -148,60 +178,80 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -216,52 +266,62 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
@@ -15,23 +15,16 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -41,31 +34,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -96,11 +74,9 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -108,7 +84,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -154,18 +129,11 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -175,7 +143,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -210,7 +177,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -240,23 +206,14 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -305,7 +262,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -348,7 +304,5 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
@@ -15,68 +15,91 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,6 +107,7 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -92,58 +116,63 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -151,6 +180,7 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -160,65 +190,90 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -233,28 +288,30 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -262,47 +319,54 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -41,40 +33,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +56,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,18 +101,11 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -149,7 +115,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -184,7 +149,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -214,23 +178,14 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -248,8 +203,5 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
@@ -15,40 +15,65 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -56,6 +81,7 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -64,58 +90,63 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -123,6 +154,7 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -132,60 +164,80 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -195,13 +247,17 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
@@ -15,43 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,13 +85,15 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -74,8 +102,8 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -88,87 +116,101 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -176,6 +218,7 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -185,60 +228,80 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -247,11 +310,15 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,25 +231,14 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -312,8 +253,5 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
@@ -15,43 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,13 +85,15 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -74,8 +102,8 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -88,87 +116,101 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -176,6 +218,7 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -185,60 +228,80 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -247,11 +310,15 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,23 +231,14 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -310,8 +253,5 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,31 +231,19 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
@@ -15,43 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,13 +85,15 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -74,8 +102,9 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -88,87 +117,101 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -176,6 +219,7 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -185,65 +229,89 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
@@ -15,60 +15,84 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -77,13 +101,15 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -92,8 +118,9 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -106,87 +133,101 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -194,6 +235,7 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -203,60 +245,80 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -271,52 +333,62 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
@@ -15,62 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -89,11 +66,9 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +77,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +107,13 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +129,7 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +137,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,18 +172,11 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -230,7 +186,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -265,7 +220,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -295,23 +249,14 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -344,7 +289,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -374,8 +318,5 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
@@ -15,62 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -101,11 +78,9 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +89,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -145,19 +119,13 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -173,9 +141,7 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -183,9 +149,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -221,18 +184,11 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -242,7 +198,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -277,7 +232,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -307,23 +261,14 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -372,7 +317,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,7 +359,5 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
@@ -15,72 +15,96 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,13 +113,15 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -104,8 +130,9 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -118,87 +145,101 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -206,6 +247,7 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -215,65 +257,90 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -288,28 +355,30 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -317,47 +386,54 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,71 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,18 +156,11 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -215,7 +170,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -250,7 +204,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -280,23 +233,14 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -314,8 +258,5 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,45 +15,70 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +86,15 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,8 +103,8 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -90,87 +117,101 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -178,6 +219,7 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -187,60 +229,80 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -250,13 +312,17 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
@@ -15,34 +15,56 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -50,6 +72,7 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -58,45 +81,45 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -105,11 +128,15 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -30,43 +26,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,14 +95,8 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -142,8 +111,5 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -31,42 +27,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,12 +95,8 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -140,8 +111,5 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
@@ -15,34 +15,56 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -50,6 +72,7 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -58,45 +81,45 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -105,11 +128,15 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
@@ -15,34 +15,56 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -50,6 +72,7 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapObjectKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -58,50 +81,54 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -29,44 +25,24 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,20 +95,13 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
@@ -15,52 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -68,6 +87,7 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey1.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -76,45 +96,45 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -129,52 +149,62 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -33,32 +29,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -77,11 +58,9 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +68,6 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,12 +113,8 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -173,7 +147,6 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -203,8 +176,5 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,31 +30,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -89,11 +70,9 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +80,6 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,12 +125,8 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -201,7 +175,6 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -244,7 +217,5 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
@@ -15,64 +15,83 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,6 +99,7 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey2.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -88,50 +108,55 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -146,28 +171,30 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -175,47 +202,54 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
@@ -15,36 +15,57 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -52,6 +73,7 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -60,45 +82,45 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -108,13 +130,17 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
@@ -15,13 +15,8 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,40 +29,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -75,7 +52,6 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -121,12 +97,8 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -144,8 +116,5 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
@@ -15,39 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,13 +77,15 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -70,8 +94,8 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -84,74 +108,83 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -160,11 +193,15 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,14 +150,8 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -208,8 +166,5 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
@@ -15,39 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,13 +77,15 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -70,8 +94,8 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -84,74 +108,83 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -160,11 +193,15 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,12 +150,8 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -206,8 +166,5 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
@@ -15,39 +15,61 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,13 +77,15 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -70,8 +94,8 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -84,79 +108,92 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,20 +150,13 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,38 +27,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -82,11 +62,9 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +72,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +102,13 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +124,7 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +132,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,12 +167,8 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -239,7 +201,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -269,8 +230,5 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
@@ -15,56 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -72,13 +92,15 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -87,8 +109,8 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -101,74 +123,83 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -183,52 +214,62 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,38 +27,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -94,11 +74,9 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +84,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -137,19 +114,13 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -165,9 +136,7 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -175,9 +144,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -213,12 +179,8 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -267,7 +229,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -310,7 +271,5 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
@@ -15,68 +15,88 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,13 +104,15 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -99,8 +121,8 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -113,79 +135,93 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -200,28 +236,30 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -229,47 +267,54 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
@@ -15,18 +15,12 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,45 +28,28 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +57,6 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -111,19 +87,13 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -139,9 +109,7 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -149,9 +117,6 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -187,12 +152,8 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -210,8 +171,5 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
@@ -15,41 +15,62 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VMThinRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,13 +78,15 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -72,8 +95,8 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -86,74 +109,83 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -163,13 +195,17 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
@@ -68,14 +68,17 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
   private final ConcurrentMap<Object, DiskEntry> map = new ConcurrentHashMap<Object, DiskEntry>();
 
   ///////////// DiskRecoveryStore methods ////////////////
+  @Override
   public DiskRegionView getDiskRegionView() {
     return this;
   }
 
+  @Override
   public DiskEntry getDiskEntry(Object key) {
     return this.map.get(key);
   }
 
+  @Override
   public DiskEntry initializeRecoveredEntry(Object key, DiskEntry.RecoveredEntry re) {
     ValidatingDiskEntry de = new ValidatingDiskEntry(key, re);
     if (this.map.putIfAbsent(key, de) != null) {
@@ -85,30 +88,36 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     return de;
   }
 
+  @Override
   public DiskEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry re) {
     ValidatingDiskEntry de = new ValidatingDiskEntry(key, re);
     this.map.put(key, de);
     return de;
   }
 
+  @Override
   public void destroyRecoveredEntry(Object key) {
     this.map.remove(key);
   }
 
+  @Override
   public void foreachRegionEntry(LocalRegion.RegionEntryCallback callback) {
     throw new IllegalStateException(
         "foreachRegionEntry should not be called when validating disk store");
   }
 
+  @Override
   public boolean lruLimitExceeded() {
     return false;
   }
 
+  @Override
   public void copyRecoveredEntries(RegionMap rm) {
     throw new IllegalStateException(
         "copyRecoveredEntries should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void updateSizeOnFaultIn(Object key, int newSize, int bytesOnDisk) {
     throw new IllegalStateException(
         "updateSizeOnFaultIn should not be called on ValidatingDiskRegion");
@@ -124,15 +133,18 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     return 0;
   }
 
+  @Override
   public RegionMap getRegionMap() {
     throw new IllegalStateException("getRegionMap should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void handleDiskAccessException(DiskAccessException dae) {
     throw new IllegalStateException(
         "handleDiskAccessException should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void initializeStats(long numEntriesInVM, long numOverflowOnDisk,
       long numOverflowBytesOnDisk) {
     throw new IllegalStateException("initializeStats should not be called on ValidatingDiskRegion");
@@ -156,11 +168,13 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       this.diskId.setValueLength(re.getValueLength());
     }
 
+    @Override
     public Object getKey() {
       return this.key;
     }
 
-    public Object _getValue() {
+    @Override
+    public Object getValue() {
       return null;
     }
 
@@ -169,10 +183,12 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       return null;
     }
 
-    public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+    @Override
+    public Object getValueRetain(RegionEntryContext context, boolean decompress) {
       return null;
     }
 
+    @Override
     public boolean isValueNull() {
       throw new IllegalStateException("should never be called");
     }
@@ -192,7 +208,8 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
 
@@ -200,30 +217,37 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskId getDiskId() {
       return this.diskId;
     }
 
+    @Override
     public long getLastModified() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public int updateAsyncEntrySize(EnableLRU capacityController) {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskEntry getPrev() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskEntry getNext() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public void setPrev(DiskEntry v) {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public void setNext(DiskEntry v) {
       throw new IllegalStateException("should never be called");
     }
@@ -235,7 +259,6 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
      */
     @Override
     public VersionStamp getVersionStamp() {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -246,115 +269,104 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
 
     @Override
     public boolean hasStats() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public long getLastAccessed() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getHitCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getMissCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
-        LocalRegion region, EntryEventImpl event) {
-      // TODO Auto-generated method stub
+        InternalRegion region, EntryEventImpl event) {
       return null;
     }
 
     @Override
     public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setRecentlyUsed() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void updateStatsForGet(boolean hit, long time) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void txDidDestroy(long currTime) {
-      // TODO Auto-generated method stub
+    public void txDidDestroy(long currentTime) {
+      // Tnothing
     }
 
     @Override
     public void resetCounts() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void makeTombstone(InternalRegion region, VersionTag version)
+        throws RegionClearedException {
+      // nothing
     }
 
     @Override
-    public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
+      // nothing
     }
 
     @Override
     public void removePhase2() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isRemovedPhase2() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
-        final Version version) {
-      // TODO Auto-generated method stub
+    public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
+        DM distributionManager, final Version version) {
       return false;
     }
 
     @Override
-    public boolean isOverflowedToDisk(LocalRegion r, DiskPosition dp) {
-      // TODO Auto-generated method stub
+    public boolean isOverflowedToDisk(InternalRegion region, DiskPosition diskPosition) {
       return false;
     }
 
     @Override
     public Object getValue(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -365,153 +377,134 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
 
     @Override
     public void setValue(RegionEntryContext context, Object value) throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void setValueWithTombstoneCheck(Object value, EntryEvent event)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public Object getTransformedValue() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public Object getValueInVM(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
-    public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public boolean initialImagePut(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
         boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean initialImageInit(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
         boolean create, boolean wasRecovered, boolean acceptedVersionTag)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+    public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
         boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
         boolean removeRecoveredEntry) throws CacheWriterException, EntryNotFoundException,
         TimeoutException, RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean getValueWasResultOfSearch() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public void setValueResultOfSearch(boolean v) {
-      // TODO Auto-generated method stub
+    public void setValueResultOfSearch(boolean value) {
+      // nothing
     }
 
     @Override
-    public Object getSerializedValueOnDisk(LocalRegion localRegion) {
-      // TODO Auto-generated method stub
+    public Object getSerializedValueOnDisk(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
     public boolean isUpdateInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setUpdateInProgress(boolean underUpdate) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isInvalid() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyed() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemovedButNotTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isInvalidOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setValueToNull() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void returnToPool() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isCacheListenerInvocationInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setCacheListenerInvocationInProgress(boolean isListenerInvoked) {
-      // TODO Auto-generated method stub
-
+      // nothing
     }
 
     @Override
@@ -524,20 +517,28 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public void setInUseByTransaction(boolean v) {}
+    public void setInUseByTransaction(boolean inUseByTransaction) {
+      // nothing
+    }
 
     @Override
-    public void incRefCount() {}
+    public void incRefCount() {
+      // nothing
+    }
 
     @Override
-    public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+    public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+      // nothing
+    }
 
     @Override
-    public void resetRefCount(NewLRUClockHand lruList) {}
+    public void resetRefCount(NewLRUClockHand lruList) {
+      // nothing
+    }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
-        boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        EntryEventImpl event, boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
   }
@@ -546,6 +547,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
   //////////////// DiskExceptionHandler methods ////////////////////
 
   public static class DummyDiskExceptionHandler implements DiskExceptionHandler {
+    @Override
     public void handleDiskAccessException(DiskAccessException dae) {
       // nothing needed
     }
@@ -563,8 +565,8 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public RuntimeException generateCancelledException(Throwable e) {
-      return new RuntimeException(e);
+    public RuntimeException generateCancelledException(Throwable throwable) {
+      return new RuntimeException(throwable);
     }
 
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,48 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapIntKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,6 +93,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -73,62 +102,61 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -136,49 +164,60 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -186,6 +225,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -195,64 +235,83 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -260,8 +319,8 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -270,9 +329,11 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "missCount");
@@ -282,7 +343,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -311,10 +372,11 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -324,61 +386,77 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -387,8 +465,10 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -396,31 +476,38 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -429,11 +516,15 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapIntKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -171,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -261,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -296,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -326,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -363,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "hitCount");
@@ -405,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -419,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -438,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -457,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -487,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -520,13 +419,8 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -541,8 +435,5 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapLongKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -171,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -261,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -296,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -326,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -363,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "hitCount");
@@ -405,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -419,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -438,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -457,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -487,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -520,11 +419,8 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -539,8 +435,5 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,48 +15,77 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapLongKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,6 +94,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -73,62 +103,61 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -136,49 +165,60 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -186,6 +226,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -195,64 +236,83 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -260,8 +320,8 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -270,9 +330,11 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "missCount");
@@ -282,7 +344,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -311,10 +373,11 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -324,61 +387,77 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -387,8 +466,10 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -396,31 +477,38 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -429,11 +517,15 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,48 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,6 +93,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -73,62 +102,61 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -136,49 +164,60 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -186,6 +225,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -195,64 +235,83 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -260,8 +319,8 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -270,9 +329,11 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "missCount");
@@ -282,7 +343,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -311,10 +372,11 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -324,61 +386,77 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -387,8 +465,10 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -396,36 +476,47 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,32 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -170,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -197,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -260,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -295,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -325,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -362,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -404,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -418,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -437,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -456,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -486,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -519,19 +419,13 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -98,11 +71,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -111,7 +82,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -157,11 +127,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -186,9 +153,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -213,60 +178,14 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -276,7 +195,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -311,7 +229,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -341,21 +258,13 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -378,7 +287,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -420,7 +328,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -434,10 +341,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -453,7 +357,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -472,7 +375,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -502,7 +404,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -535,11 +436,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -572,7 +470,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -602,8 +499,5 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,65 +15,92 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,6 +109,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -90,62 +118,61 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -153,49 +180,60 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -203,6 +241,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -212,64 +251,83 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -277,8 +335,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -287,9 +345,11 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "missCount");
@@ -299,7 +359,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -328,10 +388,11 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -341,61 +402,77 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -404,8 +481,10 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -413,31 +492,38 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -452,52 +538,62 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,77 +15,104 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,6 +121,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -102,62 +130,61 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -165,49 +192,60 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -215,6 +253,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -224,64 +263,83 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -289,8 +347,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -299,9 +357,11 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "missCount");
@@ -311,7 +371,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -340,10 +400,11 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -353,61 +414,77 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -416,8 +493,10 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -425,36 +504,48 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -469,28 +560,30 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -498,47 +591,54 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,36 +15,25 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -52,8 +41,7 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -110,11 +83,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -123,7 +94,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -169,11 +139,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -198,9 +165,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -225,60 +190,14 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -288,7 +207,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -323,7 +241,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -353,21 +270,13 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -390,7 +299,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -432,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -446,10 +353,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -465,7 +369,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -484,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -514,7 +416,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -547,11 +448,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -600,7 +498,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -643,7 +540,5 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,47 +15,34 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,34 +50,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +67,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -145,11 +112,8 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -174,9 +138,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -201,60 +163,14 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -264,7 +180,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -299,7 +214,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -329,21 +243,13 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -366,7 +272,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -408,7 +313,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -422,10 +326,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -441,7 +342,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -460,7 +360,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -490,7 +389,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -523,11 +421,8 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -545,8 +440,5 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,50 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,6 +97,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -75,62 +106,61 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -138,49 +168,60 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -188,6 +229,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -197,64 +239,83 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -262,8 +323,8 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -272,9 +333,11 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "missCount");
@@ -284,7 +347,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -313,10 +376,11 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -326,61 +390,77 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -389,8 +469,10 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -398,31 +480,38 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -432,13 +521,17 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,33 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -238,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -328,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -363,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -393,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -430,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -472,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -486,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -505,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -524,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -554,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -587,13 +474,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -608,8 +490,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,52 +15,82 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context,
+      final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -69,13 +99,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -84,9 +116,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -99,91 +131,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -191,49 +231,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +292,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,64 +302,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -315,8 +386,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -325,9 +396,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "missCount");
@@ -337,7 +410,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -366,10 +439,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -379,61 +453,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -442,8 +532,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -451,31 +543,38 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -484,11 +583,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,33 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -238,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -328,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -363,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -393,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -430,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -472,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -486,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -505,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -524,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -554,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -587,11 +474,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -606,8 +490,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,52 +15,82 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -69,13 +99,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -84,9 +116,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -99,91 +131,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -191,49 +231,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +292,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,64 +302,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -315,8 +386,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -325,9 +396,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "missCount");
@@ -337,7 +410,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -366,10 +439,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -379,61 +453,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -442,8 +532,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -451,31 +543,38 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -484,11 +583,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,52 +15,81 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -69,13 +98,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -84,9 +115,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -99,91 +130,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -191,49 +230,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +291,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,64 +301,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -315,8 +385,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -325,9 +395,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -337,7 +409,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -366,10 +438,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -379,61 +452,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -442,8 +531,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -451,36 +542,47 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,32 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -100,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -132,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -160,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -170,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -208,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -237,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -264,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -327,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -362,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -392,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -429,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -471,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -485,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -504,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -523,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -553,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -586,19 +474,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,25 +53,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -103,11 +75,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +86,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -148,19 +117,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -176,9 +139,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -186,9 +147,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -224,11 +182,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -253,9 +208,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -280,60 +233,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -343,7 +250,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -378,7 +284,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -408,21 +313,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -445,7 +342,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -487,7 +383,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -501,10 +396,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -520,7 +412,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -539,7 +430,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -569,7 +459,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -602,11 +491,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -639,7 +525,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -669,8 +554,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,69 +15,97 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,13 +114,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -101,9 +131,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -116,91 +146,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -208,49 +246,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -258,6 +307,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -267,64 +317,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -332,8 +401,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -342,9 +411,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -354,7 +425,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -383,10 +454,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -396,61 +468,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -459,8 +547,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -468,31 +558,38 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -507,52 +604,62 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,25 +53,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -115,11 +87,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -128,7 +98,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -160,19 +129,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -188,9 +151,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -198,9 +159,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -236,11 +194,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -265,9 +220,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -292,60 +245,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -355,7 +262,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -390,7 +296,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -420,21 +325,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -457,7 +354,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -499,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -513,10 +408,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -532,7 +424,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -551,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -581,7 +471,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -614,11 +503,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -667,7 +553,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -710,7 +595,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,81 +15,109 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,13 +126,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -113,9 +143,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -128,91 +158,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -220,49 +258,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -270,6 +319,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -279,64 +329,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -344,8 +413,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -354,9 +423,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -366,7 +437,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -395,10 +466,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -408,61 +480,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -471,8 +559,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -480,36 +570,48 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -524,28 +626,30 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -553,47 +657,54 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,52 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -68,34 +54,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +71,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -136,19 +102,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -164,9 +124,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -174,9 +132,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -212,11 +167,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -241,9 +193,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -268,60 +218,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -331,7 +235,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -366,7 +269,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -396,21 +298,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -433,7 +327,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -475,7 +368,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -489,10 +381,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -508,7 +397,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -527,7 +415,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -557,7 +444,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -590,11 +476,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -612,8 +495,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,54 +15,85 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -71,13 +102,15 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -86,9 +119,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -101,91 +134,99 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -193,49 +234,60 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -243,6 +295,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -252,64 +305,83 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -317,8 +389,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -327,9 +399,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "missCount");
@@ -339,7 +413,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -368,10 +442,11 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -381,61 +456,77 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -444,8 +535,10 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -453,31 +546,38 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -487,13 +587,17 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
@@ -15,45 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +89,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,86 +98,90 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -157,8 +189,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -167,9 +199,11 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "missCount");
@@ -179,7 +213,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -208,10 +242,11 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -221,61 +256,77 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -284,8 +335,10 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -293,31 +346,38 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -326,11 +386,15 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
@@ -15,75 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -152,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -179,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -245,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "hitCount");
@@ -287,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -301,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -320,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -339,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -369,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -402,13 +316,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -423,8 +332,5 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
@@ -15,45 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +89,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,86 +98,90 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -157,8 +189,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -167,9 +199,11 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "missCount");
@@ -179,7 +213,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -208,10 +242,11 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -221,61 +256,77 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -284,8 +335,10 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -293,31 +346,38 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -326,11 +386,15 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
@@ -15,75 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -152,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -179,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -245,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "hitCount");
@@ -287,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -301,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -320,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -339,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -369,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -402,11 +316,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -421,8 +332,5 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
@@ -15,45 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +89,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,86 +98,90 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -157,8 +189,8 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -167,9 +199,11 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "missCount");
@@ -179,7 +213,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -208,10 +242,11 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -221,61 +256,77 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -284,8 +335,10 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -293,36 +346,47 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -151,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -178,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -244,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "hitCount");
@@ -286,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -300,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,19 +316,13 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
@@ -15,62 +15,88 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,6 +105,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -87,86 +114,90 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -174,8 +205,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -184,9 +215,11 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "missCount");
@@ -196,7 +229,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -225,10 +258,11 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -238,61 +272,77 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -301,8 +351,10 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -310,31 +362,38 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -349,52 +408,62 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -94,11 +68,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -107,7 +79,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -153,11 +124,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -167,9 +135,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -194,50 +160,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +184,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "hitCount");
@@ -302,7 +225,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +238,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +254,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +272,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +301,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,11 +333,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -454,7 +367,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -484,8 +396,5 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
@@ -15,74 +15,100 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,6 +117,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -99,86 +126,90 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -186,8 +217,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -196,9 +227,11 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "missCount");
@@ -208,7 +241,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -237,10 +270,11 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -250,61 +284,77 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -313,8 +363,10 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -322,36 +374,48 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -366,28 +430,30 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -395,47 +461,54 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
@@ -15,33 +15,23 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -49,33 +39,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -106,11 +80,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -119,7 +91,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -165,11 +136,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -179,9 +147,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -206,50 +172,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -272,7 +196,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "hitCount");
@@ -314,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -328,10 +250,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -347,7 +266,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -366,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -396,7 +313,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -429,11 +345,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -482,7 +395,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -525,7 +437,5 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,78 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +64,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +109,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -155,9 +120,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -182,50 +145,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -248,7 +169,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -290,7 +210,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -304,10 +223,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -323,7 +239,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -342,7 +257,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -372,7 +286,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -405,11 +318,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -427,8 +337,5 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,47 +15,75 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,6 +92,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -72,86 +101,90 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -159,8 +192,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -169,9 +202,11 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "missCount");
@@ -181,7 +216,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -210,10 +245,11 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -223,61 +259,77 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -286,8 +338,10 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -295,31 +349,38 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -329,13 +390,17 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,33 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapIntKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -220,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -247,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -313,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -355,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -369,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -388,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -407,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -437,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -470,13 +372,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -491,8 +388,5 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,50 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapIntKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +95,15 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +112,9 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,115 +127,128 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -213,8 +256,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -223,9 +266,11 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "missCount");
@@ -235,7 +280,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -264,10 +309,11 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -277,61 +323,77 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -340,8 +402,10 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -349,31 +413,38 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -382,11 +453,15 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,33 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapLongKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -220,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -247,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -313,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -355,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -369,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -388,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -407,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -437,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -470,11 +372,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -489,8 +388,5 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,50 +15,79 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapLongKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +96,15 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +113,9 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,115 +128,128 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -213,8 +257,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -223,9 +267,11 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "missCount");
@@ -235,7 +281,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -264,10 +310,11 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -277,61 +324,77 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -340,8 +403,10 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -349,31 +414,38 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -382,11 +454,15 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,32 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -219,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -246,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -312,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -354,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -368,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -387,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -406,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -436,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -469,19 +372,13 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,50 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +95,15 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +112,9 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,115 +127,128 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -213,8 +256,8 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -223,9 +266,11 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -235,7 +280,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -264,10 +309,11 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -277,61 +323,77 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -340,8 +402,10 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -349,36 +413,47 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,25 +51,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -100,11 +73,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +84,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -145,19 +115,13 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -173,9 +137,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -183,9 +145,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -221,11 +180,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -235,9 +191,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -262,50 +216,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +240,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -370,7 +281,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +294,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +310,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +328,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +357,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,11 +389,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -522,7 +423,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -552,8 +452,5 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,67 +15,94 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,13 +111,15 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -99,9 +128,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -114,115 +143,128 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -230,8 +272,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -240,9 +282,11 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -252,7 +296,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -281,10 +325,11 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -294,61 +339,77 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -357,8 +418,10 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -366,31 +429,38 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -405,52 +475,62 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,25 +51,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -112,11 +85,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -125,7 +96,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -157,19 +127,13 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -185,9 +149,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -195,9 +157,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -233,11 +192,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -247,9 +203,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -274,50 +228,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -340,7 +252,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -382,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -396,10 +306,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -415,7 +322,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -434,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -464,7 +369,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -497,11 +401,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -550,7 +451,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -593,7 +493,5 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,79 +15,106 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,13 +123,15 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -111,9 +140,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -126,115 +155,128 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -242,8 +284,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -252,9 +294,11 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -264,7 +308,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -293,10 +337,11 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -306,61 +351,77 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -369,8 +430,10 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -378,36 +441,48 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -422,28 +497,30 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -451,47 +528,54 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,49 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -65,34 +52,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -223,9 +176,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -250,50 +201,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -316,7 +225,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -358,7 +266,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,10 +279,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -391,7 +295,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -410,7 +313,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -440,7 +342,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -473,11 +374,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -495,8 +393,5 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,52 +15,82 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedStatsDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -69,13 +99,15 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -84,9 +116,9 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -99,115 +131,128 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -215,8 +260,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -225,9 +270,11 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "missCount");
@@ -237,7 +284,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -266,10 +313,11 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -279,61 +327,77 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -342,8 +406,10 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -351,31 +417,38 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -385,13 +458,17 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
@@ -15,44 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,6 +90,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -69,58 +99,63 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -128,6 +163,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -137,64 +173,83 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -202,8 +257,8 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -212,9 +267,11 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "missCount");
@@ -224,7 +281,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -253,10 +310,11 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -266,61 +324,77 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -329,8 +403,10 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -338,31 +414,38 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -371,11 +454,15 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
@@ -15,74 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +61,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +106,11 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +120,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +154,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +183,13 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +212,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "hitCount");
@@ -302,7 +253,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +266,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +282,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +300,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +329,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,13 +361,8 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -438,8 +377,5 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
@@ -15,45 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +90,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,58 +99,63 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -129,6 +163,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -138,64 +173,83 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -203,8 +257,8 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -213,9 +267,11 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "missCount");
@@ -225,7 +281,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -254,10 +310,11 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -267,61 +324,77 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -330,8 +403,10 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -339,31 +414,38 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -372,11 +454,15 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +107,11 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +121,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +155,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +184,13 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +213,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "hitCount");
@@ -302,7 +254,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +267,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +301,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,11 +362,8 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -436,8 +378,5 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +107,11 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +121,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +155,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +184,13 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +213,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -302,7 +254,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +267,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +301,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,19 +362,13 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
@@ -15,45 +15,74 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +91,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,58 +100,63 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -129,6 +164,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -138,64 +174,83 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -203,8 +258,8 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -213,9 +268,11 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "missCount");
@@ -225,7 +282,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -254,10 +311,11 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -267,61 +325,77 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -330,8 +404,10 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -339,36 +415,47 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +68,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +79,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -152,18 +124,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -173,7 +138,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -208,7 +172,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -238,21 +201,13 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -275,7 +230,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -317,7 +271,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -331,10 +284,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -350,7 +300,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -369,7 +318,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -399,7 +347,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -432,11 +379,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -469,7 +413,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -499,8 +442,5 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
@@ -15,62 +15,89 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,6 +106,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -87,58 +115,63 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -146,6 +179,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -155,64 +189,83 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -220,8 +273,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -230,9 +283,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "missCount");
@@ -242,7 +297,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -271,10 +326,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -284,61 +340,77 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -347,8 +419,10 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -356,31 +430,38 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -395,52 +476,62 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
@@ -15,34 +15,24 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -50,31 +40,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +80,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +91,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -164,18 +136,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -185,7 +150,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -220,7 +184,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -250,21 +213,13 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -287,7 +242,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -329,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -343,10 +296,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -362,7 +312,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -381,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -411,7 +359,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -444,11 +391,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -497,7 +441,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -540,7 +483,5 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
@@ -15,74 +15,101 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,6 +118,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -99,58 +127,63 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -158,6 +191,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -167,64 +201,83 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -232,8 +285,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -242,9 +295,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "missCount");
@@ -254,7 +309,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -283,10 +338,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -296,61 +352,77 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -359,8 +431,10 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -368,36 +442,48 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -412,28 +498,30 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -441,47 +529,54 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
@@ -15,75 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +64,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,18 +109,11 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -159,7 +123,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -194,7 +157,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -224,21 +186,13 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -261,7 +215,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -303,7 +256,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -317,10 +269,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -336,7 +285,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -355,7 +303,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -385,7 +332,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -418,11 +364,8 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -440,8 +383,5 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
@@ -15,47 +15,74 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,6 +91,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -72,58 +100,63 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -131,6 +164,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -140,64 +174,83 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -205,8 +258,8 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -215,9 +268,11 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "missCount");
@@ -227,7 +282,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -256,10 +311,11 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -269,61 +325,77 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -332,8 +404,10 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -341,31 +415,38 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -375,13 +456,17 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
@@ -15,79 +15,49 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +66,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -128,19 +97,13 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -156,9 +119,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -166,9 +127,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -204,18 +162,11 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -225,7 +176,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -260,7 +210,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -290,21 +239,13 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -327,7 +268,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -369,7 +309,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -383,10 +322,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -402,7 +338,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -421,7 +356,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -451,7 +385,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -484,13 +417,8 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -505,8 +433,5 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
@@ -15,49 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -66,13 +95,15 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -81,9 +112,9 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -96,87 +127,101 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -184,6 +229,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -193,64 +239,83 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -258,8 +323,8 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -268,9 +333,11 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "missCount");
@@ -280,7 +347,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -309,10 +376,11 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -322,61 +390,77 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -385,8 +469,10 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -394,31 +480,38 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -427,11 +520,15 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,31 +52,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapLongKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,18 +163,11 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -226,7 +177,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -261,7 +211,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -291,21 +240,13 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +269,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -370,7 +310,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +323,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +357,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,11 +418,8 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -504,8 +434,5 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
@@ -15,50 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapLongKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +97,15 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +114,9 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,87 +129,101 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +231,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,64 +241,83 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -259,8 +325,8 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -269,9 +335,11 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "missCount");
@@ -281,7 +349,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -310,10 +378,11 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -323,61 +392,77 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -386,8 +471,10 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -395,31 +482,38 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -428,11 +522,15 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,50 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapObjectKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +97,15 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +114,9 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,87 +129,101 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +231,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,64 +241,83 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -259,8 +325,8 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -269,9 +335,11 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -281,7 +349,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -310,10 +378,11 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -323,61 +392,77 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -386,8 +471,10 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -395,36 +482,47 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,31 +52,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapObjectKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,18 +163,11 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -226,7 +177,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -261,7 +211,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -291,21 +240,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +269,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -370,7 +310,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +323,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +357,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,19 +418,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,23 +52,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapStringKey1
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -99,11 +73,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -112,7 +84,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -144,19 +115,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -172,9 +137,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -182,9 +145,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -220,18 +180,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -241,7 +194,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -276,7 +228,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -306,21 +257,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -343,7 +286,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -385,7 +327,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -399,10 +340,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -418,7 +356,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -437,7 +374,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -467,7 +403,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -500,11 +435,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -537,7 +469,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -567,8 +498,5 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,67 +15,95 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapStringKey1
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,13 +112,15 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -99,9 +129,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -114,87 +144,101 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -202,6 +246,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -211,64 +256,83 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -276,8 +340,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -286,9 +350,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -298,7 +364,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -327,10 +393,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -340,61 +407,77 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -403,8 +486,10 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -412,31 +497,38 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -451,52 +543,62 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,23 +52,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapStringKey2
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -111,11 +85,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -124,7 +96,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -156,19 +127,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -184,9 +149,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -194,9 +157,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -232,18 +192,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -253,7 +206,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -288,7 +240,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -318,21 +269,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -355,7 +298,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -397,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -411,10 +352,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -430,7 +368,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -449,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -479,7 +415,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -512,11 +447,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -565,7 +497,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -608,7 +539,5 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,79 +15,107 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapStringKey2
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,13 +124,15 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -111,9 +141,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -126,87 +156,101 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -214,6 +258,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -223,64 +268,83 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -288,8 +352,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -298,9 +362,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -310,7 +376,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -339,10 +405,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -352,61 +419,77 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -415,8 +498,10 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -424,36 +509,48 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -468,28 +565,30 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -497,47 +596,54 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,52 +15,81 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -69,13 +98,15 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -84,9 +115,9 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -99,87 +130,101 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -187,6 +232,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -196,64 +242,83 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -261,8 +326,8 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -271,9 +336,11 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "missCount");
@@ -283,7 +350,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -312,10 +379,11 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -325,61 +393,77 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -388,8 +472,10 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -397,31 +483,38 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -431,13 +524,17 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,30 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +69,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +100,13 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +122,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +130,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,18 +165,11 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -227,7 +179,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -262,7 +213,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -292,21 +242,13 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -329,7 +271,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -371,7 +312,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -385,10 +325,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -404,7 +341,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -423,7 +359,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -453,7 +388,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -486,11 +420,8 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -508,8 +439,5 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
@@ -15,41 +15,67 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +83,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,49 +92,48 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -115,8 +141,8 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -125,8 +151,10 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "missCount");
 
@@ -135,7 +163,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -164,10 +192,11 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -177,61 +206,77 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -240,8 +285,10 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -249,31 +296,38 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -282,11 +336,15 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
@@ -15,69 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +57,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,10 +102,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -157,7 +125,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> missCountUpdater =
@@ -197,7 +164,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -211,10 +177,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -230,7 +193,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -249,7 +211,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -279,7 +240,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -312,13 +272,8 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -333,8 +288,5 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
@@ -15,41 +15,67 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +83,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,49 +92,48 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -115,8 +141,8 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -125,8 +151,10 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "missCount");
 
@@ -135,7 +163,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -164,10 +192,11 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -177,61 +206,77 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -240,8 +285,10 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -249,31 +296,38 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -282,11 +336,15 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
@@ -15,69 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +57,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,10 +102,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -157,7 +125,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> missCountUpdater =
@@ -197,7 +164,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -211,10 +177,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -230,7 +193,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -249,7 +211,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -279,7 +240,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -312,11 +272,8 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -331,8 +288,5 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -132,10 +104,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -158,7 +127,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "hitCount");
@@ -200,7 +168,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -214,10 +181,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -233,7 +197,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -252,7 +215,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -282,7 +244,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -315,19 +276,13 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
@@ -15,42 +15,67 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,6 +84,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -67,49 +93,48 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -117,8 +142,8 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -127,9 +152,11 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "missCount");
@@ -139,7 +166,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -168,10 +195,11 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -181,61 +209,77 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -244,8 +288,10 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -253,36 +299,47 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +65,9 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +76,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,10 +121,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -173,7 +144,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "hitCount");
@@ -215,7 +185,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -229,10 +198,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -248,7 +214,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -267,7 +232,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -297,7 +261,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -330,11 +293,8 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -367,7 +327,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -397,8 +356,5 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
@@ -15,59 +15,82 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -76,6 +99,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -84,49 +108,48 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -134,8 +157,8 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -144,9 +167,11 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "missCount");
@@ -156,7 +181,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -185,10 +210,11 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -198,61 +224,77 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -261,8 +303,10 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -270,31 +314,38 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -309,52 +360,62 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
@@ -15,71 +15,94 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,6 +111,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -96,49 +120,48 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -146,8 +169,8 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -156,9 +179,11 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "missCount");
@@ -168,7 +193,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -197,10 +222,11 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -210,61 +236,77 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -273,8 +315,10 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -282,36 +326,48 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -326,28 +382,30 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -355,47 +413,54 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
@@ -15,29 +15,21 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -45,31 +37,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +77,9 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +88,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -159,10 +133,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -185,7 +156,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "hitCount");
@@ -227,7 +197,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -241,10 +210,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -260,7 +226,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -279,7 +244,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -309,7 +273,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -342,11 +305,8 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -395,7 +355,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -438,7 +397,5 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
@@ -15,43 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,6 +84,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -67,49 +93,48 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -117,8 +142,8 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -127,8 +152,10 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "missCount");
 
@@ -137,7 +164,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -166,10 +193,11 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -179,61 +207,77 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -242,8 +286,10 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -251,31 +297,38 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -285,13 +338,17 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -132,10 +104,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -158,7 +127,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> missCountUpdater =
@@ -198,7 +166,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -212,10 +179,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -231,7 +195,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -250,7 +213,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -280,7 +242,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -313,11 +274,8 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -335,8 +293,5 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
@@ -15,46 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +89,15 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,8 +106,9 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,78 +121,86 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -171,8 +208,8 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -181,9 +218,11 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "missCount");
@@ -193,7 +232,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -222,10 +261,11 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -235,61 +275,77 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -298,8 +354,10 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -307,31 +365,38 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -340,11 +405,15 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,10 +158,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -224,7 +181,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -266,7 +222,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -280,10 +235,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -299,7 +251,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -318,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -348,7 +298,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -381,13 +330,8 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -402,8 +346,5 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,10 +158,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -224,7 +181,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -266,7 +222,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -280,10 +235,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -299,7 +251,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -318,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -348,7 +298,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -381,11 +330,8 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -400,8 +346,5 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
@@ -15,46 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +89,15 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,8 +106,9 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,78 +121,86 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -171,8 +208,8 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -181,9 +218,11 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "missCount");
@@ -193,7 +232,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -222,10 +261,11 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -235,61 +275,77 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -298,8 +354,10 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -307,31 +365,38 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -340,11 +405,15 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +94,13 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +116,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +124,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,10 +159,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -225,7 +182,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -267,7 +223,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -281,10 +236,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -300,7 +252,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -319,7 +270,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -349,7 +299,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -382,19 +331,13 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +90,15 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,9 +107,9 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -93,78 +122,86 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -172,8 +209,8 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -182,9 +219,11 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "missCount");
@@ -194,7 +233,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -223,10 +262,11 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -236,61 +276,77 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -299,8 +355,10 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -308,36 +366,47 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
@@ -15,66 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +69,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +80,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -138,19 +111,13 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -166,9 +133,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -176,9 +141,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -214,10 +176,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -240,7 +199,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -282,7 +240,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -296,10 +253,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -315,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -334,7 +287,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -364,7 +316,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -397,11 +348,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -434,7 +382,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -464,8 +411,5 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
@@ -15,63 +15,88 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,13 +105,15 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -95,9 +122,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -110,78 +137,86 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -189,8 +224,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -199,9 +234,11 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "missCount");
@@ -211,7 +248,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -240,10 +277,11 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -253,61 +291,77 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -316,8 +370,10 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -325,31 +381,38 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -364,52 +427,62 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
@@ -15,66 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +81,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +92,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -150,19 +123,13 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -178,9 +145,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -188,9 +153,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -226,10 +188,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +211,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -294,7 +252,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -308,10 +265,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -327,7 +281,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -346,7 +299,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -376,7 +328,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -409,11 +360,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -462,7 +410,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -505,7 +452,5 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
@@ -15,75 +15,100 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,13 +117,15 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -107,9 +134,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -122,78 +149,86 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -201,8 +236,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -211,9 +246,11 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "missCount");
@@ -223,7 +260,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -252,10 +289,11 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -265,61 +303,77 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -328,8 +382,10 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -337,36 +393,48 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -381,28 +449,30 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -410,47 +480,54 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
@@ -15,75 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +65,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +95,13 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +117,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +125,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,10 +160,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -225,7 +183,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -267,7 +224,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -281,10 +237,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -300,7 +253,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -319,7 +271,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -349,7 +300,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -382,11 +332,8 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -404,8 +351,5 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
@@ -15,48 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.InternalStatisticsDisabledException;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedStatsRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +90,15 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,8 +107,9 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -94,78 +122,86 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -173,8 +209,8 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
-    _setLastModified(lastModified);
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
+    setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
@@ -183,9 +219,11 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "hitCount");
+
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "missCount");
@@ -195,7 +233,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return this.lastAccessed;
   }
 
-  private void setLastAccessed(long lastAccessed) {
+  private void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -224,10 +262,11 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -237,61 +276,77 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return true;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -300,8 +355,10 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -309,31 +366,38 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -343,13 +407,17 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,11 +108,8 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -168,9 +134,7 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -195,60 +159,14 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -258,7 +176,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -293,7 +210,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -323,21 +239,13 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -353,7 +261,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -372,7 +279,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -402,7 +308,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -435,13 +340,8 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -456,8 +356,5 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
@@ -15,46 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,6 +90,7 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -71,62 +99,61 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -134,49 +161,60 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -184,6 +222,7 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -193,113 +232,144 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -308,8 +378,10 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -317,31 +389,38 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -350,11 +429,15 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
@@ -15,47 +15,75 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapLongKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,6 +92,7 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -72,62 +101,61 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -135,49 +163,60 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +224,7 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,113 +234,144 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -309,8 +380,10 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -318,31 +391,38 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -351,11 +431,15 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,33 +48,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapLongKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +64,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -140,11 +109,8 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -169,9 +135,7 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -196,60 +160,14 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -259,7 +177,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -294,7 +211,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -324,21 +240,13 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -354,7 +262,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -373,7 +280,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -403,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -436,11 +341,8 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -455,8 +357,5 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,47 +15,74 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapObjectKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,6 +91,7 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -72,62 +100,61 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -135,49 +162,60 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +223,7 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,113 +233,144 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -309,8 +379,10 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -318,36 +390,47 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,32 +48,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapObjectKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +64,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,11 +109,8 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -168,9 +135,7 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -195,60 +160,14 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -258,7 +177,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -293,7 +211,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -323,21 +240,13 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -353,7 +262,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -372,7 +280,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -402,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -435,19 +341,13 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,64 +15,90 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapStringKey1
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,6 +107,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -89,62 +116,61 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -152,49 +178,60 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -202,6 +239,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -211,113 +249,144 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -326,8 +395,10 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -335,31 +406,38 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -374,52 +452,62 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +48,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapStringKey1
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -96,11 +70,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +81,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -155,11 +126,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -184,9 +152,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -211,60 +177,14 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -274,7 +194,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -309,7 +228,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -339,21 +257,13 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -369,7 +279,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -388,7 +297,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -418,7 +326,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -451,11 +358,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -488,7 +392,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -518,8 +421,5 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,34 +15,24 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -50,8 +40,7 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +48,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapStringKey2
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -108,11 +82,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -121,7 +93,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -167,11 +138,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -196,9 +164,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -223,60 +189,14 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -286,7 +206,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -321,7 +240,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -351,21 +269,13 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -381,7 +291,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -400,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -430,7 +338,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -463,11 +370,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -516,7 +420,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -559,7 +462,5 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,76 +15,102 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapStringKey2
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,6 +119,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -101,62 +128,61 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -164,49 +190,60 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -214,6 +251,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -223,113 +261,144 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -338,8 +407,10 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -347,36 +418,48 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -391,28 +474,30 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -420,47 +505,54 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,49 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -66,6 +95,7 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -74,62 +104,61 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -137,49 +166,60 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -187,6 +227,7 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -196,113 +237,144 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -311,8 +383,10 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -320,31 +394,38 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -354,13 +435,17 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,34 +49,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +66,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -143,11 +111,8 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -172,9 +137,7 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -199,60 +162,14 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -262,7 +179,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -297,7 +213,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -327,21 +242,13 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -357,7 +264,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -376,7 +282,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -406,7 +311,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -439,11 +343,8 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -461,8 +362,5 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,51 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context,
+      final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -68,13 +97,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -83,9 +114,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -98,91 +129,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -190,49 +229,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -240,6 +290,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -249,113 +300,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -364,8 +446,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -373,31 +457,38 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -406,11 +497,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,33 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -131,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -159,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -169,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -207,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -236,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -263,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -326,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -361,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -391,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -421,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -440,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -470,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -503,13 +396,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -524,8 +412,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,33 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -131,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -159,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -169,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -207,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -236,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -263,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -326,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -361,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -391,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -421,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -440,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -470,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -503,11 +396,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -522,8 +412,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,51 +15,80 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -68,13 +97,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -83,9 +114,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -98,91 +129,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -190,49 +229,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -240,6 +290,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -249,113 +300,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -364,8 +446,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -373,31 +457,38 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -406,11 +497,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,51 +15,79 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -68,13 +96,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -83,9 +113,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -98,91 +128,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -190,49 +228,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -240,6 +289,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -249,113 +299,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -364,8 +445,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -373,36 +456,47 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,32 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -235,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -262,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -325,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -360,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -390,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -420,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -439,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -469,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -502,19 +396,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,68 +15,95 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,13 +112,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -100,9 +129,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -115,91 +144,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -207,49 +244,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -257,6 +305,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -266,113 +315,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -381,8 +461,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -390,31 +472,38 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -429,52 +518,62 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,25 +52,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -101,11 +74,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +85,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -146,19 +116,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -174,9 +138,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -184,9 +146,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -222,11 +181,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -251,9 +207,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -278,60 +232,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -341,7 +249,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -376,7 +283,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -406,21 +312,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -436,7 +334,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -455,7 +352,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -485,7 +381,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -518,11 +413,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -555,7 +447,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -585,8 +476,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,25 +52,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -113,11 +86,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -126,7 +97,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -158,19 +128,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -186,9 +150,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -196,9 +158,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -234,11 +193,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -263,9 +219,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -290,60 +244,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -353,7 +261,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -388,7 +295,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -418,21 +324,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -448,7 +346,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -467,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -497,7 +393,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -530,11 +425,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -583,7 +475,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -626,7 +517,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,80 +15,107 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,13 +124,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -112,9 +141,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -127,91 +156,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -219,49 +256,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -269,6 +317,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -278,113 +327,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -393,8 +473,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -402,36 +484,48 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -446,28 +540,30 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -475,47 +571,54 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,53 +15,83 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -70,13 +100,15 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -85,9 +117,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -100,91 +132,99 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof LocalRegion) {
+      isBackup = ((LocalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
       throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -192,49 +232,60 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
+
+
+
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -242,6 +293,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -251,113 +303,144 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -366,8 +449,10 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -375,31 +460,38 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -409,13 +501,17 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,34 +53,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +70,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -134,19 +101,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -162,9 +123,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -172,9 +131,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -210,11 +166,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -239,9 +192,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -266,60 +217,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -329,7 +234,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -364,7 +268,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -394,21 +297,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -424,7 +319,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -443,7 +337,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -473,7 +366,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -506,11 +398,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -528,8 +417,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
@@ -15,42 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -59,6 +85,7 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -67,135 +94,151 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -204,8 +247,10 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -213,31 +258,38 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -246,11 +298,15 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
@@ -15,71 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +59,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +104,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -148,9 +115,7 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -175,50 +140,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -234,7 +157,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -253,7 +175,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -283,7 +204,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -316,13 +236,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -337,8 +252,5 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
@@ -15,43 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,6 +85,7 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -68,135 +94,151 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -205,8 +247,10 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -214,31 +258,38 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -247,11 +298,15 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
@@ -15,71 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +105,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -148,9 +116,7 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -175,50 +141,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -234,7 +158,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -253,7 +176,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -283,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -316,11 +237,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -335,8 +253,5 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +60,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +105,8 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -147,9 +116,7 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -174,50 +141,8 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -233,7 +158,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -252,7 +176,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -282,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -315,19 +237,13 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
@@ -15,43 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,6 +85,7 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -68,135 +94,151 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -205,8 +247,10 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -214,36 +258,47 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
@@ -15,63 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -90,11 +66,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -103,7 +77,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -149,11 +122,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -163,9 +133,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -190,50 +158,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -249,7 +175,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -268,7 +193,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -298,7 +222,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -331,11 +254,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -368,7 +288,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -398,8 +317,5 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
@@ -15,60 +15,84 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -77,6 +101,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -85,135 +110,151 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -222,8 +263,10 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -231,31 +274,38 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -270,52 +320,62 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
@@ -15,72 +15,96 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,6 +113,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -97,135 +122,151 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -234,8 +275,10 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -243,36 +286,48 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -287,28 +342,30 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -316,47 +373,54 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
@@ -15,29 +15,21 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -45,33 +37,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -102,11 +78,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -115,7 +89,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -161,11 +134,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -175,9 +145,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -202,50 +170,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -261,7 +187,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -280,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -310,7 +234,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -343,11 +266,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -396,7 +316,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -439,7 +358,5 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
@@ -15,45 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -62,6 +88,7 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -70,135 +97,151 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -207,8 +250,10 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -216,31 +261,38 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -250,13 +302,17 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,11 +107,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -151,9 +118,7 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -178,50 +143,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -237,7 +160,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -256,7 +178,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -286,7 +207,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -319,11 +239,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -341,8 +258,5 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
@@ -15,76 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +64,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +95,13 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +117,7 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +125,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +160,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -215,9 +171,7 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -242,50 +196,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -301,7 +213,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -320,7 +231,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -350,7 +260,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -383,13 +292,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -404,8 +308,5 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
@@ -15,47 +15,73 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -64,13 +90,15 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -79,9 +107,9 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -94,164 +122,189 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -260,8 +313,10 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -269,31 +324,38 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -302,11 +364,15 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
@@ -15,48 +15,75 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapLongKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +92,15 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,9 +109,9 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -95,164 +124,189 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -261,8 +315,10 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -270,31 +326,38 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -303,11 +366,15 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapLongKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,11 +161,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -216,9 +172,7 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -243,50 +197,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -302,7 +214,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -321,7 +232,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -351,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -384,11 +293,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -403,8 +309,5 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,32 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapObjectKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +65,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +96,13 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +118,7 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +126,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +161,8 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -215,9 +172,7 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -242,50 +197,8 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -301,7 +214,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -320,7 +232,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -350,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -383,19 +293,13 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,48 +15,74 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapObjectKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +91,15 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,9 +108,9 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -95,164 +123,189 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -261,8 +314,10 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -270,36 +325,47 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapStringKey1
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -96,11 +71,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +82,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -141,19 +113,13 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -169,9 +135,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -179,9 +143,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -217,11 +178,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -231,9 +189,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -258,50 +214,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -317,7 +231,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -336,7 +249,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -366,7 +278,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -399,11 +310,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -436,7 +344,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -466,8 +373,5 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,65 +15,90 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapStringKey1
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,13 +107,15 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -97,9 +124,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -112,164 +139,189 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -278,8 +330,10 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -287,31 +341,38 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -326,52 +387,62 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,77 +15,102 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapStringKey2
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,13 +119,15 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -109,9 +136,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -124,164 +151,189 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -290,8 +342,10 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -299,36 +353,48 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -343,28 +409,30 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -372,47 +440,54 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapStringKey2
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -108,11 +83,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -121,7 +94,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -153,19 +125,13 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -181,9 +147,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -191,9 +155,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -229,11 +190,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -243,9 +201,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -270,50 +226,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -329,7 +243,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -348,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -378,7 +290,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -411,11 +322,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -464,7 +372,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -507,7 +414,5 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,45 +15,34 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,34 +50,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,11 +163,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -219,9 +174,7 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -246,50 +199,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -305,7 +216,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -324,7 +234,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -354,7 +263,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -387,11 +295,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -409,8 +314,5 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
+
+  public VersionedThinDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+        (value instanceof RecoveredEntry ? null : value)
+
+
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     initialize(context, value);
+
+
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +95,15 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +112,9 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,164 +127,189 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+
+
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
     // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 
   /**
-   * DiskId
-   * 
    * @since GemFire 5.1
    */
-  protected DiskId id;// = new DiskId();
+  protected DiskId id;
 
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((AbstractDiskRegionEntry) oldEntry).getDiskId();
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -263,8 +318,10 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -272,31 +329,38 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -306,13 +370,17 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
@@ -15,43 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -60,6 +88,7 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapIntKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -68,58 +97,63 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -127,6 +161,7 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -136,113 +171,144 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -251,8 +317,10 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -260,31 +328,38 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -293,11 +368,15 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
@@ -15,72 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +105,11 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +119,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +153,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +182,13 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +204,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +222,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +251,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,13 +283,8 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -354,8 +299,5 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
@@ -15,44 +15,71 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,6 +88,7 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapLongKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -69,58 +97,63 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -128,6 +161,7 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -137,113 +171,144 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -252,8 +317,10 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -261,31 +328,38 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -294,11 +368,15 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +106,11 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +120,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +154,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +183,13 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +223,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,11 +284,8 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -352,8 +300,5 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
@@ -15,44 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,6 +89,7 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -69,58 +98,63 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -128,6 +162,7 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -137,113 +172,144 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -252,8 +318,10 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -261,36 +329,47 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +106,11 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +120,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +154,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +183,13 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +223,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,19 +284,13 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
@@ -15,61 +15,87 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,6 +104,7 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -86,58 +113,63 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -145,6 +177,7 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -154,113 +187,144 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -269,8 +333,10 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -278,31 +344,38 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -317,52 +390,62 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -91,11 +67,9 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +78,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -150,18 +123,11 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -171,7 +137,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -206,7 +171,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -236,21 +200,13 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -266,7 +222,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -285,7 +240,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -315,7 +269,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -348,11 +301,8 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -385,7 +335,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,8 +364,5 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
@@ -15,73 +15,99 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,6 +116,7 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -98,58 +125,63 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -157,6 +189,7 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -166,113 +199,144 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -281,8 +345,10 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -290,36 +356,48 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -334,28 +412,30 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -363,47 +443,54 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
@@ -15,32 +15,23 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -48,31 +39,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -103,11 +79,9 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +90,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -162,18 +135,11 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -183,7 +149,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -218,7 +183,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -248,21 +212,13 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -278,7 +234,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -297,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -327,7 +281,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -360,11 +313,8 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -413,7 +363,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -456,7 +405,5 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
@@ -15,73 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +63,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -136,18 +108,11 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -157,7 +122,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -192,7 +156,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -222,21 +185,13 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -252,7 +207,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -271,7 +225,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -301,7 +254,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -334,11 +286,8 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -356,8 +305,5 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
@@ -15,46 +15,72 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,6 +89,7 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapUUIDKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -71,58 +98,63 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -130,6 +162,7 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -139,113 +172,144 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -254,8 +318,10 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -263,31 +329,38 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -297,13 +370,17 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
@@ -15,77 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,18 +161,11 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -223,7 +175,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -258,7 +209,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -288,21 +238,13 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -318,7 +260,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -337,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -367,7 +307,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -400,13 +339,8 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -421,8 +355,5 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
@@ -15,48 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +93,15 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,9 +110,9 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -95,87 +125,101 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -183,6 +227,7 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -192,113 +237,144 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -307,8 +383,10 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -316,31 +394,38 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -349,11 +434,15 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
@@ -15,48 +15,76 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -65,13 +93,15 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -80,9 +110,9 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -95,87 +125,101 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -183,6 +227,7 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -192,113 +237,144 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -307,8 +383,10 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -316,31 +394,38 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -349,11 +434,15 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
@@ -15,77 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,18 +161,11 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -223,7 +175,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -258,7 +209,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -288,21 +238,13 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -318,7 +260,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -337,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -367,7 +307,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -400,11 +339,8 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -419,8 +355,5 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
@@ -15,49 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapObjectKey
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -66,13 +95,15 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -81,9 +112,9 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -96,87 +127,101 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -184,6 +229,7 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -193,113 +239,144 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
     // default implementation.
     return getKey();
+
+
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -308,8 +385,10 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -317,36 +396,47 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,31 +51,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapObjectKey
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +66,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +97,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +119,7 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +127,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,18 +162,11 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -224,7 +176,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -259,7 +210,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -289,21 +239,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +261,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +279,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +308,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,19 +340,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
@@ -15,66 +15,93 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapStringKey1
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,13 +110,15 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -98,9 +127,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -113,87 +142,101 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -201,6 +244,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -210,113 +254,144 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -325,8 +400,10 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -334,31 +411,38 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -373,52 +457,62 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,23 +51,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapStringKey1
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -97,11 +72,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +83,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -142,19 +114,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -170,9 +136,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -180,9 +144,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -218,18 +179,11 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -239,7 +193,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -274,7 +227,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -304,21 +256,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -334,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -353,7 +296,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -383,7 +325,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -416,11 +357,8 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -453,7 +391,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -483,8 +420,5 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,23 +51,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapStringKey2
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -109,11 +84,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -122,7 +95,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -154,19 +126,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -182,9 +148,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -192,9 +156,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -230,18 +191,11 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -286,7 +239,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -316,21 +268,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -346,7 +290,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -365,7 +308,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -395,7 +337,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -428,11 +369,8 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -481,7 +419,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -524,7 +461,5 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
@@ -15,78 +15,105 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapStringKey2
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,13 +122,15 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -110,9 +139,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -125,87 +154,101 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -213,6 +256,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -222,113 +266,144 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -337,8 +412,10 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -346,36 +423,48 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -390,28 +479,30 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -419,47 +510,54 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,77 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -67,13 +94,15 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -82,9 +111,9 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -97,87 +126,101 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    // nothing needed for LRUs with no disk
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  // lru code
+
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+
+
+
+    // nothing needed for LRUs with no disk
+
+  }
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // 1: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +228,7 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,113 +238,144 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
   public Object getKeyForSizing() {
+
+
+
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
+
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -309,8 +384,10 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -318,31 +395,38 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -352,13 +436,17 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,78 +15,50 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +67,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +98,13 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +120,7 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +128,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,18 +163,11 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -224,7 +177,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -259,7 +211,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -289,21 +240,13 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +262,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +280,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +309,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,11 +341,8 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -423,8 +360,5 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
@@ -15,65 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +55,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,10 +100,7 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -146,7 +116,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -165,7 +134,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -195,7 +163,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -228,13 +195,8 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -249,8 +211,5 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
@@ -15,39 +15,63 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +79,7 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapIntKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,98 +88,109 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -163,8 +199,10 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -172,31 +210,38 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -205,11 +250,15 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
@@ -15,39 +15,63 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -55,6 +79,7 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapLongKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -63,98 +88,109 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -163,8 +199,10 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -172,31 +210,38 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -205,11 +250,15 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
@@ -15,65 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +55,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,10 +100,7 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -146,7 +116,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -165,7 +134,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -195,7 +163,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -228,11 +195,8 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -247,8 +211,5 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
@@ -15,40 +15,63 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +80,7 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapObjectKey.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,98 +89,109 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -165,8 +200,10 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -174,36 +211,47 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +57,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,10 +102,7 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -147,7 +118,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -166,7 +136,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -196,7 +165,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -229,19 +197,13 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
@@ -15,57 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -84,11 +63,9 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +74,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -143,10 +119,7 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -162,7 +135,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -181,7 +153,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -211,7 +182,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -244,11 +214,8 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -281,7 +248,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -311,8 +277,5 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
@@ -15,57 +15,78 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,6 +95,7 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey1.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -82,98 +104,109 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -182,8 +215,10 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -191,31 +226,38 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -230,52 +272,62 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
@@ -15,69 +15,90 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+
+
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,6 +107,7 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey2.class,
           "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -94,98 +116,109 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -194,8 +227,10 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -203,36 +238,48 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -247,28 +294,30 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -276,47 +325,54 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
@@ -15,25 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -41,31 +35,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -96,11 +75,9 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +86,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -155,10 +131,7 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -174,7 +147,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -193,7 +165,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -223,7 +194,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -256,11 +226,8 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -309,7 +276,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -352,7 +318,5 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
@@ -15,41 +15,64 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -57,6 +80,7 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapUUIDKey.class, "lastModified");
+
   private volatile Object value;
 
   @Override
@@ -65,98 +89,109 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -165,8 +200,10 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -174,31 +211,38 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -208,13 +252,17 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +57,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,10 +102,7 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -147,7 +118,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -166,7 +136,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -196,7 +165,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -229,11 +197,8 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -251,8 +216,5 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
@@ -15,44 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +85,15 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,8 +102,9 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -90,127 +117,147 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -219,8 +266,10 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -228,31 +277,38 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final int key;
 
   @Override
@@ -261,11 +317,15 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,10 +156,7 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -213,7 +172,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -232,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -262,7 +219,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -295,13 +251,8 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -316,8 +267,5 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,10 +156,7 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -213,7 +172,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -232,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -262,7 +219,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -295,11 +251,8 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -314,8 +267,5 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
@@ -15,44 +15,68 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +85,15 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,8 +102,9 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -90,127 +117,147 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -219,8 +266,10 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -228,31 +277,38 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long key;
 
   @Override
@@ -261,11 +317,15 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
@@ -15,44 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
     this.key = key;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -61,13 +86,15 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -76,9 +103,9 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -91,127 +118,147 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -220,8 +267,10 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -229,36 +278,47 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +92,13 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +114,7 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +122,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,10 +157,7 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -214,7 +173,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -233,7 +191,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -263,7 +220,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -296,19 +252,13 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
@@ -15,61 +15,84 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,13 +101,15 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -93,9 +118,9 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -108,127 +133,147 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -237,8 +282,10 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -246,31 +293,38 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long bits1;
 
   private int getKeyLength() {
@@ -285,52 +339,62 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
@@ -15,62 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -89,11 +67,9 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +78,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -134,19 +109,13 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -162,9 +131,7 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -172,9 +139,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -210,10 +174,7 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -229,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -248,7 +208,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -278,7 +237,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -311,11 +269,8 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -348,7 +303,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -378,8 +332,5 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
@@ -15,73 +15,96 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key,
+
+      @Retained
+
+      final Object value
+
+      , final boolean byteEncode
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,13 +113,15 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -105,9 +130,9 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> offHeapAddressUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -120,127 +145,147 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -249,8 +294,10 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -258,36 +305,48 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
+
+
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
   private final long bits1;
-  // bits2 encodes character data
+
+  /**
+   * bits2 encodes character data
+   */
   private final long bits2;
 
   private int getKeyLength() {
@@ -302,28 +361,30 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -331,47 +392,54 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
@@ -15,62 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -101,11 +79,9 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +90,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -146,19 +121,13 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -174,9 +143,7 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -184,9 +151,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -222,10 +186,7 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -241,7 +202,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -260,7 +220,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -290,7 +249,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -323,11 +281,8 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -376,7 +331,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -419,7 +373,5 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
@@ -15,71 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +63,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +93,13 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +115,7 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +123,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,10 +158,7 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -214,7 +174,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -233,7 +192,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -263,7 +221,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -296,11 +253,8 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -318,8 +272,5 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
@@ -15,46 +15,69 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+
+
 import java.util.UUID;
+
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
 import org.apache.geode.cache.EntryEvent;
+
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
+
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
-    super(context, value);
+
+  public VersionedThinRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+
+      @Retained
+
+      final Object value
+
+
+
+  ) {
+    super(context,
+
+
+
+        value
+
+    );
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
+
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -63,13 +86,15 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
           "lastModified");
+
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using offHeapAddressUpdater so it is used even though the compiler can not tell
+   * it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
@@ -78,8 +103,9 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
    * re and we will once again be deadlocked. I don't know if we support any of the hardware
    * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class, "ohAddress");
+  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> offHeapAddressUpdater =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
 
   @Override
   public Token getValueAsToken() {
@@ -92,127 +118,147 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
+
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+
+
+
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
+
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return offHeapAddressUpdater.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return offHeapAddressUpdater.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
+
   @Released
+
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
+
 
   protected long getLastModifiedField() {
     return lastModifiedUpdater.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
     return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
     return this.next;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> next) {
+    this.next = next;
   }
 
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // versioned code
-  private VersionSource memberID;
+
+  private VersionSource memberId;
   private short entryVersionLowBytes;
   private short regionVersionHighBytes;
   private int regionVersionLowBytes;
   private byte entryVersionHighByte;
   private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -221,8 +267,10 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -230,31 +278,38 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   // key code
+
+
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -264,13 +319,17 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
     return false;
   }
+
+
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
+

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/lru/LRUEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/lru/LRUEntry.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.cache.lru;
 
-import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.RegionEntry;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 
 /**
  * Represents an entry in an LRU map
@@ -25,7 +25,7 @@ public interface LRUEntry extends LRUClockNode, RegionEntry {
    * If the key is stored as an Object then returns that object; but if the key is stored as
    * primitives then returns null.
    */
-  public Object getKeyForSizing();
+  Object getKeyForSizing();
 
-  public void setDelayedDiskId(LocalRegion r);
+  void setDelayedDiskId(DiskRecoveryStore diskRecoveryStore);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchEntriesMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchEntriesMessage.java
@@ -295,7 +295,7 @@ public class FetchEntriesMessage extends PartitionMessage {
           LocalRegion.NonTXEntry entry = (LocalRegion.NonTXEntry) it.next();
           RegionEntry re = entry.getRegionEntry();
           synchronized (re) {
-            Object value = re._getValueRetain(map, true);
+            Object value = re.getValueRetain(map, true);
             try {
               if (value == null) {
                 // only possible for disk entry

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskRecoveryStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskRecoveryStore.java
@@ -21,8 +21,6 @@ import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.RegionMap;
-import org.apache.geode.internal.cache.DiskEntry.RecoveredEntry;
-import org.apache.geode.internal.cache.LocalRegion.RegionEntryCallback;
 import org.apache.geode.internal.cache.versions.RegionVersionHolder;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionTag;
@@ -30,7 +28,6 @@ import org.apache.geode.internal.cache.versions.VersionTag;
 /**
  * Used by the disk code to store recovered data into the cache. The primary implementor of this
  * interface is LocalRegion.
- *
  *
  * @since GemFire prPersistSprint3
  */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -1262,7 +1262,7 @@ public abstract class BaseCommand implements Command {
           VersionStamp vs = ((NonTXEntry) entry).getRegionEntry().getVersionStamp();
           vt = vs == null ? null : vs.asVersionTag();
           key = entry.getKey();
-          value = ((NonTXEntry) entry).getRegionEntry()._getValueRetain(region, true);
+          value = ((NonTXEntry) entry).getRegionEntry().getValueRetain(region, true);
           try {
             updateValues(values, key, value, vt);
           } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.versions;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
@@ -28,11 +27,8 @@ import org.apache.geode.internal.DataSerializableFixedID;
  * (for a persistent region).
  * 
  * VersionMembers should implement equals and hashcode.
- * 
- *
  */
 public interface VersionSource<T> extends DataSerializableFixedID, Comparable<T> {
 
-  public void writeEssentialData(DataOutput out) throws IOException;
-
+  void writeEssentialData(DataOutput out) throws IOException;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionStamp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionStamp.java
@@ -15,27 +15,15 @@
 package org.apache.geode.internal.cache.versions;
 
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 
-/**
- *
- */
-public interface VersionStamp<T extends VersionSource> extends VersionHolder<T> {
-
-
+public interface VersionStamp<T extends VersionSource<T>> extends VersionHolder<T> {
 
   /**
-   * set the time stamp from the given clock value
+   * Sets the time stamp from the given clock value
    */
   void setVersionTimeStamp(long time);
-
-  // /**
-  // * @return the ID of the previous member that last changed the corresponding entry.
-  // */
-  // DistributedMember getPreviousMemberID();
-
 
   /**
    * Sets the version information with what is in the tag
@@ -49,44 +37,36 @@ public interface VersionStamp<T extends VersionSource> extends VersionHolder<T> 
    */
   void setMemberID(VersionSource memberID);
 
-  // /**
-  // * @param previousMemberID the previousMemberID to set
-  // */
-  // void setPreviousMemberID(DistributedMember previousMemberID);
-
   /**
-   * returns a VersionTag carrying this stamps information. This is used for transmission of the
+   * Returns a VersionTag carrying this stamps information. This is used for transmission of the
    * stamp in initial image transfer
    */
   VersionTag<T> asVersionTag();
 
-
   /**
    * Perform a versioning check with the incoming event. Throws a
    * ConcurrentCacheModificationException if there is a problem.
-   * 
-   * @param event
    */
-  public void processVersionTag(EntryEvent event);
+  void processVersionTag(EntryEvent event);
 
   /**
    * Perform a versioning check with the given GII information. Throws a
    * ConcurrentCacheModificationException if there is a problem.
    * 
-   * @param r the region being modified
+   * @param region the region being modified
    * @param tag the version info for the modification
    * @param isTombstoneFromGII it's a tombstone
    * @param hasDelta it has delta
-   * @param thisVM this cache's DM identifier
+   * @param versionSource this cache's DM identifier
    * @param sender the identifier of the member providing the entry
    * @param checkConflicts true if conflict checks should be performed
    */
-  public void processVersionTag(LocalRegion r, VersionTag<T> tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
+  void processVersionTag(InternalRegion region, VersionTag<T> tag, boolean isTombstoneFromGII,
+      boolean hasDelta, VersionSource<T> versionSource, InternalDistributedMember sender,
       boolean checkConflicts);
 
   /**
-   * return true if this stamp has valid entry/region version information, false if not
+   * Returns true if this stamp has valid entry/region version information, false if not
    */
-  public boolean hasValidVersion();
+  boolean hasValidVersion();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/MemoryAllocatorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/MemoryAllocatorImpl.java
@@ -285,7 +285,7 @@ public class MemoryAllocatorImpl implements MemoryAllocator {
          * value could be GATEWAY_SENDER_EVENT_IMPL_VALUE or region entry value.
          */
         @Unretained(OffHeapIdentifier.GATEWAY_SENDER_EVENT_IMPL_VALUE)
-        Object value = re._getValue();
+        Object value = re.getValue();
         if (value instanceof OffHeapStoredObject) {
           result.add((OffHeapStoredObject) value);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
@@ -1040,8 +1040,8 @@ public class CustomEntryConcurrentHashMap<K, V> extends AbstractMap<K, V>
                   if (p instanceof RegionEntry) {
                     // It is ok to call GatewaySenderEventImpl release without being synced
                     // on the region entry. It will not create an orphan.
-                    GatewaySenderEventImpl.release(((RegionEntry) p)._getValue()); // OFFHEAP
-                                                                                   // _getValue ok
+                    GatewaySenderEventImpl.release(((RegionEntry) p).getValue()); // OFFHEAP
+                                                                                  // _getValue ok
                   }
                 }
               }

--- a/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -1912,7 +1912,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           LocalRegion reRegion;
           reRegion = (LocalRegion) region;
           RegionEntry re = reRegion.getRegionEntry(key2);
-          StoredObject so = (StoredObject) re._getValue();
+          StoredObject so = (StoredObject) re.getValue();
           assertEquals(1, so.getRefCount());
           assertEquals(1, ma.getStats().getObjects());
         }
@@ -2000,7 +2000,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           assertEquals(2, ma.getStats().getObjects());
           LocalRegion reRegion;
           reRegion = (LocalRegion) region;
-          StoredObject so = (StoredObject) reRegion.getRegionEntry(key)._getValue();
+          StoredObject so = (StoredObject) reRegion.getRegionEntry(key).getValue();
           assertEquals(1, so.getRefCount());
         }
       }
@@ -2067,7 +2067,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
             assertEquals(2, ma.getStats().getObjects());
             LocalRegion reRegion;
             reRegion = (LocalRegion) region;
-            StoredObject so = (StoredObject) reRegion.getRegionEntry(key)._getValue();
+            StoredObject so = (StoredObject) reRegion.getRegionEntry(key).getValue();
             assertEquals(1, so.getRefCount());
           }
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.Lock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.AttributesMutator;
 import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.CacheWriterException;
@@ -39,6 +40,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionExistsException;
 import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
@@ -49,6 +51,9 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.extension.ExtensionPoint;
 import org.apache.geode.internal.cache.extension.SimpleExtensionPoint;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.cache.versions.VersionSource;
+import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 /**
@@ -465,6 +470,112 @@ public class AbstractRegionJUnitTest {
 
     @Override
     public CachePerfStats getCachePerfStats() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RegionVersionVector getVersionVector() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getValueInVM(Object key) throws EntryNotFoundException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getValueOnDisk(Object key) throws EntryNotFoundException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUsedForPartitionedRegionAdmin() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImageState getImageState() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VersionSource getVersionMember() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FilterProfile getFilterProfile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerRegionProxy getServerProxy() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unscheduleTombstone(RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addExpiryTaskIfAbsent(RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+        throws CacheWriterException, EntryNotFoundException, TimeoutException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void recordEvent(InternalCacheEvent event) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isConcurrencyChecksEnabled() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isThisRegionBeingClosedOrDestroyed() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DiskRegion getDiskRegion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CancelCriterion getCancelCriterion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int updateSizeOnEvict(Object key, int oldSize) {
       throw new UnsupportedOperationException();
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
@@ -169,8 +169,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
 
   /**
    * This method clears the region and notifies the other member when complete
-   * 
-   * @throws InterruptedException
    */
   private static void invokeRemoteClearAndWait(VM remoteVM, VM thisVM) {
     remoteVM.invoke(() -> clearRegionAndNotify(thisVM));
@@ -288,7 +286,7 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
      * Overridden setValue method to call clear Region before actually writing the entry
      */
     @Override
-    public boolean initialImageInit(final LocalRegion r, final long lastModifiedTime,
+    public boolean initialImageInit(final InternalRegion r, final long lastModifiedTime,
         final Object newValue, final boolean create, final boolean wasRecovered,
         final boolean versionTagAccepted) throws RegionClearedException {
       synchronized (clearOccurred) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRDataStoreMemoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRDataStoreMemoryJUnitTest.java
@@ -78,7 +78,7 @@ public class PRDataStoreMemoryJUnitTest {
     Integer val1 = new Integer(16);
     regionAck1.put(new Integer(1), val1);
     Object storedVal =
-        regionAck1.getBucketRegion(new Integer(1)).getRegionEntry(new Integer(1))._getValue();
+        regionAck1.getBucketRegion(new Integer(1)).getRegionEntry(new Integer(1)).getValue();
     final int size1 = CachedDeserializableFactory.calcMemSize(storedVal);
     int size = size1;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());
@@ -86,7 +86,7 @@ public class PRDataStoreMemoryJUnitTest {
     byte[] val2 = new byte[1000];
     regionAck1.put(new Integer(2), val2);
     storedVal =
-        regionAck1.getBucketRegion(new Integer(2)).getRegionEntry(new Integer(2))._getValue();
+        regionAck1.getBucketRegion(new Integer(2)).getRegionEntry(new Integer(2)).getValue();
     final int size2 = CachedDeserializableFactory.calcMemSize(storedVal);
     size += size2;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());
@@ -94,7 +94,7 @@ public class PRDataStoreMemoryJUnitTest {
     String val3 = "0123456789";
     regionAck1.put(new Integer(3), val3);
     storedVal =
-        regionAck1.getBucketRegion(new Integer(3)).getRegionEntry(new Integer(3))._getValue();
+        regionAck1.getBucketRegion(new Integer(3)).getRegionEntry(new Integer(3)).getValue();
     final int size3 = CachedDeserializableFactory.calcMemSize(storedVal);
     size += size3;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -4400,7 +4400,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
   public Object getEntryValue(final CustId custId0, PartitionedRegion cust) {
     RegionEntry entry = cust.getBucketRegion(custId0).getRegionEntry(custId0);
-    Object value = entry._getValue();
+    Object value = entry.getValue();
     return value;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/Bug43684DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/Bug43684DUnitTest.java
@@ -353,7 +353,7 @@ public class Bug43684DUnitTest extends JUnit4DistributedTestCase {
     LocalRegion r = (LocalRegion) cache.getRegion(REGION_NAME);
     for (int i = 0; i < numBuckets; i++) {
       RegionEntry e = r.getRegionEntry("KEY_" + i);
-      cache.getLoggerI18n().info(LocalizedStrings.DEBUG, e._getValue());
+      cache.getLoggerI18n().info(LocalizedStrings.DEBUG, e.getValue());
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapValidationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapValidationJUnitTest.java
@@ -279,7 +279,7 @@ public class OffHeapValidationJUnitTest {
   }
 
   private long getMemoryAddress(Region region, String key) {
-    Object entry = ((LocalRegion) region).getRegionEntry(key)._getValue();
+    Object entry = ((LocalRegion) region).getRegionEntry(key).getValue();
     assertTrue(entry instanceof OffHeapStoredObject);
     long memoryAddress = ((OffHeapStoredObject) entry).getAddress();
     assertTrue(memoryAddress > 0);


### PR DESCRIPTION
* this fixes the white space and some comments
* also removes commented out code

The only file I changed directly is LeafRegionEntry.cpp.

All of the Java files are generated by executing dev-tools/generateRegionEntryClasses.sh from the command-line on a Linux machine. Note: if you do this from Mac, we get some messed up Java comments and lots of extra white space lines (which is what happened in the previous commit for these Java files).