### PR TITLE
GEODE-3870: regenerate Region Entry classes from Linux

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LeafRegionEntry.cpp
@@ -239,9 +239,6 @@ public class LEAF_CLASS extends PARENT_CLASS {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-//    if (this instanceof VMThinRegionEntryLongKey) {
-//      factory.returnToPool((VMThinRegionEntryLongKey)this);
-//    }
   }
 #else    
   private volatile Object value;
@@ -343,45 +340,6 @@ public class LEAF_CLASS extends PARENT_CLASS {
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry)old).getDiskId();
   }
-//  // inlining DiskId
-//  // always have these fields
-//  /**
-//   * id consists of
-//   * most significant
-//   * 1 byte = users bits
-//   * 2-8 bytes = oplog id
-//   * least significant.
-//   * 
-//   * The highest bit in the oplog id part is set to 1 if the oplog id
-//   * is negative.
-//   * @todo this field could be an int for an overflow only region
-//   */
-//  private long id;
-//  /**
-//   * Length of the bytes on disk.
-//   * This is always set. If the value is invalid then it will be set to 0.
-//   * The most significant bit is used by overflow to mark it as needing to be written.
-//   */
-//  protected int valueLength = 0;
-//  // have intOffset or longOffset
-//  // intOffset
-//  /**
-//   * The position in the oplog (the oplog offset) where this entry's value is
-//   * stored
-//   */
-//  private volatile int offsetInOplog;
-//  // longOffset
-//  /**
-//   * The position in the oplog (the oplog offset) where this entry's value is
-//   * stored
-//   */
-//  private volatile long offsetInOplog;
-//  // have overflowOnly or persistence
-//  // overflowOnly
-//  // no fields
-//  // persistent
-//  /** unique entry identifier * */
-//  private long keyId;
 #endif
   
 #ifdef LRU
@@ -395,7 +353,7 @@ public class LEAF_CLASS extends PARENT_CLASS {
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
 #else
-  // nothing needed for LRUs with no disk
+    // nothing needed for LRUs with no disk
 #endif
   }
   public synchronized int updateEntrySize(EnableLRU capacityController) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +128,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +153,14 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +170,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +204,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +233,13 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +262,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
@@ -394,7 +301,6 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -408,14 +314,8 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -430,8 +330,5 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +128,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +153,14 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +170,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +204,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +233,13 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +262,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> missCountUpdater =
@@ -394,7 +301,6 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -408,12 +314,8 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -428,8 +330,5 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,70 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +59,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +104,8 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -162,9 +130,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -189,60 +155,14 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -252,7 +172,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -287,7 +206,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -317,21 +235,13 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -354,7 +264,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -396,7 +305,6 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -410,20 +318,13 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,28 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -44,34 +35,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -90,11 +65,9 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -103,7 +76,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -149,11 +121,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -178,9 +147,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -205,60 +172,14 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -268,7 +189,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -303,7 +223,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -333,21 +252,13 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -370,7 +281,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -412,7 +322,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -426,12 +335,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -464,7 +369,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -494,8 +398,5 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,28 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -45,33 +36,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegionEntryHeap {
   public VMStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -102,11 +77,9 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -115,7 +88,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -161,11 +133,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -190,9 +159,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -217,60 +184,14 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -280,7 +201,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -315,7 +235,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -345,21 +264,13 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -382,7 +293,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -424,7 +334,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -438,12 +347,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -492,7 +397,6 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -535,7 +439,5 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,74 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +59,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -136,11 +104,8 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -165,9 +130,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -192,60 +155,14 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -255,7 +172,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -290,7 +206,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -320,21 +235,13 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -357,7 +264,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
@@ -397,7 +303,6 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -411,12 +316,8 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -434,8 +335,5 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +93,13 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +115,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +123,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +158,8 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +184,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +209,14 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +226,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +260,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +289,13 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +318,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -463,7 +359,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,14 +372,8 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -499,8 +388,5 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +93,13 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +115,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +123,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +158,8 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +184,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +209,14 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +226,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +260,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +289,13 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +318,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -463,7 +359,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,12 +372,8 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -497,8 +388,5 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,75 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +63,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -124,19 +94,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -152,9 +116,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -162,9 +124,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -200,11 +159,8 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -229,9 +185,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -256,60 +210,14 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -319,7 +227,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -354,7 +261,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -384,21 +290,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -421,7 +319,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -463,7 +360,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -477,20 +373,13 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -95,11 +69,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -108,7 +80,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -140,19 +111,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -168,9 +133,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -178,9 +141,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -216,11 +176,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -245,9 +202,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -272,60 +227,14 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -335,7 +244,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -370,7 +278,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -400,21 +307,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -437,7 +336,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -479,7 +377,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -493,12 +390,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -531,7 +424,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -561,8 +453,5 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -107,11 +81,9 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -120,7 +92,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -152,19 +123,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -180,9 +145,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -190,9 +153,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -228,11 +188,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -257,9 +214,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -284,60 +239,14 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -347,7 +256,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -382,7 +290,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -412,21 +319,13 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -449,7 +348,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -491,7 +389,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -505,12 +402,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -559,7 +452,6 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -602,7 +494,5 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,79 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegionEntryOffHeap {
   public VMStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +95,13 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +117,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +125,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,11 +160,8 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -232,9 +186,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -259,60 +211,14 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -322,7 +228,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -357,7 +262,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -387,21 +291,13 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -424,7 +320,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -466,7 +361,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -480,12 +374,8 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -503,8 +393,5 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapIntKey.java
@@ -15,68 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -144,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -171,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -237,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> missCountUpdater =
@@ -277,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -291,14 +212,8 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -313,8 +228,5 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapLongKey.java
@@ -15,68 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -144,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -171,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -237,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> missCountUpdater =
@@ -277,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -291,12 +212,8 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -311,8 +228,5 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapObjectKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,11 +100,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -143,9 +111,7 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -170,50 +136,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -236,7 +160,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
@@ -276,7 +199,6 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -290,20 +212,13 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey1.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -41,34 +33,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -87,11 +63,9 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +73,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -145,11 +118,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -159,9 +129,7 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -186,50 +154,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +178,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
@@ -292,7 +217,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,12 +230,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -344,7 +264,6 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -374,8 +293,5 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapStringKey2.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -42,33 +34,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -99,11 +75,9 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -111,7 +85,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -157,11 +130,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -171,9 +141,7 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,50 +166,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -264,7 +190,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
@@ -304,7 +229,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -318,12 +242,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -372,7 +292,6 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,7 +334,5 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,71 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +57,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +102,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -147,9 +113,7 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -174,50 +138,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -240,7 +162,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
@@ -280,7 +201,6 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -294,12 +214,8 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -317,8 +233,5 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,73 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +90,13 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +112,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +120,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +155,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +166,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +191,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +215,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
@@ -343,7 +254,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -357,14 +267,8 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -379,8 +283,5 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,73 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +90,13 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +112,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +120,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +155,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +166,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +191,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +215,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
@@ -343,7 +254,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -357,12 +267,8 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -377,8 +283,5 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +91,13 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +113,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +121,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,11 +156,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -210,9 +167,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -237,50 +192,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -303,7 +216,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -345,7 +257,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -359,20 +270,13 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -92,11 +67,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -105,7 +78,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -136,19 +108,13 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -164,9 +130,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -174,9 +138,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -212,11 +173,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -226,9 +184,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -253,50 +209,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +233,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -361,7 +274,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -375,12 +287,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -413,7 +321,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -443,8 +350,5 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -104,11 +79,9 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -117,7 +90,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -148,19 +120,13 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -176,9 +142,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -186,9 +150,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -224,11 +185,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -238,9 +196,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,50 +221,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -331,7 +245,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -373,7 +286,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -387,12 +299,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -441,7 +349,6 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -484,7 +391,5 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntryOffHeap {
   public VMStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +92,13 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +114,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +122,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,11 +157,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -213,9 +168,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -240,50 +193,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -306,7 +217,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -346,7 +256,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -360,12 +269,8 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -383,8 +288,5 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapIntKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,14 +258,8 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -328,8 +274,5 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapLongKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,12 +258,8 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -326,8 +274,5 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapObjectKey.java
@@ -15,67 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,18 +100,11 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -150,7 +114,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -185,7 +148,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -215,21 +177,13 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +206,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> missCountUpdater =
@@ -292,7 +245,6 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -306,20 +258,13 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey1.java
@@ -15,26 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -42,32 +34,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -86,11 +63,9 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +73,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -144,18 +118,11 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -165,7 +132,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -200,7 +166,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -230,21 +195,13 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -267,7 +224,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> missCountUpdater =
@@ -307,7 +263,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -321,12 +276,8 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -359,7 +310,6 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -389,8 +339,5 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapStringKey2.java
@@ -15,26 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -43,31 +35,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -98,11 +75,9 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +85,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -156,18 +130,11 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -177,7 +144,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -212,7 +178,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -242,21 +207,13 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -279,7 +236,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> missCountUpdater =
@@ -319,7 +275,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -333,12 +288,8 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -387,7 +338,6 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -430,7 +380,5 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryHeapUUIDKey.java
@@ -15,68 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +57,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -130,18 +102,11 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -151,7 +116,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -186,7 +150,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -216,21 +179,13 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -253,7 +208,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
@@ -293,7 +247,6 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -307,12 +260,8 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -330,8 +279,5 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapIntKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,18 +155,11 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -216,7 +169,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -251,7 +203,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -281,21 +232,13 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -318,7 +261,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
@@ -358,7 +300,6 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,14 +313,8 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -394,8 +329,5 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapLongKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,18 +155,11 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -216,7 +169,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -251,7 +203,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -281,21 +232,13 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -318,7 +261,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
@@ -358,7 +300,6 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,12 +313,8 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -392,8 +329,5 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +91,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +113,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +121,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,18 +156,11 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -217,7 +170,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -252,7 +204,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -282,21 +233,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +262,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
@@ -360,7 +302,6 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -374,20 +315,13 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -91,11 +67,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +78,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -135,19 +108,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -163,9 +130,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -173,9 +138,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -211,18 +173,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -232,7 +187,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -267,7 +221,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -297,21 +250,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -334,7 +279,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -376,7 +320,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -390,12 +333,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -428,7 +367,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -458,8 +396,5 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -103,11 +79,9 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +90,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -147,19 +120,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -175,9 +142,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -185,9 +150,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -223,18 +185,11 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -244,7 +199,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -279,7 +233,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -309,21 +262,13 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -346,7 +291,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -388,7 +332,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -402,12 +345,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -456,7 +395,6 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -499,7 +437,5 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,73 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
+// lru: LRU
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOffHeap {
   public VMStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +62,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -120,19 +92,13 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -148,9 +114,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -158,9 +122,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -196,18 +157,11 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -217,7 +171,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -252,7 +205,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -282,21 +234,13 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -319,7 +263,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -359,7 +302,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -373,12 +315,8 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -396,8 +334,5 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapIntKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,14 +172,8 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -226,8 +188,5 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapLongKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,12 +172,8 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -224,8 +188,5 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapObjectKey.java
@@ -15,62 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -78,7 +52,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -124,10 +97,7 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -150,7 +120,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> missCountUpdater =
@@ -190,7 +159,6 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -204,20 +172,13 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey1.java
@@ -15,21 +15,15 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -37,32 +31,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -81,11 +60,9 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +70,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,10 +115,7 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -165,7 +138,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> missCountUpdater =
@@ -205,7 +177,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -219,12 +190,8 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -257,7 +224,6 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -287,8 +253,5 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapStringKey2.java
@@ -15,21 +15,15 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
@@ -38,31 +32,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -93,11 +72,9 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -105,7 +82,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -151,10 +127,7 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -177,7 +150,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> missCountUpdater =
@@ -217,7 +189,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -231,12 +202,8 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -285,7 +252,6 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -328,7 +294,5 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryHeapUUIDKey.java
@@ -15,63 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +54,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -125,10 +99,7 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -151,7 +122,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> missCountUpdater =
@@ -191,7 +161,6 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -205,12 +174,8 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -228,8 +193,5 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapIntKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,14 +227,8 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -292,8 +243,5 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapLongKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,12 +227,8 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -290,8 +243,5 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapObjectKey.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +57,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -114,19 +87,13 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -142,9 +109,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -152,9 +117,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -190,10 +152,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -216,7 +175,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> missCountUpdater =
@@ -256,7 +214,6 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -270,20 +227,13 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey1.java
@@ -15,59 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -86,11 +64,9 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +74,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +104,13 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +126,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +134,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,10 +169,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -231,7 +192,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> missCountUpdater =
@@ -271,7 +231,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -285,12 +244,8 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -323,7 +278,6 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -353,8 +307,5 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapStringKey2.java
@@ -15,59 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -98,11 +76,9 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +86,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -141,19 +116,13 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -169,9 +138,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -179,9 +146,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -217,10 +181,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -243,7 +204,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> missCountUpdater =
@@ -283,7 +243,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -297,12 +256,8 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -351,7 +306,6 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -394,7 +348,5 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMStatsRegionEntryOffHeapUUIDKey.java
@@ -15,68 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
+// stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap {
   public VMStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -84,7 +59,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -115,19 +89,13 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -143,9 +111,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -153,9 +119,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -191,10 +154,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -217,7 +177,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
@@ -257,7 +216,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -271,12 +229,8 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -294,8 +248,5 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapIntKey.java
@@ -15,69 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +56,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +101,8 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +127,7 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +152,14 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +169,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +203,6 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,25 +232,14 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -348,8 +254,5 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapLongKey.java
@@ -15,69 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +56,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +101,8 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +127,7 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +152,14 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +169,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +203,6 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,23 +232,14 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -346,8 +254,5 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,68 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,11 +103,8 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -160,9 +129,7 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -187,60 +154,14 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -250,7 +171,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -285,7 +205,6 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -315,31 +234,19 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -42,34 +34,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +64,9 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +75,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,11 +120,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -176,9 +146,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -203,60 +171,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -266,7 +188,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -301,7 +222,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -331,23 +251,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -380,7 +291,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -410,8 +320,5 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -43,33 +35,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionEntryHeap {
   public VMThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +76,9 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +87,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -159,11 +132,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -188,9 +158,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -215,60 +183,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -278,7 +200,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -313,7 +234,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -343,23 +263,14 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -408,7 +319,6 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -451,7 +361,5 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,27 +15,18 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -43,44 +34,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +58,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +103,8 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -163,9 +129,7 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -190,60 +154,14 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -253,7 +171,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -288,7 +205,6 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -318,23 +234,14 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -352,8 +259,5 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +92,13 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +114,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +122,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +157,8 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +183,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +208,14 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +225,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +259,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,25 +288,14 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -415,8 +310,5 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +92,13 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +114,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +122,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +157,8 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +183,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +208,14 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +225,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +259,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,23 +288,14 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -413,8 +310,5 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,73 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +62,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,11 +158,8 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -227,9 +184,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -254,60 +209,14 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -317,7 +226,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -352,7 +260,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -382,31 +289,19 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +68,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +79,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -138,19 +110,13 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -166,9 +132,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -176,9 +140,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -214,11 +175,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -243,9 +201,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -270,60 +226,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -333,7 +243,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -368,7 +277,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -398,23 +306,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -447,7 +346,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -477,8 +375,5 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +80,9 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +91,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -150,19 +122,13 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -178,9 +144,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -188,9 +152,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -226,11 +187,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -255,9 +213,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -282,60 +238,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -345,7 +255,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -380,7 +289,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -410,23 +318,14 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -475,7 +374,6 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -518,7 +416,5 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,77 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionEntryOffHeap {
   public VMThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +64,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +94,13 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +116,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +124,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +159,8 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -230,9 +185,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -257,60 +210,14 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -320,7 +227,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -355,7 +261,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -385,23 +290,14 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -419,8 +315,5 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapIntKey.java
@@ -15,64 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +53,6 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -126,11 +98,8 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -140,9 +109,7 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -167,54 +134,9 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -229,8 +151,5 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapLongKey.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -35,44 +29,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +53,6 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -126,11 +98,8 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -140,9 +109,7 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -167,52 +134,9 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -227,8 +151,5 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapObjectKey.java
@@ -15,63 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +53,6 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -125,11 +98,8 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -139,9 +109,7 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -166,60 +134,14 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey1.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -37,34 +31,18 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -83,11 +61,9 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +71,6 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +116,8 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -155,9 +127,7 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -182,52 +152,9 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -260,7 +187,6 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -290,8 +216,5 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapStringKey2.java
@@ -15,19 +15,13 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -38,33 +32,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -95,11 +73,9 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -107,7 +83,6 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -153,11 +128,8 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -167,9 +139,7 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -194,52 +164,9 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -288,7 +215,6 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -331,7 +257,5 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryHeapUUIDKey.java
@@ -15,21 +15,14 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
@@ -38,44 +31,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -83,7 +55,6 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -129,11 +100,8 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -143,9 +111,7 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -170,52 +136,9 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -233,8 +156,5 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapIntKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +88,13 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +110,7 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +118,6 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +153,8 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +164,7 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,54 +189,9 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -295,8 +206,5 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapLongKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +58,6 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +88,13 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +110,7 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +118,6 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +153,8 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +164,7 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,52 +189,9 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -293,8 +206,5 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,68 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +59,6 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -116,19 +89,13 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -144,9 +111,7 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -154,9 +119,6 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -192,11 +154,8 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -206,9 +165,7 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -233,60 +190,14 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +65,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +76,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -132,19 +106,13 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -160,9 +128,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -170,9 +136,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -208,11 +171,8 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -222,9 +182,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -249,52 +207,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -327,7 +242,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -357,8 +271,5 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +77,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +88,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -144,19 +118,13 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -172,9 +140,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -182,9 +148,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -220,11 +183,8 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -234,9 +194,7 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -261,52 +219,9 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -355,7 +270,6 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -398,7 +312,5 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOffHeap {
   public VMThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +90,13 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +112,7 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +120,6 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,11 +155,8 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -209,9 +166,7 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -236,52 +191,9 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -299,8 +211,5 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapIntKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,25 +176,14 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -246,8 +198,5 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapLongKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,23 +176,14 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -244,8 +198,5 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapObjectKey.java
@@ -15,65 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +54,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,18 +99,11 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -148,7 +113,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -183,7 +147,6 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -213,31 +176,19 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey1.java
@@ -15,23 +15,16 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -40,32 +33,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -84,11 +62,9 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +72,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,18 +117,11 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -163,7 +131,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -198,7 +165,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -228,23 +194,14 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -277,7 +234,6 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -307,8 +263,5 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapStringKey2.java
@@ -15,23 +15,16 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -41,31 +34,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -96,11 +74,9 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -108,7 +84,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -154,18 +129,11 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -175,7 +143,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -210,7 +177,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -240,23 +206,14 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -305,7 +262,6 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -348,7 +304,5 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryHeapUUIDKey.java
@@ -15,25 +15,17 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
 // offheap: OFFHEAP
@@ -41,40 +33,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +56,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,18 +101,11 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -149,7 +115,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -184,7 +149,6 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -214,23 +178,14 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -248,8 +203,5 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapIntKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,25 +231,14 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -312,8 +253,5 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapLongKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,23 +231,14 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -310,8 +253,5 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapObjectKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -117,19 +89,13 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -145,9 +111,7 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -155,9 +119,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -193,18 +154,11 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -214,7 +168,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -249,7 +202,6 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -279,31 +231,19 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey1.java
@@ -15,62 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -89,11 +66,9 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +77,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +107,13 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +129,7 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +137,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,18 +172,11 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -230,7 +186,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -265,7 +220,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -295,23 +249,14 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -344,7 +289,6 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -374,8 +318,5 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapStringKey2.java
@@ -15,62 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -101,11 +78,9 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +89,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -145,19 +119,13 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -173,9 +141,7 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -183,9 +149,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -221,18 +184,11 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -242,7 +198,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -277,7 +232,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -307,23 +261,14 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -372,7 +317,6 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,7 +359,5 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,71 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffHeap {
   public VMThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,18 +156,11 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -215,7 +170,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -250,7 +204,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -280,23 +233,14 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -314,8 +258,5 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapIntKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -30,43 +26,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,14 +95,8 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -142,8 +111,5 @@ public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapLongKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -31,42 +27,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,12 +95,8 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -140,8 +111,5 @@ public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapObjectKey.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -29,44 +25,24 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -74,7 +50,6 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapObjectKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -120,20 +95,13 @@ public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey1.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -33,32 +29,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -77,11 +58,9 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +68,6 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey1.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,12 +113,8 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -173,7 +147,6 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -203,8 +176,5 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapStringKey2.java
@@ -15,11 +15,7 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,31 +30,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
+      boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -89,11 +70,9 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +80,6 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey2.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,12 +125,8 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -201,7 +175,6 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -244,7 +217,5 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryHeapUUIDKey.java
@@ -15,13 +15,8 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,40 +29,22 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -75,7 +52,6 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -121,12 +97,8 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -144,8 +116,5 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapIntKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,14 +150,8 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -208,8 +166,5 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapLongKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,12 +150,8 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -206,8 +166,5 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapObjectKey.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,46 +27,27 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -79,7 +55,6 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -110,19 +85,13 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -138,9 +107,7 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -148,9 +115,6 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -186,20 +150,13 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey1.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,38 +27,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -82,11 +62,9 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +72,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +102,13 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +124,7 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +132,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,12 +167,8 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -239,7 +201,6 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -269,8 +230,5 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapStringKey2.java
@@ -15,16 +15,11 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -32,38 +27,23 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -94,11 +74,9 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +84,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -137,19 +114,13 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -165,9 +136,7 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -175,9 +144,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -213,12 +179,8 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -267,7 +229,6 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -310,7 +271,5 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VMThinRegionEntryOffHeapUUIDKey.java
@@ -15,18 +15,12 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
@@ -34,45 +28,28 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // lru: LRU
 // stats: STATS
 // versioned: VERSIONED
-// offheap: 1
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   public VMThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -80,7 +57,6 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -111,19 +87,13 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -139,9 +109,7 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -149,9 +117,6 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -187,12 +152,8 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -210,8 +171,5 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapIntKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapIntKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -171,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -261,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -296,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -326,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -363,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
           "hitCount");
@@ -405,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -419,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -438,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -457,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -487,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -520,13 +419,8 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -541,8 +435,5 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapLongKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapLongKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -142,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -171,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -198,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -261,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -296,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -326,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -363,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapLongKey.class,
           "hitCount");
@@ -405,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -419,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -438,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -457,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -487,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -520,11 +419,8 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -539,8 +435,5 @@ public class VersionedStatsDiskLRURegionEntryHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,32 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +65,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +110,8 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -170,9 +136,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -197,60 +161,14 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -260,7 +178,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -295,7 +212,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -325,21 +241,13 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -362,7 +270,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -404,7 +311,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -418,10 +324,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -437,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -456,7 +358,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -486,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -519,19 +419,13 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -98,11 +71,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -111,7 +82,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -157,11 +127,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -186,9 +153,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -213,60 +178,14 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -276,7 +195,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -311,7 +229,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -341,21 +258,13 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -378,7 +287,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -420,7 +328,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -434,10 +341,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -453,7 +357,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -472,7 +375,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -502,7 +404,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -535,11 +436,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -572,7 +470,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -602,8 +499,5 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
@@ -15,36 +15,25 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -52,8 +41,7 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -110,11 +83,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -123,7 +94,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -169,11 +139,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -198,9 +165,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -225,60 +190,14 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -288,7 +207,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -323,7 +241,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -353,21 +270,13 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -390,7 +299,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -432,7 +340,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -446,10 +353,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -465,7 +369,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -484,7 +387,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -514,7 +416,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -547,11 +448,8 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -600,7 +498,6 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -643,7 +540,5 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -15,47 +15,34 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,34 +50,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryHeap {
   public VersionedStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +67,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -145,11 +112,8 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -174,9 +138,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -201,60 +163,14 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -264,7 +180,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -299,7 +214,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -329,21 +243,13 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -366,7 +272,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -408,7 +313,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -422,10 +326,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -441,7 +342,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -460,7 +360,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -490,7 +389,6 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -523,11 +421,8 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -545,8 +440,5 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,33 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -238,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -328,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -363,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -393,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -430,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -472,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -486,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -505,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -524,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -554,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -587,13 +474,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -608,8 +490,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,33 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -238,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -265,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -328,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -363,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -393,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -430,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -472,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -486,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -505,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -524,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -554,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -587,11 +474,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -606,8 +490,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,32 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -100,7 +69,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -132,19 +100,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -160,9 +122,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -170,9 +130,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -208,11 +165,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -237,9 +191,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -264,60 +216,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -327,7 +233,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -362,7 +267,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -392,21 +296,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -429,7 +325,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -471,7 +366,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -485,10 +379,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -504,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -523,7 +413,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -553,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -586,19 +474,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,25 +53,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -103,11 +75,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +86,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -148,19 +117,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -176,9 +139,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -186,9 +147,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -224,11 +182,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -253,9 +208,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -280,60 +233,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -343,7 +250,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -378,7 +284,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -408,21 +313,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -445,7 +342,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -487,7 +383,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -501,10 +396,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -520,7 +412,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -539,7 +430,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -569,7 +459,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -602,11 +491,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -639,7 +525,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -669,8 +554,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,25 +53,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -115,11 +87,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -128,7 +98,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -160,19 +129,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -188,9 +151,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -198,9 +159,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -236,11 +194,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -265,9 +220,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -292,60 +245,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -355,7 +262,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -390,7 +296,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -420,21 +325,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -457,7 +354,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -499,7 +395,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -513,10 +408,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -532,7 +424,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -551,7 +442,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -581,7 +471,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -614,11 +503,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -667,7 +553,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -710,7 +595,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,52 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// disk: DISK
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -68,34 +54,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
   public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +71,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -136,19 +102,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -164,9 +124,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -174,9 +132,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -212,11 +167,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -241,9 +193,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -268,60 +218,14 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -331,7 +235,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -366,7 +269,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -396,21 +298,13 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -433,7 +327,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -475,7 +368,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -489,10 +381,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -508,7 +397,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -527,7 +415,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -557,7 +444,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -590,11 +476,8 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -612,8 +495,5 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapIntKey.java
@@ -15,75 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -152,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -179,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -245,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
           "hitCount");
@@ -287,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -301,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -320,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -339,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -369,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -402,13 +316,8 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -423,8 +332,5 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapLongKey.java
@@ -15,75 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -152,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -179,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -245,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
           "hitCount");
@@ -287,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -301,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -320,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -339,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -369,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -402,11 +316,8 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -421,8 +332,5 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapObjectKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,11 +107,8 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -151,9 +118,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -178,50 +143,8 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -244,7 +167,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
           "hitCount");
@@ -286,7 +208,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -300,10 +221,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +255,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,19 +316,13 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey1.java
@@ -15,67 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -94,11 +68,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -107,7 +79,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -153,11 +124,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -167,9 +135,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -194,50 +160,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +184,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
           "hitCount");
@@ -302,7 +225,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +238,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +254,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +272,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +301,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,11 +333,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -454,7 +367,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -484,8 +396,5 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapStringKey2.java
@@ -15,33 +15,23 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -49,33 +39,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -106,11 +80,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -119,7 +91,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -165,11 +136,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -179,9 +147,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -206,50 +172,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -272,7 +196,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
           "hitCount");
@@ -314,7 +237,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -328,10 +250,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -347,7 +266,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -366,7 +284,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -396,7 +313,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -429,11 +345,8 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -482,7 +395,6 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -525,7 +437,5 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryHeapUUIDKey.java
@@ -15,78 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDiskRegionEntryHeap {
   public VersionedStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +64,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -141,11 +109,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -155,9 +120,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -182,50 +145,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -248,7 +169,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -290,7 +210,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -304,10 +223,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -323,7 +239,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -342,7 +257,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -372,7 +286,6 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -405,11 +318,8 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -427,8 +337,5 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapIntKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,33 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapIntKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -220,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -247,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -313,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -355,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -369,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -388,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -407,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -437,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -470,13 +372,8 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -491,8 +388,5 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapLongKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,33 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapLongKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -220,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -247,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -313,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -355,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -369,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -388,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -407,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -437,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -470,11 +372,8 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -489,8 +388,5 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,32 +51,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,11 +163,8 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -219,9 +174,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -246,50 +199,8 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -312,7 +223,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -354,7 +264,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -368,10 +277,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -387,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -406,7 +311,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -436,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -469,19 +372,13 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,25 +51,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -100,11 +73,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +84,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -145,19 +115,13 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -173,9 +137,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -183,9 +145,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -221,11 +180,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -235,9 +191,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -262,50 +216,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +240,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -370,7 +281,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +294,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +310,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +328,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +357,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,11 +389,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -522,7 +423,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -552,8 +452,5 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
@@ -15,47 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -63,25 +51,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -112,11 +85,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -125,7 +96,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -157,19 +127,13 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -185,9 +149,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -195,9 +157,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -233,11 +192,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -247,9 +203,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -274,50 +228,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -340,7 +252,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -382,7 +293,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -396,10 +306,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -415,7 +322,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -434,7 +340,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -464,7 +369,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -497,11 +401,8 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -550,7 +451,6 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -593,7 +493,5 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -15,49 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -65,34 +52,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskRegionEntryOffHeap {
   public VersionedStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +69,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -133,19 +100,13 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -161,9 +122,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -171,9 +130,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -209,11 +165,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -223,9 +176,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -250,50 +201,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -316,7 +225,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -358,7 +266,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -372,10 +279,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -391,7 +295,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -410,7 +313,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -440,7 +342,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -473,11 +374,8 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -495,8 +393,5 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapIntKey.java
@@ -15,74 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +61,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +106,11 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +120,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +154,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +183,13 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +212,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
           "hitCount");
@@ -302,7 +253,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +266,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +282,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +300,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +329,6 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,13 +361,8 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -438,8 +377,5 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapLongKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +107,11 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +121,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +155,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +184,13 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +213,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
           "hitCount");
@@ -302,7 +254,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +267,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +301,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,11 +362,8 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -436,8 +378,5 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapObjectKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,18 +107,11 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -158,7 +121,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -193,7 +155,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -223,21 +184,13 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -260,7 +213,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
           "hitCount");
@@ -302,7 +254,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -316,10 +267,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -335,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -354,7 +301,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -384,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -417,19 +362,13 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey1.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +68,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +79,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -152,18 +124,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -173,7 +138,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -208,7 +172,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -238,21 +201,13 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -275,7 +230,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
           "hitCount");
@@ -317,7 +271,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -331,10 +284,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -350,7 +300,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -369,7 +318,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -399,7 +347,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -432,11 +379,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -469,7 +413,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -499,8 +442,5 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapStringKey2.java
@@ -15,34 +15,24 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -50,31 +40,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +80,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +91,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -164,18 +136,11 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -185,7 +150,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -220,7 +184,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -250,21 +213,13 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -287,7 +242,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
           "hitCount");
@@ -329,7 +283,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -343,10 +296,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -362,7 +312,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -381,7 +330,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -411,7 +359,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -444,11 +391,8 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -497,7 +441,6 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -540,7 +483,5 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryHeapUUIDKey.java
@@ -15,75 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURegionEntryHeap {
   public VersionedStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +64,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -138,18 +109,11 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -159,7 +123,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -194,7 +157,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -224,21 +186,13 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -261,7 +215,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
           "hitCount");
@@ -303,7 +256,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -317,10 +269,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -336,7 +285,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -355,7 +303,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -385,7 +332,6 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -418,11 +364,8 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -440,8 +383,5 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapIntKey.java
@@ -15,79 +15,49 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -96,7 +66,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -128,19 +97,13 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -156,9 +119,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -166,9 +127,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -204,18 +162,11 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -225,7 +176,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -260,7 +210,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -290,21 +239,13 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -327,7 +268,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -369,7 +309,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -383,10 +322,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -402,7 +338,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -421,7 +356,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -451,7 +385,6 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -484,13 +417,8 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -505,8 +433,5 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapLongKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,31 +52,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapLongKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,18 +163,11 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -226,7 +177,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -261,7 +211,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -291,21 +240,13 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +269,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -370,7 +310,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +323,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +357,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,11 +418,8 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -504,8 +434,5 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapObjectKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,31 +52,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapObjectKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,18 +163,11 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -226,7 +177,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -261,7 +211,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -291,21 +240,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -328,7 +269,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -370,7 +310,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -384,10 +323,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -403,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -422,7 +357,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -452,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -485,19 +418,13 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey1.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,23 +52,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapStringKey1
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -99,11 +73,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -112,7 +84,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -144,19 +115,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -172,9 +137,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -182,9 +145,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -220,18 +180,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -241,7 +194,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -276,7 +228,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -306,21 +257,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -343,7 +286,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -385,7 +327,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -399,10 +340,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -418,7 +356,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -437,7 +374,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -467,7 +403,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -500,11 +435,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -537,7 +469,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -567,8 +498,5 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapStringKey2.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,23 +52,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapStringKey2
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -111,11 +85,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -124,7 +96,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -156,19 +127,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -184,9 +149,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -194,9 +157,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -232,18 +192,11 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -253,7 +206,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -288,7 +240,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -318,21 +269,13 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -355,7 +298,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -397,7 +339,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -411,10 +352,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -430,7 +368,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -449,7 +386,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -479,7 +415,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -512,11 +447,8 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -565,7 +497,6 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -608,7 +539,5 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
-// stats: 1
-// versioned: 1
-// offheap: 1
+// lru: LRU
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,30 +53,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsLRURegionEntryOffHeap {
   public VersionedStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +69,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +100,13 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +122,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +130,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,18 +165,11 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -227,7 +179,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -262,7 +213,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -292,21 +242,13 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -329,7 +271,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -371,7 +312,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -385,10 +325,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -404,7 +341,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -423,7 +359,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -453,7 +388,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -486,11 +420,8 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -508,8 +439,5 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapIntKey.java
@@ -15,69 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +57,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,10 +102,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -157,7 +125,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> missCountUpdater =
@@ -197,7 +164,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -211,10 +177,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -230,7 +193,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -249,7 +211,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -279,7 +240,6 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -312,13 +272,8 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -333,8 +288,5 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapLongKey.java
@@ -15,69 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -85,7 +57,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -131,10 +102,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -157,7 +125,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> missCountUpdater =
@@ -197,7 +164,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -211,10 +177,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -230,7 +193,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -249,7 +211,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -279,7 +240,6 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -312,11 +272,8 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -331,8 +288,5 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapObjectKey.java
@@ -15,69 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -132,10 +104,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -158,7 +127,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
           "hitCount");
@@ -200,7 +168,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -214,10 +181,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -233,7 +197,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -252,7 +215,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -282,7 +244,6 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -315,19 +276,13 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey1.java
@@ -15,61 +15,38 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -88,11 +65,9 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -101,7 +76,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -147,10 +121,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -173,7 +144,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
           "hitCount");
@@ -215,7 +185,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -229,10 +198,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -248,7 +214,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -267,7 +232,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -297,7 +261,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -330,11 +293,8 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -367,7 +327,6 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -397,8 +356,5 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapStringKey2.java
@@ -15,29 +15,21 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -45,31 +37,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegionEntryHeap {
   public VersionedStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -100,11 +77,9 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -113,7 +88,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -159,10 +133,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -185,7 +156,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
           "hitCount");
@@ -227,7 +197,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -241,10 +210,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -260,7 +226,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -279,7 +244,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -309,7 +273,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -342,11 +305,8 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -395,7 +355,6 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -438,7 +397,5 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryHeapUUIDKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
+// stats: STATS
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -86,7 +59,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -132,10 +104,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -158,7 +127,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "hitCount");
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> missCountUpdater =
@@ -198,7 +166,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -212,10 +179,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -231,7 +195,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -250,7 +213,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -280,7 +242,6 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -313,11 +274,8 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -335,8 +293,5 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapIntKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,10 +158,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -224,7 +181,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
           "hitCount");
@@ -266,7 +222,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -280,10 +235,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -299,7 +251,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -318,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -348,7 +298,6 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -381,13 +330,8 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -402,8 +346,5 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapLongKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -122,19 +93,13 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -150,9 +115,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -160,9 +123,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -198,10 +158,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -224,7 +181,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
           "hitCount");
@@ -266,7 +222,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -280,10 +235,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -299,7 +251,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -318,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -348,7 +298,6 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -381,11 +330,8 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -400,8 +346,5 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapObjectKey.java
@@ -15,74 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +63,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +94,13 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +116,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +124,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,10 +159,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -225,7 +182,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
           "hitCount");
@@ -267,7 +223,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -281,10 +236,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -300,7 +252,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -319,7 +270,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -349,7 +299,6 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -382,19 +331,13 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey1.java
@@ -15,66 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -93,11 +69,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -106,7 +80,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -138,19 +111,13 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -166,9 +133,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -176,9 +141,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -214,10 +176,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -240,7 +199,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "hitCount");
@@ -282,7 +240,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -296,10 +253,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -315,7 +269,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -334,7 +287,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -364,7 +316,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -397,11 +348,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -434,7 +382,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -464,8 +411,5 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapStringKey2.java
@@ -15,66 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -105,11 +81,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -118,7 +92,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -150,19 +123,13 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -178,9 +145,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -188,9 +153,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -226,10 +188,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -252,7 +211,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "hitCount");
@@ -294,7 +252,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -308,10 +265,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -327,7 +281,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -346,7 +299,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -376,7 +328,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -409,11 +360,8 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -462,7 +410,6 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -505,7 +452,5 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedStatsRegionEntryOffHeapUUIDKey.java
@@ -15,75 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
-// stats: 1
-// versioned: 1
-// offheap: 1
+// stats: STATS
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegionEntryOffHeap {
   public VersionedStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -92,7 +65,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -123,19 +95,13 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -151,9 +117,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -161,9 +125,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -199,10 +160,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // stats code
   @Override
   public void updateStatsForGet(boolean hit, long time) {
@@ -225,7 +183,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   private volatile long lastAccessed;
   private volatile int hitCount;
   private volatile int missCount;
-
   private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
       AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
           "hitCount");
@@ -267,7 +224,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public void txDidDestroy(long currTime) {
     setLastModified(currTime);
@@ -281,10 +237,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return true;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -300,7 +253,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -319,7 +271,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -349,7 +300,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -382,11 +332,8 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -404,8 +351,5 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapIntKey.java
@@ -15,76 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +63,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,11 +108,8 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -168,9 +134,7 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -195,60 +159,14 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -258,7 +176,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -293,7 +210,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -323,21 +239,13 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -353,7 +261,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -372,7 +279,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -402,7 +308,6 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -435,13 +340,8 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -456,8 +356,5 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapLongKey.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,33 +48,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapLongKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +64,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -140,11 +109,8 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -169,9 +135,7 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -196,60 +160,14 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -259,7 +177,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -294,7 +211,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -324,21 +240,13 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -354,7 +262,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -373,7 +280,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -403,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -436,11 +341,8 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -455,8 +357,5 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapObjectKey.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,32 +48,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapObjectKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +64,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -139,11 +109,8 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -168,9 +135,7 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -195,60 +160,14 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -258,7 +177,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -293,7 +211,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -323,21 +240,13 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -353,7 +262,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -372,7 +280,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -402,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -435,19 +341,13 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey1.java
@@ -15,43 +15,32 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +48,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapStringKey1
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -96,11 +70,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +81,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -155,11 +126,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -184,9 +152,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -211,60 +177,14 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -274,7 +194,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -309,7 +228,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -339,21 +257,13 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -369,7 +279,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -388,7 +297,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -418,7 +326,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -451,11 +358,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -488,7 +392,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -518,8 +421,5 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapStringKey2.java
@@ -15,34 +15,24 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -50,8 +40,7 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +48,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapStringKey2
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -108,11 +82,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -121,7 +93,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -167,11 +138,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -196,9 +164,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -223,60 +189,14 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -286,7 +206,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -321,7 +240,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -351,21 +269,13 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -381,7 +291,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -400,7 +309,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -430,7 +338,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -463,11 +370,8 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -516,7 +420,6 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -559,7 +462,5 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
@@ -15,45 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,34 +49,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryHeap {
   public VersionedThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +66,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -143,11 +111,8 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -172,9 +137,7 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -199,60 +162,14 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -262,7 +179,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -297,7 +213,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -327,21 +242,13 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -357,7 +264,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -376,7 +282,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -406,7 +311,6 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -439,11 +343,8 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -461,8 +362,5 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,33 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -131,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -159,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -169,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -207,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -236,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -263,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -326,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -361,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -391,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -421,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -440,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -470,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -503,13 +396,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -524,8 +412,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,33 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -99,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -131,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -159,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -169,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -207,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -236,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -263,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -326,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -361,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -391,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -421,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -440,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -470,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -503,11 +396,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -522,8 +412,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,32 +52,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -98,7 +68,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -130,19 +99,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -158,9 +121,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -168,9 +129,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -206,11 +164,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -235,9 +190,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -262,60 +215,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -325,7 +232,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -360,7 +266,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -390,21 +295,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -420,7 +317,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -439,7 +335,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -469,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -502,19 +396,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,25 +52,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -101,11 +74,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +85,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -146,19 +116,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -174,9 +138,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -184,9 +146,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -222,11 +181,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -251,9 +207,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -278,60 +232,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -341,7 +249,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -376,7 +283,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -406,21 +312,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -436,7 +334,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -455,7 +352,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -485,7 +381,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -518,11 +413,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -555,7 +447,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -585,8 +476,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -15,48 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -64,25 +52,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -113,11 +86,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -126,7 +97,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -158,19 +128,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -186,9 +150,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -196,9 +158,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -234,11 +193,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -263,9 +219,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -290,60 +244,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -353,7 +261,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -388,7 +295,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -418,21 +324,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -448,7 +346,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -467,7 +364,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -497,7 +393,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -530,11 +425,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -583,7 +475,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -626,7 +517,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -15,50 +15,37 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
-// lru: 1
+// disk: DISK
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -66,34 +53,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
   public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +70,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -134,19 +101,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -162,9 +123,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -172,9 +131,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -210,11 +166,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext drs, Object value) {
     boolean isBackup;
     if (drs instanceof LocalRegion) {
@@ -239,9 +192,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -266,60 +217,14 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
     DiskStoreImpl ds = r.getDiskStore();
     long maxOplogSize = ds.getMaxOplogSize();
     this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
-
-
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -329,7 +234,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -364,7 +268,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -394,21 +297,13 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -424,7 +319,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -443,7 +337,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -473,7 +366,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -506,11 +398,8 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -528,8 +417,5 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapIntKey.java
@@ -15,71 +15,42 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +59,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +104,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -148,9 +115,7 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -175,50 +140,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -234,7 +157,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -253,7 +175,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -283,7 +204,6 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -316,13 +236,8 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -337,8 +252,5 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapLongKey.java
@@ -15,71 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +60,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -134,11 +105,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -148,9 +116,7 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -175,50 +141,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -234,7 +158,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -253,7 +176,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -283,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -316,11 +237,8 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -335,8 +253,5 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapObjectKey.java
@@ -15,70 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +60,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -133,11 +105,8 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -147,9 +116,7 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -174,50 +141,8 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -233,7 +158,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -252,7 +176,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -282,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -315,19 +237,13 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey1.java
@@ -15,63 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -90,11 +66,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -103,7 +77,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -149,11 +122,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -163,9 +133,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -190,50 +158,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -249,7 +175,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -268,7 +193,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -298,7 +222,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -331,11 +254,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -368,7 +288,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -398,8 +317,5 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapStringKey2.java
@@ -15,29 +15,21 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -45,33 +37,17 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -102,11 +78,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -115,7 +89,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -161,11 +134,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -175,9 +145,7 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -202,50 +170,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -261,7 +187,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -280,7 +205,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -310,7 +234,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -343,11 +266,8 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -396,7 +316,6 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -439,7 +358,5 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryHeapUUIDKey.java
@@ -15,74 +15,45 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRegionEntryHeap {
   public VersionedThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -91,7 +62,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -137,11 +107,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -151,9 +118,7 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -178,50 +143,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -237,7 +160,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -256,7 +178,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -286,7 +207,6 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -319,11 +239,8 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -341,8 +258,5 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapIntKey.java
@@ -15,76 +15,47 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +64,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +95,13 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +117,7 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +125,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +160,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -215,9 +171,7 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -242,50 +196,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -301,7 +213,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -320,7 +231,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -350,7 +260,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -383,13 +292,8 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -404,8 +308,5 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapLongKey.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,33 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapLongKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,11 +161,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -216,9 +172,7 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -243,50 +197,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -302,7 +214,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -321,7 +232,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -351,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -384,11 +293,8 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -403,8 +309,5 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapObjectKey.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,32 +49,14 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapObjectKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -93,7 +65,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -125,19 +96,13 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -153,9 +118,7 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -163,9 +126,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -201,11 +161,8 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -215,9 +172,7 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -242,50 +197,8 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -301,7 +214,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -320,7 +232,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -350,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -383,19 +293,13 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey1.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapStringKey1
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -96,11 +71,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +82,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -141,19 +113,13 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -169,9 +135,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -179,9 +143,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -217,11 +178,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -231,9 +189,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -258,50 +214,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -317,7 +231,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -336,7 +249,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -366,7 +278,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -399,11 +310,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -436,7 +344,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -466,8 +373,5 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapStringKey2.java
@@ -15,43 +15,33 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -59,25 +49,10 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapStringKey2
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -108,11 +83,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -121,7 +94,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -153,19 +125,13 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -181,9 +147,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -191,9 +155,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -229,11 +190,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -243,9 +201,7 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -270,50 +226,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -329,7 +243,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -348,7 +261,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -378,7 +290,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -411,11 +322,8 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -464,7 +372,6 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -507,7 +414,5 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
@@ -15,45 +15,34 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
-// disk: 1
+// disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -61,34 +50,15 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     extends VersionedThinDiskRegionEntryOffHeap {
   public VersionedThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-        (value instanceof RecoveredEntry ? null : value)
-
-
-
-    );
+      @Retained Object value) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     initialize(context, value);
-
-
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +67,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -129,19 +98,13 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -157,9 +120,7 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -167,9 +128,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -205,11 +163,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     this.next = n;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // disk code
-
   protected void initialize(RegionEntryContext context, Object value) {
     diskInitialize(context, value);
   }
@@ -219,9 +174,7 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     throw new IllegalStateException("should never be called");
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private void diskInitialize(RegionEntryContext context, Object value) {
     DiskRecoveryStore drs = (DiskRecoveryStore) context;
     DiskStoreImpl ds = drs.getDiskStore();
@@ -246,50 +199,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   void setDiskId(RegionEntry old) {
     this.id = ((AbstractDiskRegionEntry) old).getDiskId();
   }
-  // // inlining DiskId
-  // // always have these fields
-  // /**
-  // * id consists of
-  // * most significant
-  // * 1 byte = users bits
-  // * 2-8 bytes = oplog id
-  // * least significant.
-  // *
-  // * The highest bit in the oplog id part is set to 1 if the oplog id
-  // * is negative.
-  // * @todo this field could be an int for an overflow only region
-  // */
-  // private long id;
-  // /**
-  // * Length of the bytes on disk.
-  // * This is always set. If the value is invalid then it will be set to 0.
-  // * The most significant bit is used by overflow to mark it as needing to be written.
-  // */
-  // protected int valueLength = 0;
-  // // have intOffset or longOffset
-  // // intOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile int offsetInOplog;
-  // // longOffset
-  // /**
-  // * The position in the oplog (the oplog offset) where this entry's value is
-  // * stored
-  // */
-  // private volatile long offsetInOplog;
-  // // have overflowOnly or persistence
-  // // overflowOnly
-  // // no fields
-  // // persistent
-  // /** unique entry identifier * */
-  // private long keyId;
-
-
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -305,7 +216,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -324,7 +234,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -354,7 +263,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -387,11 +295,8 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -409,8 +314,5 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapIntKey.java
@@ -15,72 +15,43 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +60,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapIntKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +105,11 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +119,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +153,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +182,13 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +204,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +222,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +251,6 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,13 +283,8 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -354,8 +299,5 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapLongKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapLongKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +106,11 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +120,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +154,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +183,13 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +223,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,11 +284,8 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -352,8 +300,5 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapObjectKey.java
@@ -15,72 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -89,7 +61,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -135,18 +106,11 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -156,7 +120,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -191,7 +154,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -221,21 +183,13 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -270,7 +223,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -300,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -333,19 +284,13 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey1.java
@@ -15,64 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -91,11 +67,9 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -104,7 +78,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -150,18 +123,11 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -171,7 +137,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -206,7 +171,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -236,21 +200,13 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -266,7 +222,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -285,7 +240,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -315,7 +269,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -348,11 +301,8 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -385,7 +335,6 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -415,8 +364,5 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapStringKey2.java
@@ -15,32 +15,23 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -48,31 +39,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -103,11 +79,9 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -116,7 +90,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -162,18 +135,11 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -183,7 +149,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -218,7 +183,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -248,21 +212,13 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -278,7 +234,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -297,7 +252,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -327,7 +281,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -360,11 +313,8 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -413,7 +363,6 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -456,7 +405,5 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryHeapUUIDKey.java
@@ -15,73 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegionEntryHeap {
   public VersionedThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -90,7 +63,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapUUIDKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -136,18 +108,11 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -157,7 +122,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -192,7 +156,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -222,21 +185,13 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -252,7 +207,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -271,7 +225,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -301,7 +254,6 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -334,11 +286,8 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -356,8 +305,5 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapIntKey.java
@@ -15,77 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,18 +161,11 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -223,7 +175,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -258,7 +209,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -288,21 +238,13 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -318,7 +260,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -337,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -367,7 +307,6 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -400,13 +339,8 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -421,8 +355,5 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapLongKey.java
@@ -15,77 +15,48 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -94,7 +65,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -126,19 +96,13 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -154,9 +118,7 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -164,9 +126,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -202,18 +161,11 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -223,7 +175,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -258,7 +209,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -288,21 +238,13 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -318,7 +260,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -337,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -367,7 +307,6 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -400,11 +339,8 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -419,8 +355,5 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapObjectKey.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,31 +51,13 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapObjectKey
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +66,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +97,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +119,7 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +127,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,18 +162,11 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -224,7 +176,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -259,7 +210,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -289,21 +239,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
     // default implementation.
     return getKey();
-
-
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +261,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +279,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +308,6 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,19 +340,13 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey1.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,23 +51,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapStringKey1
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -97,11 +72,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -110,7 +83,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -142,19 +114,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -170,9 +136,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -180,9 +144,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -218,18 +179,11 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -239,7 +193,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -274,7 +227,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -304,21 +256,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -334,7 +278,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -353,7 +296,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -383,7 +325,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -416,11 +357,8 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -453,7 +391,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -483,8 +420,5 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapStringKey2.java
@@ -15,46 +15,35 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
@@ -62,23 +51,9 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 public class VersionedThinLRURegionEntryOffHeapStringKey2
     extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -109,11 +84,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -122,7 +95,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -154,19 +126,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -182,9 +148,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -192,9 +156,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -230,18 +191,11 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -251,7 +205,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -286,7 +239,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -316,21 +268,13 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -346,7 +290,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -365,7 +308,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -395,7 +337,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -428,11 +369,8 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -481,7 +419,6 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -524,7 +461,5 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinLRURegionEntryOffHeapUUIDKey.java
@@ -15,78 +15,50 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.internal.cache.lru.EnableLRU;
-
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
-// lru: 1
+// lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRURegionEntryOffHeap {
   public VersionedThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -95,7 +67,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -127,19 +98,13 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -155,9 +120,7 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -165,9 +128,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -203,18 +163,11 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // lru code
   @Override
   public void setDelayedDiskId(LocalRegion r) {
-
-
-
     // nothing needed for LRUs with no disk
-
   }
 
   public synchronized int updateEntrySize(EnableLRU capacityController) {
@@ -224,7 +177,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
@@ -259,7 +211,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   private LRUClockNode nextLRU;
   private LRUClockNode prevLRU;
   private int size;
@@ -289,21 +240,13 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public Object getKeyForSizing() {
-
-
-
     // inline keys always report null for sizing since the size comes from the entry size
     return null;
-
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -319,7 +262,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -338,7 +280,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -368,7 +309,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -401,11 +341,8 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -423,8 +360,5 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapIntKey.java
@@ -15,65 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +55,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapIntKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,10 +100,7 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -146,7 +116,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -165,7 +134,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -195,7 +163,6 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -228,13 +195,8 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -249,8 +211,5 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapLongKey.java
@@ -15,65 +15,39 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -81,7 +55,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapLongKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -127,10 +100,7 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -146,7 +116,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -165,7 +134,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -195,7 +163,6 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -228,11 +195,8 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -247,8 +211,5 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapObjectKey.java
@@ -15,65 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +57,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapObjectKey.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,10 +102,7 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -147,7 +118,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -166,7 +136,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -196,7 +165,6 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -229,19 +197,13 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey1.java
@@ -15,57 +15,36 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -84,11 +63,9 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -97,7 +74,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey1.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -143,10 +119,7 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -162,7 +135,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -181,7 +153,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -211,7 +182,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -244,11 +214,8 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -281,7 +248,6 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -311,8 +277,5 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapStringKey2.java
@@ -15,25 +15,19 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
@@ -41,31 +35,16 @@ import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.Ha
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionEntryHeap {
   public VersionedThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-
-
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -96,11 +75,9 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -109,7 +86,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey2.class,
           "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -155,10 +131,7 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -174,7 +147,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -193,7 +165,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -223,7 +194,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -256,11 +226,8 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -309,7 +276,6 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -352,7 +318,5 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryHeapUUIDKey.java
@@ -15,66 +15,41 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
+// versioned: VERSIONED
 // offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-
-
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -82,7 +57,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   private volatile long lastModified;
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapUUIDKey.class, "lastModified");
-
   private volatile Object value;
 
   @Override
@@ -128,10 +102,7 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -147,7 +118,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -166,7 +136,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -196,7 +165,6 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -229,11 +197,8 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -251,8 +216,5 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapIntKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
-// key int: 1
+// key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,10 +156,7 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -213,7 +172,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -232,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -262,7 +219,6 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -295,13 +251,8 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
-
-
   private final int key;
 
   @Override
@@ -316,8 +267,5 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapLongKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
-// key long: 1
+// key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -118,19 +91,13 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -146,9 +113,7 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -156,9 +121,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -194,10 +156,7 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -213,7 +172,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -232,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -262,7 +219,6 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -295,11 +251,8 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long key;
 
   @Override
@@ -314,8 +267,5 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapObjectKey.java
@@ -15,70 +15,44 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
-// key object: 1
+// key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
     this.key = key;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -87,7 +61,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +92,13 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +114,7 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +122,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,10 +157,7 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -214,7 +173,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -233,7 +191,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -263,7 +220,6 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -296,19 +252,13 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final Object key;
 
   @Override
   public Object getKey() {
     return this.key;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey1.java
@@ -15,62 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
-// key string1: 1
+// key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     if (byteEncode) {
@@ -89,11 +67,9 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     }
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -102,7 +78,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -134,19 +109,13 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -162,9 +131,7 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -172,9 +139,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -210,10 +174,7 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -229,7 +190,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -248,7 +208,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -278,7 +237,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -311,11 +269,8 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long bits1;
 
   private int getKeyLength() {
@@ -348,7 +303,6 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -378,8 +332,5 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapStringKey2.java
@@ -15,62 +15,40 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
 // key uuid: KEY_UUID
 // key string1: KEY_STRING1
-// key string2: 1
-
+// key string2: KEY_STRING2
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-
-      @Retained
-
-      Object value
-
-      , boolean byteEncode
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value, boolean byteEncode) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
     long tmpBits1 = 0L;
     long tmpBits2 = 0L;
@@ -101,11 +79,9 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     tmpBits1 |= key.length();
     this.bits1 = tmpBits1;
     this.bits2 = tmpBits2;
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -114,7 +90,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -146,19 +121,13 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -174,9 +143,7 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -184,9 +151,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -222,10 +186,7 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -241,7 +202,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -260,7 +220,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -290,7 +249,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -323,11 +281,8 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   // strlen is encoded in lowest 6 bits (max strlen is 63)
   // character encoding info is in bits 7 and 8
   // The other bits are used to encoded character data.
@@ -376,7 +331,6 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   @Override
   public boolean isKeyEqual(Object k) {
     if (k instanceof String) {
@@ -419,7 +373,5 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     }
     return false;
   }
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/VersionedThinRegionEntryOffHeapUUIDKey.java
@@ -15,71 +15,46 @@
 package org.apache.geode.internal.cache;
 
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
-
-
 import java.util.UUID;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 import org.apache.geode.cache.EntryEvent;
-
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
-
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
-
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
 // macros whose definition changes this class:
 // disk: DISK
 // lru: LRU
 // stats: STATS
-// versioned: 1
-// offheap: 1
+// versioned: VERSIONED
+// offheap: OFFHEAP
 // One of the following key macros must be defined:
 // key object: KEY_OBJECT
 // key int: KEY_INT
 // key long: KEY_LONG
-// key uuid: 1
+// key uuid: KEY_UUID
 // key string1: KEY_STRING1
 // key string2: KEY_STRING2
-
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionEntryOffHeap {
   public VersionedThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-
-      @Retained
-
-      Object value
-
-
-
-  ) {
-    super(context,
-
-
-
-        value
-
-    );
+      @Retained Object value) {
+    super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
     this.keyMostSigBits = key.getMostSignificantBits();
     this.keyLeastSigBits = key.getLeastSignificantBits();
-
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // common code
   protected int hash;
   private HashEntry<Object, Object> next;
@@ -88,7 +63,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
           "lastModified");
-
   /**
    * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
    */
@@ -119,19 +93,13 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-
   @Unretained
   protected void setValueField(@Unretained Object v) {
-
-
-
     OffHeapRegionEntryHelper.setValue(this, v);
   }
 
   @Override
-
   @Retained
-
   public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
@@ -147,9 +115,7 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   @Override
-
   @Released
-
   public void release() {
     OffHeapRegionEntryHelper.releaseEntry(this);
   }
@@ -157,9 +123,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   @Override
   public void returnToPool() {
     // Deadcoded for now; never was working
-    // if (this instanceof VMThinRegionEntryLongKey) {
-    // factory.returnToPool((VMThinRegionEntryLongKey)this);
-    // }
   }
 
   protected long getLastModifiedField() {
@@ -195,10 +158,7 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     this.next = n;
   }
 
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // versioned code
   private VersionSource memberID;
   private short entryVersionLowBytes;
@@ -214,7 +174,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
-
 
   public long getVersionTimeStamp() {
     return getLastModified();
@@ -233,7 +192,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public void setVersions(VersionTag tag) {
     this.memberID = tag.getMemberID();
     int eVersion = tag.getEntryVersion();
@@ -263,7 +221,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   public VersionTag asVersionTag() {
     VersionTag tag = VersionTag.create(memberID);
     tag.setEntryVersion(getEntryVersion());
@@ -296,11 +253,8 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     return this.regionVersionLowBytes;
   }
 
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-
   // key code
-
   private final long keyMostSigBits;
   private final long keyLeastSigBits;
 
@@ -318,8 +272,5 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     }
     return false;
   }
-
-
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }
-


### PR DESCRIPTION
* this fixes the white space and some comments
* also removes commented out code

The only file I changed directly is LeafRegionEntry.cpp.

All of the Java files are generated by executing dev-tools/generateRegionEntryClasses.sh from the command-line on a Linux machine. Note: if you do this from Mac, we get some messed up Java comments and lots of extra white space lines (which is what happened in the previous commit for these Java files).