### PR TITLE
GEODE-3843: Fix gfsh shutdown error message

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
@@ -60,6 +60,7 @@ public class ShutdownCommand implements GfshCommand {
       @CliOption(key = CliStrings.SHUTDOWN__TIMEOUT, unspecifiedDefaultValue = DEFAULT_TIME_OUT,
           help = CliStrings.SHUTDOWN__TIMEOUT__HELP) int userSpecifiedTimeout,
       @CliOption(key = CliStrings.INCLUDE_LOCATORS, unspecifiedDefaultValue = "false",
+          specifiedDefaultValue = "true",
           help = CliStrings.INCLUDE_LOCATORS_HELP) boolean shutdownLocators) {
     try {
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2057,7 +2057,7 @@ public class CliStrings {
   public static final String SHUTDOWN__MSG__CAN_NOT_SHUTDOWN_WITHIN_TIMEOUT =
       "Could not shutdown within timeout. Shutdown will continue in background";
   public static final String SHUTDOWN__MSG__NO_DATA_NODE_FOUND =
-      "No data node found for stopping. Please specify --include-locators=true option if you want locators to be stopped";
+      "No data node found for stopping. Please specify the --include-locators option if you want locators to be stopped";
 
   public static final String SHUTDOWN_TIMEDOUT =
       "Shutdown command timedout. Please manually check node status";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2057,7 +2057,7 @@ public class CliStrings {
   public static final String SHUTDOWN__MSG__CAN_NOT_SHUTDOWN_WITHIN_TIMEOUT =
       "Could not shutdown within timeout. Shutdown will continue in background";
   public static final String SHUTDOWN__MSG__NO_DATA_NODE_FOUND =
-      "No data node found for stopping. Please specify --include-locators option if you want locators to be stopped";
+      "No data node found for stopping. Please specify --include-locators=true option if you want locators to be stopped";
 
   public static final String SHUTDOWN_TIMEDOUT =
       "Shutdown command timedout. Please manually check node status";

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/GfshParserParsingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/GfshParserParsingTest.java
@@ -362,4 +362,11 @@ public class GfshParserParsingTest {
     assertThat(result.getParamValue("name")).isEqualTo("test");
     assertThat(result.getCommandName()).isEqualTo("start server");
   }
+
+  @Test
+  public void testShutdownWithOption() throws Exception {
+    String command = "shutdown --include-locators";
+    GfshParseResult result = parser.parse(command);
+    assertThat(result.getParamValue("include-locators")).isEqualTo("true");
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandDUnitTest.java
@@ -91,25 +91,8 @@ public class ShutdownCommandDUnitTest {
 
   @Test
   public void testShutdownServers() {
-    executeShutdownServers("shutdown");
-  }
+    String command = "shutdown";
 
-  @Test
-  public void testShutdownServersWithSpecifiedOptionValue() {
-    executeShutdownServers("shutdown --include-locators=false");
-  }
-
-  @Test
-  public void testShutdownAll() {
-    executeShutdownAllCommand("shutdown --include-locators=true");
-  }
-
-  @Test
-  public void testShutdownAllUnspecifiedOptionValue() {
-    executeShutdownAllCommand("shutdown --include-locators");
-  }
-
-  private void executeShutdownServers(String command) {
     gfsh.executeAndVerifyCommand(command);
     assertThat(gfsh.getGfshOutput()).contains("Shutdown is triggered");
 
@@ -120,7 +103,10 @@ public class ShutdownCommandDUnitTest {
     assertThat(gfsh.getGfshOutput()).contains(MANAGER_NAME);
   }
 
-  private void executeShutdownAllCommand(String command) {
+  @Test
+  public void testShutdownAll() {
+    String command = "shutdown --include-locators=true";
+
     gfsh.executeAndVerifyCommand(command);
     assertThat(gfsh.getGfshOutput()).contains("Shutdown is triggered");
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandDUnitTest.java
@@ -91,8 +91,25 @@ public class ShutdownCommandDUnitTest {
 
   @Test
   public void testShutdownServers() {
-    String command = "shutdown";
+    executeShutdownServers("shutdown");
+  }
 
+  @Test
+  public void testShutdownServersWithSpecifiedOptionValue() {
+    executeShutdownServers("shutdown --include-locators=false");
+  }
+
+  @Test
+  public void testShutdownAll() {
+    executeShutdownAllCommand("shutdown --include-locators=true");
+  }
+
+  @Test
+  public void testShutdownAllUnspecifiedOptionValue() {
+    executeShutdownAllCommand("shutdown --include-locators");
+  }
+
+  private void executeShutdownServers(String command) {
     gfsh.executeAndVerifyCommand(command);
     assertThat(gfsh.getGfshOutput()).contains("Shutdown is triggered");
 
@@ -103,10 +120,7 @@ public class ShutdownCommandDUnitTest {
     assertThat(gfsh.getGfshOutput()).contains(MANAGER_NAME);
   }
 
-  @Test
-  public void testShutdownAll() {
-    String command = "shutdown --include-locators=true";
-
+  private void executeShutdownAllCommand(String command) {
     gfsh.executeAndVerifyCommand(command);
     assertThat(gfsh.getGfshOutput()).contains("Shutdown is triggered");
 


### PR DESCRIPTION
- gfsh message while running shutdown command contains the text "use --shutdown-locators to stop your locator". This to be read as "use --shutdown-locators=true to stop your locator"

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
