### PR TITLE
GEODE-3882: ClusterConfiguration to support GatewayReceiver hostnameF…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGenerator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGenerator.java
@@ -1536,6 +1536,9 @@ public class CacheXmlGenerator extends CacheXml implements XMLReader {
     for (GatewayReceiver receiver : receiverList) {
       AttributesImpl atts = new AttributesImpl();
       try {
+        // hostnameForSenders
+        if (generateDefaults() || receiver.getHostnameForSenders() != null)
+          atts.addAttribute("", "", HOSTNAME_FOR_SENDERS, "", receiver.getHostnameForSenders());
         // start port
         if (generateDefaults() || receiver.getStartPort() != GatewayReceiver.DEFAULT_START_PORT)
           atts.addAttribute("", "", START_PORT, "", String.valueOf(receiver.getStartPort()));

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
@@ -18,8 +18,8 @@ import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
 import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.Set;
 
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -88,6 +88,7 @@ public class WANClusterConfigurationDUnitTest {
     csb.addOption(CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT, "10000");
     csb.addOption(CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT, "20000");
     csb.addOptionWithValueCheck(CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS, "20");
+    csb.addOption(CliStrings.CREATE_GATEWAYRECEIVER__HOSTNAMEFORSENDERS, "myLocalHost");
     gfsh.executeAndVerifyCommand(csb.getCommandString());
 
     // create GatewaySender
@@ -125,6 +126,13 @@ public class WANClusterConfigurationDUnitTest {
       assertNotNull(gatewayReceivers);
       assertFalse(gatewayReceivers.isEmpty());
       assertTrue(gatewayReceivers.size() == 1);
+      for (GatewayReceiver gr : gatewayReceivers) {
+        assertThat(gr.isManualStart()).isTrue();
+        assertThat(gr.getStartPort()).isEqualTo(10000);
+        assertThat(gr.getEndPort()).isEqualTo(20000);
+        assertThat(gr.getMaximumTimeBetweenPings()).isEqualTo(20);
+        assertThat(gr.getHostnameForSenders()).isEqualTo("myLocalHost");
+      }
     });
 
     // verify GatewaySender attributes saved in cluster config


### PR DESCRIPTION
…orSenders

- Add support for GatewayReceiver hostnameForSenders in CacheXmlGenerator (already there in CacheXmlParser)
- improve WANClusterConfigurationDUnitTest to verify specific GatewayReceiver attributes

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
