### PR TITLE
Add Dockerfile for building geode in our concourse infrastructure.

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM apachegeode/geode-build
+
+
+# Setup Google APT repository
+RUN apt-get update && \
+    apt-get install -y lsb-release && \
+    echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt-get update && apt-get install -y google-cloud-sdk && \
+    apt-get clean
+
+# For a CI tool, disable updates to gcloud since they'll be thrown away at end of run
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image
+
+ENV GRADLE_USER_HOME /usr/local/maven_files
+WORKDIR /tmp/work
+ADD cache_dependencies.sh cache_dependencies.sh
+RUN chmod +x cache_dependencies.sh && \
+    ./cache_dependencies.sh && \
+    rm -rf /tmp/work
+
+ENTRYPOINT []

--- a/ci/docker/cache_dependencies.sh
+++ b/ci/docker/cache_dependencies.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+git clone -b develop --depth 1 https://github.com/apache/geode.git geode
+
+pushd geode
+  cat << EOF >> build.gradle
+  subprojects {
+    task getDeps(type: Copy) {
+      from project.sourceSets.main.runtimeClasspath
+      from project.sourceSets.test.runtimeClasspath
+      from configurations.testRuntime
+      into 'runtime/'
+    }
+  }
+EOF
+
+# Include rat to get its runtime dependencies, which are apparently not captured by the 'getDeps' task above
+./gradlew --no-daemon getDeps :rat
+
+popd
+
+rm -rf geode


### PR DESCRIPTION
[GEODE-3892]

This commit is for the Dockerfile associated with the in-progress concourse CI infrastructure for Apache Geode. This image caches geode's and gradle's dependencies, as well as installs Google's Cloud SDK client, in order to reduce runtime and network traffic.

Signed-off-by: Sean Goller <sgoller@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X ] Is your initial contribution a single, squashed commit?

- [ X ] Does `gradlew build` run cleanly?

- [ N/A ] Have you written or updated unit tests to verify your changes?

- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
