### PR TITLE
GEODE-3299: throw CacheClosedException in FunctionContext.getCache()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionContextImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionContextImpl.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.execute;
 
 import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
@@ -99,7 +100,10 @@ public class FunctionContextImpl implements FunctionContext {
   }
 
   @Override
-  public Cache getCache() {
+  public Cache getCache() throws CacheClosedException {
+    if (cache == null) {
+      throw new CacheClosedException("FunctionContext does not have a valid Cache");
+    }
     return cache;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GetRegionDescriptionFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GetRegionDescriptionFunction.java
@@ -43,8 +43,6 @@ public class GetRegionDescriptionFunction extends FunctionAdapter implements Int
       } else {
         context.getResultSender().lastResult(null);
       }
-    } catch (CacheClosedException e) {
-      context.getResultSender().sendException(e);
     } catch (Exception e) {
       context.getResultSender().sendException(e);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunction.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.FunctionAdapter;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.distributed.DistributedMember;
@@ -65,8 +64,6 @@ public class ShowMissingDiskStoresFunction extends FunctionAdapter implements In
           }
         }
       }
-    } catch (CacheClosedException ignored) {
-      // return empty results
     } catch (Exception e) {
       context.getResultSender().sendException(e);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunction.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.FunctionAdapter;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.InternalEntity;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.partitioned.ColocatedRegionDetails;
@@ -65,23 +65,25 @@ public class ShowMissingDiskStoresFunction extends FunctionAdapter implements In
           }
         }
       }
-
-      if (memberMissingIDs.isEmpty() && missingColocatedRegions.isEmpty()) {
-        context.getResultSender().lastResult(null);
-      } else {
-        if (!memberMissingIDs.isEmpty()) {
-          if (missingColocatedRegions.isEmpty()) {
-            context.getResultSender().lastResult(memberMissingIDs);
-          } else {
-            context.getResultSender().sendResult(memberMissingIDs);
-          }
-        }
-        if (!missingColocatedRegions.isEmpty()) {
-          context.getResultSender().lastResult(missingColocatedRegions);
-        }
-      }
+    } catch (CacheClosedException ignored) {
+      // return empty results
     } catch (Exception e) {
       context.getResultSender().sendException(e);
+    }
+
+    if (memberMissingIDs.isEmpty() && missingColocatedRegions.isEmpty()) {
+      context.getResultSender().lastResult(null);
+    } else {
+      if (!memberMissingIDs.isEmpty()) {
+        if (missingColocatedRegions.isEmpty()) {
+          context.getResultSender().lastResult(memberMissingIDs);
+        } else {
+          context.getResultSender().sendResult(memberMissingIDs);
+        }
+      }
+      if (!missingColocatedRegions.isEmpty()) {
+        context.getResultSender().lastResult(missingColocatedRegions);
+      }
     }
   }
 


### PR DESCRIPTION
Throw the exception when cache == null instead of returning the null.

Gfsh functions handle CacheClosedException, whereas
NullPointerExceptions that resulted from returning null are not.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
