### PR TITLE
GEODE-3190: Fix a race by checking if region is destroyed

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -97,7 +97,7 @@ public abstract class AbstractRegionMap implements RegionMap {
    * This test hook is used to force the conditions for defect 48182. This hook is used by
    * Bug48182JUnitTest.
    */
-  static Runnable testHookRunnableFor48182 = null;
+  static Runnable testHookRunnableForConcurrentOperation = null;
 
   private RegionEntryFactory entryFactory;
 
@@ -1070,8 +1070,8 @@ public abstract class AbstractRegionMap implements RegionMap {
         /*
          * Execute the test hook runnable inline (not threaded) if it is not null.
          */
-        if (null != testHookRunnableFor48182) {
-          testHookRunnableFor48182.run();
+        if (null != testHookRunnableForConcurrentOperation) {
+          testHookRunnableForConcurrentOperation.run();
         }
 
         try {
@@ -1388,6 +1388,7 @@ public abstract class AbstractRegionMap implements RegionMap {
             }
             try {
               synchronized (re) {
+                owner.checkReadiness();
                 // if the entry is a tombstone and the event is from a peer or a client
                 // then we allow the operation to be performed so that we can update the
                 // version stamp. Otherwise we would retain an old version stamp and may allow
@@ -1489,6 +1490,7 @@ public abstract class AbstractRegionMap implements RegionMap {
                         duringRI, true);
                     doPart3 = true;
                   } finally {
+                    owner.checkReadiness();
                     if (re.isRemoved() && !re.isTombstone()) {
                       if (!removed) {
                         removeEntry(event.getKey(), re, true, event, owner);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -94,8 +94,8 @@ public abstract class AbstractRegionMap implements RegionMap {
   protected CustomEntryConcurrentHashMap<Object, Object> map;
 
   /**
-   * This test hook is used to force the conditions for defect 48182. This hook is used by
-   * Bug48182JUnitTest.
+   * This test hook is used to force the conditions during entry destroy. This hook is used by
+   * DestroyEntryWithConcurrentOperationJUnitTest.
    */
   static Runnable testHookRunnableForConcurrentOperation = null;
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DestroyEntryWithConcurrentOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DestroyEntryWithConcurrentOperationJUnitTest.java
@@ -133,12 +133,12 @@ public class DestroyEntryWithConcurrentOperationJUnitTest {
 
   @Test
   public void testEntryDestroyWithCacheClose() throws Exception {
-    testEntryDestroyWithCacheClose(false);
+    verifyEntryDestroyWithCacheClose(false);
   }
 
   @Test
   public void testOffHeapRegionEntryDestroyWithCacheClose() throws Exception {
-    testEntryDestroyWithCacheClose(true);
+    verifyEntryDestroyWithCacheClose(true);
   }
 
   /**
@@ -147,7 +147,7 @@ public class DestroyEntryWithConcurrentOperationJUnitTest {
    * CacheClosedException is thrown rather than an EntryNotFoundException (or any other exception
    * type for that matter).
    */
-  private void testEntryDestroyWithCacheClose(boolean isOffHeap) {
+  private void verifyEntryDestroyWithCacheClose(boolean isOffHeap) {
     AbstractRegionMap.testHookRunnableForConcurrentOperation = new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
  * Add test case for heap region as well as offheap region.
  * Rename the test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
